### PR TITLE
e2e: change port for local wheel server

### DIFF
--- a/e2e/test_build_with_build_order.sh
+++ b/e2e/test_build_with_build_order.sh
@@ -47,10 +47,10 @@ pypi-mirror create -d "$OUTDIR/wheels-repo/downloads/" -m "$OUTDIR/wheels-repo/s
 # Start a web server for the wheels-repo. We remember the PID so we
 # can stop it later, and we determine the primary IP of the host
 # because podman won't see the server via localhost.
-python3 -m http.server --directory "$OUTDIR/wheels-repo/" 9090 &
+python3 -m http.server --directory "$OUTDIR/wheels-repo/" 9999 &
 HTTP_SERVER_PID=$!
 IP=$(ip route get 1.1.1.1 | grep 1.1.1.1 | awk '{print $7}')
-export WHEEL_SERVER_URL="http://${IP}:9090/simple"
+export WHEEL_SERVER_URL="http://${IP}:9999/simple"
 
 # Define the function used in the build script
 build_wheel() {

--- a/e2e/test_report_missing_dependency.sh
+++ b/e2e/test_report_missing_dependency.sh
@@ -53,10 +53,10 @@ rm -rf "$OUTDIR/wheels-repo/simple"
 # Start a web server for the wheels-repo. We remember the PID so we
 # can stop it later, and we determine the primary IP of the host
 # because podman won't see the server via localhost.
-.tox/e2e/bin/python3 -m http.server --directory "$OUTDIR/wheels-repo/" 9090 &
+.tox/e2e/bin/python3 -m http.server --directory "$OUTDIR/wheels-repo/" 9999 &
 HTTP_SERVER_PID=$!
 IP=$(ip route get 1.1.1.1 | grep 1.1.1.1 | awk '{print $7}')
-export WHEEL_SERVER_URL="http://${IP}:9090/simple"
+export WHEEL_SERVER_URL="http://${IP}:9999/simple"
 
 # Rebuild the original toplevel wheel, expecting a failure.
 version=$(jq -r '.[] | select ( .dist == "'$DIST'" ) | .version' "$OUTDIR/work-dir/build-order.json")


### PR DESCRIPTION
Move to a different port to avoid collisions with cockpit on RHEL and
Fedora systems.