### PR TITLE
move --variant option to main

### DIFF
--- a/src/fromager/__main__.py
+++ b/src/fromager/__main__.py
@@ -32,11 +32,14 @@ VERBOSE_LOG_FMT = '%(levelname)s:%(name)s:%(lineno)d: %(message)s'
               help='URL for the wheel server for builds')
 @click.option('--cleanup/--no-cleanup', default=True,
               help='control removal of working files when a build completes successfully')
+@click.option('--variant', default='cpu',
+              help='the build variant name')
 @click.pass_context
 def main(ctx, verbose, log_file,
          sdists_repo, wheels_repo, work_dir, patches_dir, envs_dir,
          settings_file, wheel_server_url,
          cleanup,
+         variant,
          ):
     # Configure console and log output.
     stream_handler = logging.StreamHandler()
@@ -66,6 +69,7 @@ def main(ctx, verbose, log_file,
         work_dir=work_dir,
         wheel_server_url=wheel_server_url,
         cleanup=cleanup,
+        variant=variant,
     )
     wkctx.setup()
     ctx.obj = wkctx

--- a/src/fromager/commands/bootstrap.py
+++ b/src/fromager/commands/bootstrap.py
@@ -24,20 +24,18 @@ def _get_requirements_from_args(toplevel, requirements_file):
 
 
 @click.command()
-@click.option('--variant', default='cpu',
-              help='the build variant name')
 @click.option('-r', '--requirements-file', multiple=True,
               help='pip requirements file')
 @click.argument('toplevel', nargs=-1)
 @click.pass_obj
-def bootstrap(wkctx, variant, requirements_file, toplevel):
+def bootstrap(wkctx, requirements_file, toplevel):
     """Compute and build the dependencies of a set of requirements recursively
 
     TOPLEVEL is a requirements specification, including a package name
     and optional version constraints.
 
     """
-    pre_built = wkctx.settings.pre_built(variant)
+    pre_built = wkctx.settings.pre_built(wkctx.variant)
     if pre_built:
         logger.info('treating %s as pre-built wheels', list(sorted(pre_built)))
 
@@ -46,7 +44,7 @@ def bootstrap(wkctx, variant, requirements_file, toplevel):
     to_build = _get_requirements_from_args(toplevel, requirements_file)
     if not to_build:
         raise RuntimeError('Pass a requirement specificiation or use -r to pass a requirements file')
-    logger.debug('bootstrapping %s', to_build)
+    logger.debug('bootstrapping %r variant of %s', wkctx.variant, to_build)
     for toplevel in to_build:
         sdist.handle_requirement(wkctx, Requirement(toplevel))
 


### PR DESCRIPTION
Several commands need to know the variant so move it from the
bootstrap command to main and ensure it is configured on the context
all the time.