### PR TITLE
allowing specified options for variants

### DIFF
--- a/src/fromager/commands/bootstrap.py
+++ b/src/fromager/commands/bootstrap.py
@@ -24,8 +24,8 @@ def _get_requirements_from_args(toplevel, requirements_file):
 
 
 @click.command()
-@click.option('--variant', default='cpu',
-              help='the build variant name')
+@click.option('--variant', default='cpu', help='the build variant name',
+              type=click.Choice(['cpu', 'cuda-ubi9', 'gaudi-ubi9', 'rocm-ubi9']))
 @click.option('-r', '--requirements-file', multiple=True,
               help='pip requirements file')
 @click.argument('toplevel', nargs=-1)


### PR DESCRIPTION
While learning the codebase and playing around I thought it would be a good idea to restrict `VARIANT` options and keep them inline with the backend.