### PR TITLE
drop python-gitlab dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "pkginfo",
     "PyYAML",
     "pyproject_hooks>=1.0.0,!=1.1.0",
-    "python-gitlab",
     "python-pypi-mirror",
     "requests",
     "resolvelib",


### PR DESCRIPTION
We had some legacy commands using the gitlab API that are no longer
part of fromager.