### PR TITLE
use virtualenv instead of venv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "resolvelib",
     "stevedore",
     "tomli",
+    "virtualenv",
 ]
 
 [project.optional-dependencies]

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -1,8 +1,8 @@
 import logging
 import os
 import platform
+import sys
 import tempfile
-import venv
 
 from . import external_commands, overrides
 
@@ -75,10 +75,11 @@ class BuildEnvironment:
         if self.path.exists():
             logger.info('reusing build environment in %s', self.path)
             return
+
         logger.debug('creating build environment in %s', self.path)
-        self._builder = venv.EnvBuilder(clear=True, with_pip=True)
-        self._builder.create(self.path)
+        external_commands.run([sys.executable, '-m', 'virtualenv', self.path])
         logger.info('created build environment in %s', self.path)
+
         req_filename = self.path / 'requirements.txt'
         # FIXME: Ensure each requirement is pinned to a specific version.
         with open(req_filename, 'w') as f:

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import platform
 import tempfile
 import venv
@@ -24,6 +25,23 @@ def build_wheel(ctx, req, sdist_root_dir, build_env):
 
 def default_build_wheel(ctx, build_env, extra_environ, req, sdist_root_dir):
     logger.debug('building wheel for %s with %s', sdist_root_dir, extra_environ)
+
+    # Activate the virtualenv for the subprocess:
+    # 1. Put the build environment at the front of the PATH to ensure
+    #    any build tools are picked up from there and not global
+    #    versions. If the caller has already set a path, start there.
+    # 2. Set VIRTUAL_ENV so tools looking for that (for example,
+    #    maturin) find it.
+    existing_path = extra_environ.get('PATH') or os.environ.get('PATH') or ''
+    path_parts = [str(build_env.python.parent)]
+    if existing_path:
+        path_parts.append(existing_path)
+    updated_path = ':'.join(path_parts)
+    override_env = {}
+    override_env.update(extra_environ)
+    override_env['PATH'] = updated_path
+    override_env['VIRTUAL_ENV'] = str(build_env.path)
+
     with tempfile.TemporaryDirectory() as dir_name:
         cmd = [
             build_env.python, '-m', 'pip', '-vvv',
@@ -37,7 +55,7 @@ def default_build_wheel(ctx, build_env, extra_environ, req, sdist_root_dir):
             '--log', sdist_root_dir.parent / 'build.log',
             sdist_root_dir,
         ]
-        external_commands.run(cmd, cwd=dir_name, extra_environ=extra_environ)
+        external_commands.run(cmd, cwd=dir_name, extra_environ=override_env)
 
 
 class BuildEnvironment:


### PR DESCRIPTION
It's not clear why, but the virtual environments created by the two tools
are different, at least for python3.11. This causes maturin to incorrectly
try to build rust dependencies using the python3 in
/usr/bin, instead of the one in the virtual environment.

One difference we noted is in the pyvenv.cfg files:

```
diff virtualenv.pyvenv.cfg venv.pyvenv.cfg 2,4d1
< implementation = CPython
< version_info = 3.11.7.final.0
< virtualenv = 20.26.2 6,8c3,5
< base-prefix = /usr
< base-exec-prefix = /usr
< base-executable = /usr/bin/python3.11
---
> version = 3.11.7
> executable = /usr/bin/python3.11
> command = /usr/bin/python3.11 -m venv --copies --clear
/work/bootstrap-output/work-dir/pydantic_core-2.18.4/build-3.11.7
```