### PR TITLE
feature: make a new sdist after running prepare_source

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ The `step prepare-build` command creates a virtualenv with the build
 dependencies for building the wheel. It expects a `--wheel-server-url`
 as argument to control where built wheels can be downloaded.
 
+The `step build-sdist` command turns the prepared source tree into a
+new source distribution ("sdist"), including any patches or vendored
+code.
+
 The `step build-wheel` command creates a wheel using the build
 environment and prepared source, compiling any extensions using the
 appropriate override environment settings (refer to

--- a/e2e/run_all.sh
+++ b/e2e/run_all.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Run all of the e2e tests. Useful for local development.
+
+set -e
+set -o pipefail
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+for test_script in $SCRIPTDIR/test_*.sh; do
+    echo "****************************************"
+    echo "$test_script"
+    echo "****************************************"
+    $test_script
+done

--- a/e2e/test_bootstrap.sh
+++ b/e2e/test_bootstrap.sh
@@ -11,6 +11,7 @@ set -x
 set -e
 set -o pipefail
 
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
 
 rm -rf "$OUTDIR"
@@ -37,6 +38,10 @@ $OUTDIR/wheels-repo/downloads/stevedore-*.whl
 $OUTDIR/sdists-repo/downloads/stevedore-*.tar.gz
 $OUTDIR/sdists-repo/downloads/setuptools-*.tar.gz
 $OUTDIR/sdists-repo/downloads/pbr-*.tar.gz
+
+$OUTDIR/sdists-repo/builds/stevedore-*.tar.gz
+$OUTDIR/sdists-repo/builds/setuptools-*.tar.gz
+$OUTDIR/sdists-repo/builds/pbr-*.tar.gz
 
 $OUTDIR/work-dir/build-order.json
 $OUTDIR/work-dir/constraints.txt

--- a/e2e/test_build_steps.sh
+++ b/e2e/test_build_steps.sh
@@ -82,6 +82,14 @@ build_wheel() {
         --wheel-server-url "${WHEEL_SERVER_URL}" \
         step prepare-build "$dist" "$version"
 
+    # Build an updated sdist
+    fromager \
+        --log-file "$OUTDIR/build-logs/${dist}-build-sdist.log" \
+        --work-dir "$OUTDIR/work-dir" \
+        --sdists-repo "$OUTDIR/sdists-repo" \
+        --wheels-repo "$OUTDIR/wheels-repo" \
+        step build-sdist "$dist" "$version"
+
     # Build the wheel
     fromager \
         --log-file "$OUTDIR/build-logs/${dist}-prepare-build.log" \
@@ -122,6 +130,10 @@ $OUTDIR/wheels-repo/downloads/stevedore-*.whl
 $OUTDIR/sdists-repo/downloads/stevedore-*.tar.gz
 $OUTDIR/sdists-repo/downloads/setuptools-*.tar.gz
 $OUTDIR/sdists-repo/downloads/pbr-*.tar.gz
+
+$OUTDIR/sdists-repo/builds/stevedore-*.tar.gz
+$OUTDIR/sdists-repo/builds/setuptools-*.tar.gz
+$OUTDIR/sdists-repo/builds/pbr-*.tar.gz
 "
 
 pass=true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,9 @@ version_file = "src/fromager/version.py"
 target-version = "py310"
 # same as black's default line length
 line-length = 88
+exclude = [
+    "src/fromager/version.py",  # file is generated dynamically, out of our control
+]
 
 [tool.ruff.lint]
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/src/fromager/commands/build.py
+++ b/src/fromager/commands/build.py
@@ -92,6 +92,9 @@ def _build(wkctx, dist_name, dist_version, sdist_server_url):
     # Build environment
     sdist.prepare_build_environment(wkctx, req, source_root_dir)
 
+    # Make a new source distribution, in case we patched the code.
+    sources.build_sdist(wkctx, req, source_root_dir)
+
     # Build
     build_env = wheels.BuildEnvironment(wkctx, source_root_dir.parent, None)
     wheel_filename = wheels.build_wheel(wkctx, req, source_root_dir, build_env)

--- a/src/fromager/commands/step.py
+++ b/src/fromager/commands/step.py
@@ -48,8 +48,6 @@ def prepare_source(wkctx, dist_name, dist_version):
 
     DIST_VERSION is the version to process
 
-    SDIST_SERVER_URL is the URL for a PyPI-compatible package index hosting sdists
-
     """
     req = Requirement(f"{dist_name}=={dist_version}")
     sdists_downloads = pathlib.Path(wkctx.sdists_repo) / "downloads"
@@ -64,6 +62,27 @@ def prepare_source(wkctx, dist_name, dist_version):
     # FIXME: Does the version need to be a Version instead of str?
     source_root_dir = sources.prepare_source(wkctx, req, source_filename, dist_version)
     print(source_root_dir)
+
+
+@step.command()
+@click.argument("dist_name")
+@click.argument("dist_version")
+@click.pass_obj
+def build_sdist(wkctx, dist_name, dist_version):
+    """build a new source distribution for the package
+
+    DIST_NAME is the name of a distribution
+
+    DIST_VERSION is the version to process
+
+    The source distribution is placed in the `sdists-repo/builds`
+    directory.
+
+    """
+    req = Requirement(f"{dist_name}=={dist_version}")
+    source_root_dir = _find_source_root_dir(wkctx.work_dir, req, dist_version)
+    sdist_filename = sources.build_sdist(wkctx, req, source_root_dir)
+    print(sdist_filename)
 
 
 def _find_source_root_dir(work_dir, req, dist_version):

--- a/src/fromager/context.py
+++ b/src/fromager/context.py
@@ -26,6 +26,7 @@ class WorkContext:
         self.envs_dir = pathlib.Path(envs_dir).absolute()
         self.sdists_repo = pathlib.Path(sdists_repo).absolute()
         self.sdists_downloads = self.sdists_repo / "downloads"
+        self.sdists_builds = self.sdists_repo / "builds"
         self.wheels_repo = pathlib.Path(wheels_repo).absolute()
         self.wheels_build = self.wheels_repo / "build"
         self.wheels_downloads = self.wheels_repo / "downloads"
@@ -112,6 +113,7 @@ class WorkContext:
             self.work_dir,
             self.sdists_repo,
             self.sdists_downloads,
+            self.sdists_builds,
             self.wheels_repo,
             self.wheels_downloads,
             self.wheels_prebuilt,

--- a/src/fromager/tarballs.py
+++ b/src/fromager/tarballs.py
@@ -1,0 +1,36 @@
+"""Based on https://src.fedoraproject.org/rpms/python-cryptography/blob/rawhide/f/vendor_rust.py"""
+
+import os
+import stat
+import tarfile
+
+
+def _tar_reset(tarinfo):
+    """Reset user, group, mtime, and mode to create reproducible tar"""
+    tarinfo.uid = 0
+    tarinfo.gid = 0
+    tarinfo.uname = "root"
+    tarinfo.gname = "root"
+    tarinfo.mtime = 0
+    if tarinfo.type == tarfile.DIRTYPE or stat.S_IMODE(tarinfo.mode) & stat.S_IXUSR:
+        tarinfo.mode = 0o755
+    else:
+        tarinfo.mode = 0o644
+    if tarinfo.pax_headers:
+        raise ValueError(tarinfo.name, tarinfo.pax_headers)
+    return tarinfo
+
+
+def tar_reproducible(tar, basedir):
+    """Create reproducible tar file"""
+
+    content = [str(basedir)]  # convert from pathlib.Path, if that's what we have
+    for root, dirs, files in os.walk(basedir):
+        for directory in dirs:
+            content.append(os.path.join(root, directory))
+        for filename in files:
+            content.append(os.path.join(root, filename))
+    content.sort()
+
+    for fn in content:
+        tar.add(fn, filter=_tar_reset, recursive=False, arcname=fn)

--- a/tests/test_tarballs.py
+++ b/tests/test_tarballs.py
@@ -1,0 +1,25 @@
+import tarfile
+
+from fromager import tarballs
+
+
+def test_modes_change(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    a = root / "a"
+    a.write_text("this is file a")
+    a.chmod(0o0600)
+
+    t1 = tmp_path / "out1.tar"
+    with tarfile.open(t1, "w") as tf:
+        tarballs.tar_reproducible(tf, root)
+
+    a.chmod(0o0666)
+
+    t2 = tmp_path / "out2.tar"
+    with tarfile.open(t2, "w") as tf:
+        tarballs.tar_reproducible(tf, root)
+
+    t1_contents = t1.read_bytes()
+    t2_contents = t2.read_bytes()
+    assert t1_contents == t2_contents, "file contents differ"


### PR DESCRIPTION
Add a step command to build an sdist for a set of sources.

Update the build and build-sequence commands to produce an sdist as
well as a wheel when building something.

Update the bootstrap command to create sdists for everything that is
bootstrapped.

Fixes #67 
