### PR TITLE
be more explicit about the types of dists to download

### DIFF
--- a/src/fromager/sdist.py
+++ b/src/fromager/sdist.py
@@ -173,7 +173,9 @@ def _resolve_prebuilt_wheel(req, wheel_server_urls):
     "Return URL to wheel and its version."
     for url in wheel_server_urls:
         try:
-            wheel_url, resolved_version = sources.resolve_dist(req, url, include_sdists=False)
+            wheel_url, resolved_version = sources.resolve_dist(req, url,
+                                                               include_sdists=False,
+                                                               include_wheels=True)
         except Exception:
             continue
         if wheel_url and resolved_version:

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -78,7 +78,7 @@ def resolve_dist(req, sdist_server_url, include_sdists=True, include_wheels=True
 
 def default_download_source(ctx, req, sdist_server_url):
     "Download the requirement and return the name of the output path."
-    url, version = resolve_dist(req, sdist_server_url, include_wheels=False)
+    url, version = resolve_dist(req, sdist_server_url, include_sdists=True, include_wheels=False)
     source_filename = download_url(ctx.sdists_downloads, url)
     logger.debug(f'{req.name}: have source for {req} version {version} in {source_filename}')
     return (source_filename, version, url)


### PR DESCRIPTION
In a few places where we change the default inputs to resolve_dist()
pass both options for clarity about what sorts of distributions are
expected as results.

Related to #88
Related to #87