### PR TITLE
Test on Python 3.10 for Intel Gaudi

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
+          - "3.10"
           - "3.11"
           - "3.12"
 
@@ -39,6 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
+          - "3.10"
           - "3.11"
           - "3.12"
         test-script:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -29,8 +29,10 @@ pull_request_rules:
           - check-success=linter
           - check-success=pkglint
           - check-success=markdownlint
+          - check-success=unit (3.10)
           - check-success=unit (3.11)
           - check-success=unit (3.12)
+          - check-success=e2e (3.10, bootstrap)
           - check-success=e2e (3.11, bootstrap)
           - check-success=e2e (3.12, bootstrap)
           - check-success=e2e (3.11, report_missing_dependency)

--- a/e2e/flit_core_override/pyproject.toml
+++ b/e2e/flit_core_override/pyproject.toml
@@ -18,13 +18,14 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Utilities",
 ]
 
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,14 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Utilities",
 ]
 
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 
 dependencies = [
     "html5lib",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.2.0
-envlist=py{310,311,312},linter
+envlist=py,linter
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.2.0
-envlist=py,linter
+envlist=py{310,311,312},linter
 
 [testenv]
 deps =


### PR DESCRIPTION
SynapseAI / HabanaLabs 1.15 for Intel Gaudi is only available for Python 3.10.