### PR TITLE
adding download sequence command

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,6 +68,7 @@ jobs:
           - override
           - report_missing_dependency
           - rust_vendor
+          - download_sequence
 
     steps:
       - name: Get source

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -62,6 +62,10 @@ pull_request_rules:
           - check-success=e2e (3.11, 1.75, rust_vendor)
           - check-success=e2e (3.12, 1.75, rust_vendor)
 
+          - check-success=e2e (3.10, 1.75, download_sequence)
+          - check-success=e2e (3.11, 1.75, download_sequence)
+          - check-success=e2e (3.12, 1.75, download_sequence)
+
           - '-draft'
 
           - or:

--- a/e2e/download_sequence/simplejson-build-order.json
+++ b/e2e/download_sequence/simplejson-build-order.json
@@ -1,0 +1,96 @@
+[
+  {
+    "type": "build-system",
+    "req": "flit_core<4,>=3.8",
+    "dist": "flit-core",
+    "version": "3.9.0",
+    "why": [
+      [
+        "toplevel",
+        "simplejson==3.19.2",
+        "3.19.2"
+      ],
+      [
+        "build-system",
+        "setuptools>=40.8.0",
+        "70.0.0"
+      ],
+      [
+        "build-backend",
+        "wheel",
+        "0.43.0"
+      ],
+      [
+        "build-system",
+        "flit_core<4,>=3.8",
+        "3.9.0"
+      ]
+    ],
+    "prebuilt": false,
+    "source_url": "https://files.pythonhosted.org/packages/c4/e6/c1ac50fe3eebb38a155155711e6e864e254ce4b6e17fe2429b4c4d5b9e80/flit_core-3.9.0.tar.gz#sha256=72ad266176c4a3fcfab5f2930d76896059851240570ce9a98733b658cb786eba",
+    "source_url_type": "sdist"
+  },
+  {
+    "type": "build-backend",
+    "req": "wheel",
+    "dist": "wheel",
+    "version": "0.43.0",
+    "why": [
+      [
+        "toplevel",
+        "simplejson==3.19.2",
+        "3.19.2"
+      ],
+      [
+        "build-system",
+        "setuptools>=40.8.0",
+        "70.0.0"
+      ],
+      [
+        "build-backend",
+        "wheel",
+        "0.43.0"
+      ]
+    ],
+    "prebuilt": false,
+    "source_url": "https://files.pythonhosted.org/packages/b8/d6/ac9cd92ea2ad502ff7c1ab683806a9deb34711a1e2bd8a59814e8fc27e69/wheel-0.43.0.tar.gz#sha256=465ef92c69fa5c5da2d1cf8ac40559a8c940886afcef87dcf14b9470862f1d85",
+    "source_url_type": "sdist"
+  },
+  {
+    "type": "build-system",
+    "req": "setuptools>=40.8.0",
+    "dist": "setuptools",
+    "version": "70.0.0",
+    "why": [
+      [
+        "toplevel",
+        "simplejson==3.19.2",
+        "3.19.2"
+      ],
+      [
+        "build-system",
+        "setuptools>=40.8.0",
+        "70.0.0"
+      ]
+    ],
+    "prebuilt": false,
+    "source_url": "https://files.pythonhosted.org/packages/aa/60/5db2249526c9b453c5bb8b9f6965fcab0ddb7f40ad734420b3b421f7da44/setuptools-70.0.0.tar.gz#sha256=f211a66637b8fa059bb28183da127d4e86396c991a942b028c6650d4319c3fd0",
+    "source_url_type": "sdist"
+  },
+  {
+    "type": "toplevel",
+    "req": "simplejson==3.19.2",
+    "dist": "simplejson",
+    "version": "3.19.2",
+    "why": [
+      [
+        "toplevel",
+        "simplejson==3.19.2",
+        "3.19.2"
+      ]
+    ],
+    "prebuilt": false,
+    "source_url": "https://files.pythonhosted.org/packages/79/79/3ccb95bb4154952532f280f7a41979fbfb0fbbaee4d609810ecb01650afa/simplejson-3.19.2.tar.gz#sha256=9eb442a2442ce417801c912df68e1f6ccfcd41577ae7274953ab3ad24ef7d82c",
+    "source_url_type": "sdist"
+  }
+]

--- a/e2e/test_download_sequence.sh
+++ b/e2e/test_download_sequence.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# -*- indent-tabs-mode: nil; tab-width: 2; sh-indentation: 2; -*-
+
+# Tests downloading source for an entire `build-order.json` via
+# sources.download_source.
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+set -x
+set -e
+set -o pipefail
+
+# Bootstrap to create the build order file.
+OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
+
+# Recreate output directory for idempotency
+rm -rf "$OUTDIR"
+mkdir -p "$OUTDIR/build-logs"
+
+# Set up virtualenv with the CLI and dependencies.
+tox -e e2e -n -r
+source ".tox/e2e/bin/activate"
+
+# Bootstrap the test project
+fromager \
+  --sdists-repo="$OUTDIR/sdists-repo" \
+  --wheels-repo="$OUTDIR/wheels-repo" \
+  --work-dir="$OUTDIR/work-dir" \
+  download-sequence \
+  "$SCRIPTDIR/download_sequence/simplejson-build-order.json" \
+  "https://pypi.org/simple"
+
+pass=true
+
+# Check for output files
+EXPECTED_FILES="
+sdists-repo/downloads/flit_core-3.9.0.tar.gz
+sdists-repo/downloads/setuptools-70.0.0.tar.gz
+sdists-repo/downloads/simplejson-3.19.2.tar.gz
+sdists-repo/downloads/wheel-0.43.0.tar.gz
+"
+
+pass=true
+for f in $EXPECTED_FILES; do
+  if [ ! -f "$OUTDIR/$f" ]; then
+    echo "FAIL: Did not find $OUTDIR/$f" 1>&2
+    pass=false
+  fi
+done
+echo $pass
+$pass

--- a/src/fromager/commands/__init__.py
+++ b/src/fromager/commands/__init__.py
@@ -1,4 +1,4 @@
-from . import bootstrap, build, build_order, canonicalize, step
+from . import bootstrap, build, build_order, canonicalize, step, download_sequence
 
 commands = [
     bootstrap.bootstrap,
@@ -7,4 +7,5 @@ commands = [
     build_order.build_order,
     step.step,
     canonicalize.canonicalize,
+    download_sequence.download_sequence,
 ]

--- a/src/fromager/commands/download_sequence.py
+++ b/src/fromager/commands/download_sequence.py
@@ -1,0 +1,30 @@
+import logging
+import json
+
+import click
+from packaging.requirements import Requirement
+
+from .. import sources
+
+logger = logging.getLogger(__name__)
+
+
+@click.command()
+@click.argument('build_order_file')
+@click.argument('sdist_server_url')
+@click.pass_obj
+def download_sequence(wkctx, build_order_file, sdist_server_url):
+    """Download a sequence of source distributions in order.
+
+    BUILD_ORDER_FILE is the build-order.json files to build
+
+    SDIST_SERVER_URL is the URL for a PyPI-compatible package index hosting sdists
+
+    Performs the equivalent of the 'step download-source-archive' command for each item in
+    the build order file.
+
+    """
+    with open(build_order_file, 'r') as f:
+        for entry in json.load(f):
+            req = Requirement(f"{entry['dist']}=={entry['version']}")
+            sources.download_source(wkctx, req, [sdist_server_url])


### PR DESCRIPTION
Implements `download-sequence` command and corresponding tests. Uses a `build-order.json` compiled for CPU for `simplejson==3.19.2`. Later on enablement / testing should be added for multiple sdist servers.