### PR TITLE
when bootstrapping, report origin of each requirement

### DIFF
--- a/src/fromager/commands/bootstrap.py
+++ b/src/fromager/commands/bootstrap.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 def _get_requirements_from_args(toplevel, requirements_file):
     to_build = []
-    to_build.extend(toplevel)
+    to_build.extend(('toplevel', t) for t in toplevel)
     for filename in requirements_file:
         with open(filename, 'r') as f:
             for line in f:
@@ -19,7 +19,7 @@ def _get_requirements_from_args(toplevel, requirements_file):
                 logger.debug('line %r useful %r', line, useful)
                 if not useful:
                     continue
-                to_build.append(useful)
+                to_build.append((str(filename), useful))
     return to_build
 
 
@@ -46,8 +46,8 @@ def bootstrap(wkctx, requirements_file, toplevel):
 
     server.start_wheel_server(wkctx)
 
-    for toplevel in to_build:
-        sdist.handle_requirement(wkctx, Requirement(toplevel))
+    for origin, toplevel in to_build:
+        sdist.handle_requirement(wkctx, Requirement(toplevel), req_type=origin)
 
     # If we put pre-built wheels in the downloads directory, we should
     # remove them so we can treat that directory as a source of wheels

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -5,19 +5,19 @@ from fromager.commands import bootstrap
 
 def test_get_requirements_single_arg():
     requirements = bootstrap._get_requirements_from_args(['a'], [])
-    assert ['a'] == requirements
+    assert [('toplevel', 'a')] == requirements
 
 
 def test_get_requirements_multiple_args():
     requirements = bootstrap._get_requirements_from_args(['a', 'b'], [])
-    assert ['a', 'b'] == requirements
+    assert [('toplevel', 'a'), ('toplevel', 'b')] == requirements
 
 
 def test_get_requirements_requirements_file(tmp_path):
     requirements_file = tmp_path / 'requirements.txt'
     requirements_file.write_text('c\n')
     requirements = bootstrap._get_requirements_from_args([], [requirements_file])
-    assert ['c'] == requirements
+    assert [(str(requirements_file), 'c')] == requirements
 
 
 def test_get_requirements_requirements_file_comments(tmp_path):
@@ -31,7 +31,7 @@ def test_get_requirements_requirements_file_comments(tmp_path):
         '''),
     )
     requirements = bootstrap._get_requirements_from_args([], [requirements_file])
-    assert ['c', 'd'] == requirements
+    assert [(str(requirements_file), 'c'), (str(requirements_file), 'd')] == requirements
 
 
 def test_get_requirements_requirements_file_multiple(tmp_path):
@@ -40,18 +40,19 @@ def test_get_requirements_requirements_file_multiple(tmp_path):
     requirements2_file = tmp_path / 'requirements2.txt'
     requirements2_file.write_text('b\n')
     requirements = bootstrap._get_requirements_from_args([], [requirements1_file, requirements2_file])
-    assert ['a', 'b'] == requirements
+    assert [(str(requirements1_file), 'a'), (str(requirements2_file), 'b')] == requirements
 
 
 def test_get_requirements_file_with_comments_and_blanks(tmp_path):
     requirements_file = tmp_path / 'requirements.txt'
     requirements_file.write_text('a\n\n# ignore\nb\nc\n')
     requirements = bootstrap._get_requirements_from_args([], [requirements_file])
-    assert ['a', 'b', 'c'] == requirements
+    f = str(requirements_file)
+    assert [(f, 'a'), (f, 'b'), (f, 'c')] == requirements
 
 
 def test_get_requirements_args_and_file(tmp_path):
     requirements_file = tmp_path / 'requirements.txt'
     requirements_file.write_text('c\n')
     requirements = bootstrap._get_requirements_from_args(['a', 'b'], [requirements_file])
-    assert ['a', 'b', 'c'] == requirements
+    assert [('toplevel', 'a'), ('toplevel', 'b'), (str(requirements_file), 'c')] == requirements


### PR DESCRIPTION
The CLI takes as input requirements or files with lists of requirements. This adds the filename as part of the build-order output and log messages so it is easier to understand where a requirement was fed into the system.