### PR TITLE
make e2e jobs more robust

### DIFF
--- a/e2e/test_bootstrap.sh
+++ b/e2e/test_bootstrap.sh
@@ -25,35 +25,31 @@ fromager \
   --work-dir="$OUTDIR/work-dir" \
   bootstrap 'stevedore==5.2.0'
 
-find "$OUTDIR/wheels-repo/simple/" -name '*.whl'
+find "$OUTDIR/wheels-repo/" -name '*.whl'
+find "$OUTDIR/sdists-repo/" -name '*.tar.gz'
+ls "$OUTDIR"/work-dir/*/build.log || true
 
 EXPECTED_FILES="
-wheels-repo/downloads/flit_core-3.9.0-py3-none-any.whl
-wheels-repo/downloads/wheel-0.43.0-py3-none-any.whl
-wheels-repo/downloads/setuptools-70.0.0-py3-none-any.whl
-wheels-repo/downloads/pbr-6.0.0-py2.py3-none-any.whl
-wheels-repo/downloads/stevedore-5.2.0-py3-none-any.whl
+$OUTDIR/wheels-repo/downloads/setuptools-*.whl
+$OUTDIR/wheels-repo/downloads/pbr-*.whl
+$OUTDIR/wheels-repo/downloads/stevedore-*.whl
 
-sdists-repo/downloads/stevedore-5.2.0.tar.gz
-sdists-repo/downloads/setuptools-70.0.0.tar.gz
-sdists-repo/downloads/wheel-0.43.0.tar.gz
-sdists-repo/downloads/flit_core-3.9.0.tar.gz
-sdists-repo/downloads/pbr-6.0.0.tar.gz
+$OUTDIR/sdists-repo/downloads/stevedore-*.tar.gz
+$OUTDIR/sdists-repo/downloads/setuptools-*.tar.gz
+$OUTDIR/sdists-repo/downloads/pbr-*.tar.gz
 
-work-dir/build-order.json
-work-dir/constraints.txt
+$OUTDIR/work-dir/build-order.json
+$OUTDIR/work-dir/constraints.txt
 
-work-dir/flit_core-3.9.0/build.log
-work-dir/pbr-6.0.0/build.log
-work-dir/setuptools-70.0.0/build.log
-work-dir/stevedore-5.2.0/build.log
-work-dir/wheel-0.43.0/build.log
+$OUTDIR/work-dir/pbr-*/build.log
+$OUTDIR/work-dir/setuptools-*/build.log
+$OUTDIR/work-dir/stevedore-*/build.log
 "
 
 pass=true
-for f in $EXPECTED_FILES; do
-  if [ ! -f "$OUTDIR/$f" ]; then
-    echo "Did not find $f" 1>&2
+for pattern in $EXPECTED_FILES; do
+  if [ ! -f "${pattern}" ]; then
+    echo "Did not find $pattern" 1>&2
     pass=false
   fi
 done

--- a/e2e/test_build_order.sh
+++ b/e2e/test_build_order.sh
@@ -63,30 +63,21 @@ fromager \
 find "$OUTDIR/wheels-repo/"
 
 EXPECTED_FILES="
-wheels-repo/downloads/flit_core-3.9.0-py3-none-any.whl
-wheels-repo/downloads/wheel-0.43.0-py3-none-any.whl
-wheels-repo/downloads/setuptools-70.0.0-py3-none-any.whl
-wheels-repo/downloads/pbr-6.0.0-py2.py3-none-any.whl
-wheels-repo/downloads/stevedore-5.2.0-py3-none-any.whl
+$OUTDIR/wheels-repo/downloads/setuptools-*.whl
+$OUTDIR/wheels-repo/downloads/pbr-*.whl
+$OUTDIR/wheels-repo/downloads/stevedore-*.whl
 
-sdists-repo/downloads/stevedore-5.2.0.tar.gz
-sdists-repo/downloads/setuptools-70.0.0.tar.gz
-sdists-repo/downloads/wheel-0.43.0.tar.gz
-sdists-repo/downloads/flit_core-3.9.0.tar.gz
-sdists-repo/downloads/pbr-6.0.0.tar.gz
-
-work-dir/flit_core-3.9.0/build.log
-work-dir/pbr-6.0.0/build.log
-work-dir/setuptools-70.0.0/build.log
-work-dir/stevedore-5.2.0/build.log
-work-dir/wheel-0.43.0/build.log
+$OUTDIR/sdists-repo/downloads/stevedore-*.tar.gz
+$OUTDIR/sdists-repo/downloads/setuptools-*.tar.gz
+$OUTDIR/sdists-repo/downloads/pbr-*.tar.gz
 "
 
 pass=true
-for f in $EXPECTED_FILES; do
-  if [ ! -f "$OUTDIR/$f" ]; then
-    echo "FAIL: Did not find $OUTDIR/$f" 1>&2
+for pattern in $EXPECTED_FILES; do
+  if [ ! -f "${pattern}" ]; then
+    echo "Did not find $pattern" 1>&2
     pass=false
   fi
 done
+
 $pass

--- a/e2e/test_build_steps.sh
+++ b/e2e/test_build_steps.sh
@@ -115,30 +115,21 @@ source "$OUTDIR/build.sh"
 find "$OUTDIR/wheels-repo/"
 
 EXPECTED_FILES="
-wheels-repo/downloads/flit_core-3.9.0-py3-none-any.whl
-wheels-repo/downloads/wheel-0.43.0-py3-none-any.whl
-wheels-repo/downloads/setuptools-70.0.0-py3-none-any.whl
-wheels-repo/downloads/pbr-6.0.0-py2.py3-none-any.whl
-wheels-repo/downloads/stevedore-5.2.0-py3-none-any.whl
+$OUTDIR/wheels-repo/downloads/setuptools-*.whl
+$OUTDIR/wheels-repo/downloads/pbr-*.whl
+$OUTDIR/wheels-repo/downloads/stevedore-*.whl
 
-sdists-repo/downloads/stevedore-5.2.0.tar.gz
-sdists-repo/downloads/setuptools-70.0.0.tar.gz
-sdists-repo/downloads/wheel-0.43.0.tar.gz
-sdists-repo/downloads/flit_core-3.9.0.tar.gz
-sdists-repo/downloads/pbr-6.0.0.tar.gz
-
-work-dir/flit_core-3.9.0/build.log
-work-dir/pbr-6.0.0/build.log
-work-dir/setuptools-70.0.0/build.log
-work-dir/stevedore-5.2.0/build.log
-work-dir/wheel-0.43.0/build.log
+$OUTDIR/sdists-repo/downloads/stevedore-*.tar.gz
+$OUTDIR/sdists-repo/downloads/setuptools-*.tar.gz
+$OUTDIR/sdists-repo/downloads/pbr-*.tar.gz
 "
 
 pass=true
-for f in $EXPECTED_FILES; do
-  if [ ! -f "$OUTDIR/$f" ]; then
-    echo "FAIL: Did not find $OUTDIR/$f" 1>&2
+for pattern in $EXPECTED_FILES; do
+  if [ ! -f "${pattern}" ]; then
+    echo "Did not find $pattern" 1>&2
     pass=false
   fi
 done
+
 $pass


### PR DESCRIPTION
Some of the e2e jobs had hard-coded expectations for version numbers
of dependencies of packages involved in the tests. Those versions will
change over time as new releases are created, so this commit reworks
the tests to be more flexible about the version numbers and removes
the dependencies that have been dropped from the test packages.