### PR TITLE
update the mergify rules to account for python 3.10 and rust 1.75

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -29,16 +29,18 @@ pull_request_rules:
           - check-success=linter
           - check-success=pkglint
           - check-success=markdownlint
-          - check-success=unit (3.10)
-          - check-success=unit (3.11)
-          - check-success=unit (3.12)
-          - check-success=e2e (3.10, bootstrap)
-          - check-success=e2e (3.11, bootstrap)
-          - check-success=e2e (3.12, bootstrap)
-          - check-success=e2e (3.11, report_missing_dependency)
-          - check-success=e2e (3.12, report_missing_dependency)
-          - check-success=e2e (3.11, build_with_build_order)
-          - check-success=e2e (3.12, build_with_build_order)
+          - check-success=unit (3.10, 1.75)
+          - check-success=unit (3.11, 1.75)
+          - check-success=unit (3.12, 1.75)
+          - check-success=e2e (3.10, 1.75, bootstrap)
+          - check-success=e2e (3.11, 1.75, bootstrap)
+          - check-success=e2e (3.12, 1.75, bootstrap)
+          - check-success=e2e (3.10, 1.75, report_missing_dependency)
+          - check-success=e2e (3.11, 1.75, report_missing_dependency)
+          - check-success=e2e (3.12, 1.75, report_missing_dependency)
+          - check-success=e2e (3.10, 1.75, build_with_build_order)
+          - check-success=e2e (3.11, 1.75, build_with_build_order)
+          - check-success=e2e (3.12, 1.75, build_with_build_order)
           - '-draft'
           # - or:
           #     - check-success=history-update


### PR DESCRIPTION
Introducing rust into the test matrix changed the names of the jobs,
so update the auto-merge rules to reflect the new names. Also require
3.10 jobs to pass.