### PR TITLE
let the resolver filter the type of distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ __pycache__/
 /e2e/pyo3_test/dist
 /e2e/pyo3_test/target
 /e2e/pyo3_test/vendor
+/overrides/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ test = [
     "pytest",
     "pytest-cov",
     "coverage!=4.4,>=4.0",
+    "requests-mock",
 ]
 build = [
     "build",

--- a/src/fromager/sdist.py
+++ b/src/fromager/sdist.py
@@ -27,7 +27,7 @@ class MissingDependency(Exception):
         resolutions = []
         for r in all_reqs:
             try:
-                url, version = sources.resolve_sdist(r, sources.PYPI_SERVER_URL)
+                url, version = sources.resolve_dist(r, sources.PYPI_SERVER_URL)
             except Exception as err:
                 resolutions.append(f'{r} -> {err}')
             else:
@@ -173,7 +173,7 @@ def _resolve_prebuilt_wheel(req, wheel_server_urls):
     "Return URL to wheel and its version."
     for url in wheel_server_urls:
         try:
-            wheel_url, resolved_version = sources.resolve_sdist(req, url, only_sdists=False)
+            wheel_url, resolved_version = sources.resolve_dist(req, url, include_sdists=False)
         except Exception:
             continue
         if wheel_url and resolved_version:

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -49,15 +49,20 @@ def download_source(ctx, req, sdist_server_urls):
     raise ValueError(f'failed to find source for {req} at {servers}')
 
 
-def resolve_sdist(req, sdist_server_url, only_sdists=True):
+def resolve_dist(req, sdist_server_url, include_sdists=True, include_wheels=True):
     "Return URL to source and its version."
+    logger.debug(f'{req.name}: resolving requirement {req} using {sdist_server_url}')
+
     # Create the (reusable) resolver. Limit to sdists.
-    provider = resolver.PyPIProvider(only_sdists=only_sdists, sdist_server_url=sdist_server_url)
+    provider = resolver.PyPIProvider(
+        include_sdists=include_sdists,
+        include_wheels=include_wheels,
+        sdist_server_url=sdist_server_url,
+    )
     reporter = resolvelib.BaseReporter()
     rslvr = resolvelib.Resolver(provider, reporter)
 
     # Kick off the resolution process, and get the final result.
-    logger.debug(f'{req.name}: resolving requirement {req} using {sdist_server_url}')
     try:
         result = rslvr.resolve([req])
     except (resolvelib.InconsistentCandidate,
@@ -73,7 +78,7 @@ def resolve_sdist(req, sdist_server_url, only_sdists=True):
 
 def default_download_source(ctx, req, sdist_server_url):
     "Download the requirement and return the name of the output path."
-    url, version = resolve_sdist(req, sdist_server_url)
+    url, version = resolve_dist(req, sdist_server_url, include_wheels=False)
     source_filename = download_url(ctx.sdists_downloads, url)
     logger.debug(f'{req.name}: have source for {req} version {version} in {source_filename}')
     return (source_filename, version, url)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,0 +1,59 @@
+import requests_mock
+import resolvelib
+from packaging.requirements import Requirement
+
+from fromager import resolver
+
+_hydra_core_simple_response = '''
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="pypi:repository-version" content="1.1">
+<title>Links for hydra-core</title>
+</head>
+<body>
+<h1>Links for hydra-core</h1>
+<a href="https://files.pythonhosted.org/packages/6d/8e/07e42bc434a847154083b315779b0a81d567154504624e181caf2c71cd98/hydra-core-1.3.2.tar.gz#sha256=8a878ed67216997c3e9d88a8e72e7b4767e81af37afb4ea3334b269a4390a824">hydra-core-1.3.2.tar.gz</a>
+<br/>
+<a href="https://files.pythonhosted.org/packages/c6/50/e0edd38dcd63fb26a8547f13d28f7a008bc4a3fd4eb4ff030673f22ad41a/hydra_core-1.3.2-py3-none-any.whl#sha256=fa0238a9e31df3373b35b0bfb672c34cc92718d21f81311d8996a16de1141d8b" data-dist-info-metadata="sha256=399046cbf9ae7ebab8dfd009e2b4f748212c710a0e75ca501a72bbb2d456e2e7" data-core-metadata="sha256=399046cbf9ae7ebab8dfd009e2b4f748212c710a0e75ca501a72bbb2d456e2e7">hydra_core-1.3.2-py3-none-any.whl</a>
+<br/>
+</body>
+</html>
+<!--SERIAL 22812307-->
+'''
+
+
+def test_provider_choose_wheel():
+    with requests_mock.Mocker() as r:
+        r.get('https://pypi.org/simple/hydra-core/',
+              text=_hydra_core_simple_response,
+              )
+
+        provider = resolver.PyPIProvider(include_sdists=False)
+        reporter = resolvelib.BaseReporter()
+        rslvr = resolvelib.Resolver(provider, reporter)
+
+        result = rslvr.resolve([Requirement('hydra-core')])
+        assert 'hydra-core' in result.mapping
+
+        candidate = result.mapping['hydra-core']
+        assert candidate.url == 'https://files.pythonhosted.org/packages/c6/50/e0edd38dcd63fb26a8547f13d28f7a008bc4a3fd4eb4ff030673f22ad41a/hydra_core-1.3.2-py3-none-any.whl#sha256=fa0238a9e31df3373b35b0bfb672c34cc92718d21f81311d8996a16de1141d8b'
+        assert str(candidate.version) == '1.3.2'
+
+
+def test_provider_choose_sdist():
+    with requests_mock.Mocker() as r:
+        r.get('https://pypi.org/simple/hydra-core/',
+              text=_hydra_core_simple_response,
+              )
+
+        provider = resolver.PyPIProvider(include_wheels=False)
+        reporter = resolvelib.BaseReporter()
+        rslvr = resolvelib.Resolver(provider, reporter)
+
+        result = rslvr.resolve([Requirement('hydra-core')])
+        assert 'hydra-core' in result.mapping
+
+        candidate = result.mapping['hydra-core']
+        assert candidate.url == 'https://files.pythonhosted.org/packages/6d/8e/07e42bc434a847154083b315779b0a81d567154504624e181caf2c71cd98/hydra-core-1.3.2.tar.gz#sha256=8a878ed67216997c3e9d88a8e72e7b4767e81af37afb4ea3334b269a4390a824'
+        assert str(candidate.version) == '1.3.2'

--- a/tests/test_sdist.py
+++ b/tests/test_sdist.py
@@ -6,13 +6,13 @@ from packaging.version import Version
 from fromager import sdist
 
 
-@patch('fromager.sources.resolve_sdist')
-def test_missing_dependency_format(resolve_sdist):
+@patch('fromager.sources.resolve_dist')
+def test_missing_dependency_format(resolve_dist):
     resolutions = {
         'flit_core': '3.9.0',
         'setuptools': '69.5.1',
     }
-    resolve_sdist.side_effect = lambda req, url: ('', Version(resolutions[req.name]))
+    resolve_dist.side_effect = lambda req, url: ('', Version(resolutions[req.name]))
 
     req = Requirement('setuptools>=40.8.0')
     other_reqs = [


### PR DESCRIPTION
Change the resolver code to have explicit options for whether to include
sdist and wheel distributions as candidates.

Rename sources.resolve_sdist() to sources.resolve_dist() to reflect the
scope change.

Add requests_mock testing dependency.

Fixes #87