### PR TITLE
feature: log the output of the build command

### DIFF
--- a/e2e/test_bootstrap.sh
+++ b/e2e/test_bootstrap.sh
@@ -42,6 +42,12 @@ sdists-repo/downloads/pbr-6.0.0.tar.gz
 
 work-dir/build-order.json
 work-dir/constraints.txt
+
+work-dir/flit_core-3.9.0/build.log
+work-dir/pbr-6.0.0/build.log
+work-dir/setuptools-70.0.0/build.log
+work-dir/stevedore-5.2.0/build.log
+work-dir/wheel-0.43.0/build.log
 "
 
 pass=true

--- a/e2e/test_build_with_build_order.sh
+++ b/e2e/test_build_with_build_order.sh
@@ -126,6 +126,12 @@ sdists-repo/downloads/setuptools-70.0.0.tar.gz
 sdists-repo/downloads/wheel-0.43.0.tar.gz
 sdists-repo/downloads/flit_core-3.9.0.tar.gz
 sdists-repo/downloads/pbr-6.0.0.tar.gz
+
+work-dir/flit_core-3.9.0/build.log
+work-dir/pbr-6.0.0/build.log
+work-dir/setuptools-70.0.0/build.log
+work-dir/stevedore-5.2.0/build.log
+work-dir/wheel-0.43.0/build.log
 "
 
 pass=true

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -34,6 +34,7 @@ def default_build_wheel(ctx, build_env, extra_environ, req, sdist_root_dir):
             '--wheel-dir', ctx.wheels_build,
             '--no-deps',
             '--index-url', ctx.wheel_server_url,  # probably redundant, but just in case
+            '--log', sdist_root_dir.parent / 'build.log',
             sdist_root_dir,
         ]
         external_commands.run(cmd, cwd=dir_name, extra_environ=extra_environ)


### PR DESCRIPTION
When we run the step to build the wheel, tell pip to write a log file
in the directory above where the source is located. Using this
location ensures the file is preserved when bootstrap cleans up the
source tree, and makes it easy to collect all of the files if we are
building a sequence.