### PR TITLE
include current package as prefix in log messages

### DIFF
--- a/src/fromager/commands/build.py
+++ b/src/fromager/commands/build.py
@@ -71,7 +71,6 @@ def _build(wkctx, dist_name, dist_version, sdist_server_url):
     req = Requirement(f'{dist_name}=={dist_version}')
 
     # Download
-    logger.info('downloading source archive for %s from %s', req, sdist_server_url)
     source_filename, version, source_url, _ = sources.download_source(
         wkctx, req, [sdist_server_url],
     )
@@ -79,14 +78,12 @@ def _build(wkctx, dist_name, dist_version, sdist_server_url):
                  req.name, version, source_url, source_filename)
 
     # Prepare source
-    logger.info('preparing source directory for %s', req)
     source_root_dir = sources.prepare_source(wkctx, req, source_filename, dist_version)
 
     # Build environment
-    logger.info('preparing build environment for %s', req)
     sdist.prepare_build_environment(wkctx, req, source_root_dir)
 
-    logger.info('building for %s', req)
+    # Build
     build_env = wheels.BuildEnvironment(wkctx, source_root_dir.parent, None)
     wheel_filename = wheels.build_wheel(wkctx, req, source_root_dir, build_env)
     return wheel_filename

--- a/src/fromager/commands/step.py
+++ b/src/fromager/commands/step.py
@@ -31,9 +31,7 @@ def download_source_archive(wkctx, dist_name, dist_version, sdist_server_url):
 
     """
     req = Requirement(f'{dist_name}=={dist_version}')
-    logger.info('downloading source archive for %s from %s', req, sdist_server_url)
     filename, version, source_url, _ = sources.download_source(wkctx, req, [sdist_server_url])
-    logger.debug('saved %s version %s from %s to %s', req.name, version, source_url, filename)
     print(filename)
 
 
@@ -52,7 +50,6 @@ def prepare_source(wkctx, dist_name, dist_version):
 
     """
     req = Requirement(f'{dist_name}=={dist_version}')
-    logger.info('preparing source directory for %s', req)
     sdists_downloads = pathlib.Path(wkctx.sdists_repo) / 'downloads'
     source_filename = finders.find_sdist(wkctx.sdists_downloads, req, dist_version)
     if source_filename is None:
@@ -92,7 +89,6 @@ def prepare_build(wkctx, dist_name, dist_version):
     server.start_wheel_server(wkctx)
     req = Requirement(f'{dist_name}=={dist_version}')
     source_root_dir = _find_source_root_dir(wkctx.work_dir, req, dist_version)
-    logger.info('preparing build environment for %s', req)
     sdist.prepare_build_environment(wkctx, req, source_root_dir)
 
 
