### PR TITLE
tox: set base_python to 3.11 for most envs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ commands =
       tests
 
 [testenv:linter]
+base_python=python3.11
 deps=
     flake8==7.0.0
     flake8-debug==0.2.0
@@ -24,6 +25,7 @@ commands =
 skip_install = true
 
 [testenv:cli]
+base_python=python3.11
 deps = .
 commands =
     fromager {posargs}
@@ -32,6 +34,7 @@ commands =
 deps = .
 
 [testenv:pkglint]
+base_python=python3.11
 deps=
     .[build]
     check-python-versions


### PR DESCRIPTION
Set the base_python to python3.11 for specialized environments so they
do not use an old version accidentally. Leave the default unset so
that the `py` environment picks up python3 from the $PATH to allow for
a newer version easily.