@@ -109,7 +105,6 @@ def build_wheel(wkctx, dist_name, dist_version):
 
     """
     req = Requirement(f'{dist_name}=={dist_version}')
-    logger.info('building for %s', req)
     source_root_dir = _find_source_root_dir(wkctx.work_dir, req, dist_version)
     build_env = wheels.BuildEnvironment(wkctx, source_root_dir.parent, None)
     wheel_filename = wheels.build_wheel(wkctx, req, source_root_dir, build_env)

--- a/src/fromager/context.py
+++ b/src/fromager/context.py
@@ -65,8 +65,9 @@ class WorkContext:
         return (canonicalize_name(req.name), tuple(sorted(req.extras)), str(version))
 
     def mark_as_seen(self, req, version):
-        logger.debug('remembering seen sdist %s', self._resolved_key(req, version))
-        self._seen_requirements.add(self._resolved_key(req, version))
+        key = self._resolved_key(req, version)
+        logger.debug(f'{req.name}: remembering seen sdist {key}')
+        self._seen_requirements.add(key)
 
     def has_been_seen(self, req, version):
         return self._resolved_key(req, version) in self._seen_requirements
@@ -81,7 +82,7 @@ class WorkContext:
         key = (canonicalize_name(req.name), str(version))
         if key in self._build_requirements:
             return
-        logger.info(f'adding {key} to build order')
+        logger.info(f'{req.name}: adding {key} to build order')
         self._build_requirements.add(key)
         info = {
             'type': req_type,

--- a/src/fromager/dependencies.py
+++ b/src/fromager/dependencies.py
@@ -15,8 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_build_system_dependencies(ctx, req, sdist_root_dir):
-    logger.info('getting build system dependencies for %s in %s',
-                req, sdist_root_dir)
+    logger.info(f'{req.name}: getting build system dependencies for {req} in {sdist_root_dir}')
     dep_func = overrides.find_override_method(req.name, 'get_build_system_dependencies')
     if not dep_func:
         dep_func = default_get_build_system_dependencies
@@ -40,8 +39,7 @@ def default_get_build_system_dependencies(ctx, req, sdist_root_dir):
 
 
 def get_build_backend_dependencies(ctx, req, sdist_root_dir):
-    logger.info('getting build backend dependencies for %s in %s',
-                req, sdist_root_dir)
+    logger.info(f'{req.name}: getting build backend dependencies for {req} in {sdist_root_dir}')
     dep_func = overrides.find_override_method(req.name, 'get_build_backend_dependencies')
     if not dep_func:
         dep_func = default_get_build_backend_dependencies
@@ -58,8 +56,7 @@ def default_get_build_backend_dependencies(ctx, req, sdist_root_dir):
 
 
 def get_install_dependencies(ctx, req, sdist_root_dir):
-    logger.info('getting installation dependencies for %s in %s',
-                req, sdist_root_dir)
+    logger.info(f'{req.name}: getting installation dependencies for {req} in {sdist_root_dir}')
     dep_func = overrides.find_override_method(req.name, 'get_install_dependencies')
     if not dep_func:
         dep_func = default_get_install_dependencies
@@ -68,7 +65,7 @@ def get_install_dependencies(ctx, req, sdist_root_dir):
 
 
 def get_install_dependencies_of_wheel(req, wheel_filename):
-    logger.info('getting installation dependencies from %s', wheel_filename)
+    logger.info(f'{req.name}: getting installation dependencies from {wheel_filename}')
     wheel = pkginfo.Wheel(wheel_filename)
     return _filter_requirements(req, wheel.requires_dist)
 
@@ -82,7 +79,7 @@ def default_get_install_dependencies(ctx, req, sdist_root_dir):
 
     # Clean up any existing dist-info so we don't get an error regenerating it.
     for info_dir in sdist_root_dir.glob('*.dist-info'):
-        logger.debug('removing existing dist-info dir %s', info_dir)
+        logger.debug(f'{req.name}: removing existing dist-info dir {info_dir}')
         shutil.rmtree(info_dir)
 
     metadata_path = hook_caller.prepare_metadata_for_build_wheel(sdist_root_dir)

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -10,8 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 def build_wheel(ctx, req, sdist_root_dir, build_env):
-    logger.info('building wheel for %s in %s writing to %s', req.name, sdist_root_dir,
-                ctx.wheels_build)
+    logger.info(f'{req.name}: building wheel for {req} in {sdist_root_dir} writing to {ctx.wheels_build}')
     builder = overrides.find_override_method(req.name, 'build_wheel')
     if not builder:
         builder = default_build_wheel
@@ -27,7 +26,7 @@ def build_wheel(ctx, req, sdist_root_dir, build_env):
 
 
 def default_build_wheel(ctx, build_env, extra_environ, req, sdist_root_dir):
-    logger.debug('building wheel for %s with %s', sdist_root_dir, extra_environ)
+    logger.debug(f'{req.name}: building wheel in {sdist_root_dir} with {extra_environ}')
 
     # Activate the virtualenv for the subprocess:
     # 1. Put the build environment at the front of the PATH to ensure


### PR DESCRIPTION
Make the logs easier to follow by including the current requirement
being processed as a prefix for most log message lines.