### PR TITLE
 Add Ruff for linting and auto-formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,10 +70,33 @@ fromager_test = "fromager.example_override"
 [tool.setuptools_scm]
 version_file = "src/fromager/version.py"
 
-[tool.isort]
-known_first_party=["fromager"]
-skip_glob=[
-  ".tox/*",    # test runner environment
-  "work-dir*", # test runner output
-  "tox_env",   # CI job venv
+[tool.ruff]
+target-version = "py310"
+# same as black's default line length
+line-length = 88
+
+[tool.ruff.lint]
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+select = [
+  "B",  # flake8-bugbear
+  "E",  # pycodestyle
+  "F",  # pyflakes
+  "Q",  # flake8-quotes
+  "I",  # isort
+  "N",  # pep8-naming
+  "W",  # pycodestyle
+  "RUF", # ruff-specific rules
+  "UP",  # pyupgrade
+  "TID", # flake8-tidy-imports
 ]
+ignore = [
+    "E501",  # Line too long
+    "RUF005",  # Consider iterable unpacking instead of concatenation
+    "TID252",  # Prefer absolute imports over relative imports from parent modules
+    "UP015",  # Unnecessary open mode parameters
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["fromager"]

--- a/src/fromager/__main__.py
+++ b/src/fromager/__main__.py
@@ -9,38 +9,89 @@ from . import commands, context, overrides, settings
 
 logger = logging.getLogger(__name__)
 
-TERSE_LOG_FMT = '%(message)s'
-VERBOSE_LOG_FMT = '%(levelname)s:%(name)s:%(lineno)d: %(message)s'
+TERSE_LOG_FMT = "%(message)s"
+VERBOSE_LOG_FMT = "%(levelname)s:%(name)s:%(lineno)d: %(message)s"
 
 
 @click.group()
-@click.option('-v', '--verbose', default=False, is_flag=True, help='report more detail to the console')
-@click.option('--log-file', type=click.Path(), help='save detailed report of actions to file')
-@click.option('-o', '--sdists-repo', default=pathlib.Path('sdists-repo'), type=click.Path(),
-              help='location to manage source distributions')
-@click.option('-w', '--wheels-repo', default=pathlib.Path('wheels-repo'), type=click.Path(),
-              help='location to manage wheel repository')
-@click.option('-t', '--work-dir', default=pathlib.Path('work-dir'), type=click.Path(),
-              help='location to manage working files, including builds')
-@click.option('-p', '--patches-dir', default=pathlib.Path('overrides/patches'), type=click.Path(),
-              help='location of files for patching source before building')
-@click.option('-e', '--envs-dir', default=pathlib.Path('overrides/envs'), type=click.Path(),
-              help='location of environment override files')
-@click.option('--settings-file', default=pathlib.Path('overrides/settings.yaml'), type=click.Path(),
-              help='location of the application settings file')
-@click.option('--wheel-server-url', default='', type=str,
-              help='URL for the wheel server for builds')
-@click.option('--cleanup/--no-cleanup', default=True,
-              help='control removal of working files when a build completes successfully')
-@click.option('--variant', default='cpu',
-              help='the build variant name')
+@click.option(
+    "-v",
+    "--verbose",
+    default=False,
+    is_flag=True,
+    help="report more detail to the console",
+)
+@click.option(
+    "--log-file", type=click.Path(), help="save detailed report of actions to file"
+)
+@click.option(
+    "-o",
+    "--sdists-repo",
+    default=pathlib.Path("sdists-repo"),
+    type=click.Path(),
+    help="location to manage source distributions",
+)
+@click.option(
+    "-w",
+    "--wheels-repo",
+    default=pathlib.Path("wheels-repo"),
+    type=click.Path(),
+    help="location to manage wheel repository",
+)
+@click.option(
+    "-t",
+    "--work-dir",
+    default=pathlib.Path("work-dir"),
+    type=click.Path(),
+    help="location to manage working files, including builds",
+)
+@click.option(
+    "-p",
+    "--patches-dir",
+    default=pathlib.Path("overrides/patches"),
+    type=click.Path(),
+    help="location of files for patching source before building",
+)
+@click.option(
+    "-e",
+    "--envs-dir",
+    default=pathlib.Path("overrides/envs"),
+    type=click.Path(),
+    help="location of environment override files",
+)
+@click.option(
+    "--settings-file",
+    default=pathlib.Path("overrides/settings.yaml"),
+    type=click.Path(),
+    help="location of the application settings file",
+)
+@click.option(
+    "--wheel-server-url",
+    default="",
+    type=str,
+    help="URL for the wheel server for builds",
+)
+@click.option(
+    "--cleanup/--no-cleanup",
+    default=True,
+    help="control removal of working files when a build completes successfully",
+)
+@click.option("--variant", default="cpu", help="the build variant name")
 @click.pass_context
-def main(ctx, verbose, log_file,
-         sdists_repo, wheels_repo, work_dir, patches_dir, envs_dir,
-         settings_file, wheel_server_url,
-         cleanup,
-         variant,
-         ):
+def main(
+    ctx,
+    verbose,
+    log_file,
+    sdists_repo,
+    wheels_repo,
+    work_dir,
+    patches_dir,
+    envs_dir,
+    settings_file,
+    wheel_server_url,
+    cleanup,
+    variant,
+):
     # Configure console and log output.
     stream_handler = logging.StreamHandler()
     stream_handler.setLevel(logging.DEBUG if verbose else logging.INFO)
@@ -83,11 +134,11 @@ def invoke_main():
     # Wrapper for the click main command that ensures any exceptions
     # are logged so that build pipeline outputs include the traceback.
     try:
-        main(auto_envvar_prefix='FROMAGER')
+        main(auto_envvar_prefix="FROMAGER")
     except Exception as err:
         logger.exception(err)
         raise
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     invoke_main()

--- a/src/fromager/commands/__init__.py
+++ b/src/fromager/commands/__init__.py
@@ -1,4 +1,4 @@
-from . import bootstrap, build, build_order, canonicalize, step, download_sequence
+from . import bootstrap, build, build_order, canonicalize, download_sequence, step
 
 commands = [
     bootstrap.bootstrap,

--- a/src/fromager/commands/bootstrap.py
+++ b/src/fromager/commands/bootstrap.py
@@ -10,13 +10,13 @@ logger = logging.getLogger(__name__)
 
 def _get_requirements_from_args(toplevel, requirements_file):
     to_build = []
-    to_build.extend(('toplevel', t) for t in toplevel)
+    to_build.extend(("toplevel", t) for t in toplevel)
     for filename in requirements_file:
-        with open(filename, 'r') as f:
+        with open(filename, "r") as f:
             for line in f:
-                useful, _, _ = line.partition('#')
+                useful, _, _ = line.partition("#")
                 useful = useful.strip()
-                logger.debug('line %r useful %r', line, useful)
+                logger.debug("line %r useful %r", line, useful)
                 if not useful:
                     continue
                 to_build.append((str(filename), useful))
@@ -24,9 +24,8 @@ def _get_requirements_from_args(toplevel, requirements_file):
 
 
 @click.command()
-@click.option('-r', '--requirements-file', multiple=True,
-              help='pip requirements file')
-@click.argument('toplevel', nargs=-1)
+@click.option("-r", "--requirements-file", multiple=True, help="pip requirements file")
+@click.argument("toplevel", nargs=-1)
 @click.pass_obj
 def bootstrap(wkctx, requirements_file, toplevel):
     """Compute and build the dependencies of a set of requirements recursively
@@ -37,12 +36,14 @@ def bootstrap(wkctx, requirements_file, toplevel):
     """
     to_build = _get_requirements_from_args(toplevel, requirements_file)
     if not to_build:
-        raise RuntimeError('Pass a requirement specificiation or use -r to pass a requirements file')
-    logger.info('bootstrapping %r variant of %s', wkctx.variant, to_build)
+        raise RuntimeError(
+            "Pass a requirement specificiation or use -r to pass a requirements file"
+        )
+    logger.info("bootstrapping %r variant of %s", wkctx.variant, to_build)
 
     pre_built = wkctx.settings.pre_built(wkctx.variant)
     if pre_built:
-        logger.info('treating %s as pre-built wheels', list(sorted(pre_built)))
+        logger.info("treating %s as pre-built wheels", list(sorted(pre_built)))
 
     server.start_wheel_server(wkctx)
 
@@ -52,8 +53,10 @@ def bootstrap(wkctx, requirements_file, toplevel):
     # If we put pre-built wheels in the downloads directory, we should
     # remove them so we can treat that directory as a source of wheels
     # to upload to an index.
-    for prebuilt_wheel in wkctx.wheels_prebuilt.glob('*.whl'):
+    for prebuilt_wheel in wkctx.wheels_prebuilt.glob("*.whl"):
         filename = wkctx.wheels_downloads / prebuilt_wheel.name
         if filename.exists():
-            logger.info(f'removing prebuilt wheel {prebuilt_wheel.name} from download cache')
+            logger.info(
+                f"removing prebuilt wheel {prebuilt_wheel.name} from download cache"
+            )
             filename.unlink()

--- a/src/fromager/commands/build.py
+++ b/src/fromager/commands/build.py
@@ -10,9 +10,9 @@ logger = logging.getLogger(__name__)
 
 
 @click.command()
-@click.argument('dist_name')
-@click.argument('dist_version')
-@click.argument('sdist_server_url')
+@click.argument("dist_name")
+@click.argument("dist_version")
+@click.argument("sdist_server_url")
 @click.pass_obj
 def build(wkctx, dist_name, dist_version, sdist_server_url):
     """Build a single version of a single wheel
@@ -41,8 +41,8 @@ def build(wkctx, dist_name, dist_version, sdist_server_url):
 
 
 @click.command()
-@click.argument('build_order_file')
-@click.argument('sdist_server_url')
+@click.argument("build_order_file")
+@click.argument("sdist_server_url")
 @click.pass_obj
 def build_sequence(wkctx, build_order_file, sdist_server_url):
     """Build a sequence of wheels in order
@@ -55,9 +55,11 @@ def build_sequence(wkctx, build_order_file, sdist_server_url):
     the build order file.
 
     """
-    with open(build_order_file, 'r') as f:
+    with open(build_order_file, "r") as f:
         for entry in json.load(f):
-            wheel_filename = _build(wkctx, entry['dist'], entry['version'], sdist_server_url)
+            wheel_filename = _build(
+                wkctx, entry["dist"], entry["version"], sdist_server_url
+            )
             server.update_wheel_mirror(wkctx)
             # After we update the wheel mirror, the built file has
             # moved to a new directory.
@@ -68,14 +70,21 @@ def build_sequence(wkctx, build_order_file, sdist_server_url):
 def _build(wkctx, dist_name, dist_version, sdist_server_url):
     server.start_wheel_server(wkctx)
 
-    req = Requirement(f'{dist_name}=={dist_version}')
+    req = Requirement(f"{dist_name}=={dist_version}")
 
     # Download
     source_filename, version, source_url, _ = sources.download_source(
-        wkctx, req, [sdist_server_url],
+        wkctx,
+        req,
+        [sdist_server_url],
     )
-    logger.debug('saved %s version %s from %s to %s',
-                 req.name, version, source_url, source_filename)
+    logger.debug(
+        "saved %s version %s from %s to %s",
+        req.name,
+        version,
+        source_url,
+        source_filename,
+    )
 
     # Prepare source
     source_root_dir = sources.prepare_source(wkctx, req, source_filename, dist_version)

--- a/src/fromager/commands/build_order.py
+++ b/src/fromager/commands/build_order.py
@@ -226,14 +226,14 @@ def graph(build_order_file, output):
                     ('fontcolor', 'white'),
                     ('tooltip', 'toplevel package'),
                 ])
-            node_attr_text = ','.join('%s="%s"' % a for a in node_attrs)
+            node_attr_text = ','.join(f'{a}="{b}"' for a, b in node_attrs)
 
             outfile.write(f'  {nid} [{node_attr_text}];\n')
 
         outfile.write('\n')
         if len(toplevel_nodes) > 1:
             outfile.write('  /* toplevel nodes should all be at the same level */\n')
-            outfile.write('  {rank=same; %s;}\n\n' % " ".join(toplevel_nodes))
+            outfile.write(f"  {{rank=same; {' '.join(toplevel_nodes)};}}\n\n")
         # if len(leaves) > 1:
         #     outfile.write('  /* leaf nodes should all be at the same level */\n')
         #     outfile.write('  {rank=same; %s;}\n\n' % " ".join(leaves))

--- a/src/fromager/commands/build_order.py
+++ b/src/fromager/commands/build_order.py
@@ -18,9 +18,8 @@ def build_order():
 
 
 @build_order.command()
-@click.option('-o', '--output', type=click.Path(),
-              help='output file to create')
-@click.argument('build_order_file')
+@click.option("-o", "--output", type=click.Path(), help="output file to create")
+@click.argument("build_order_file")
 def as_csv(build_order_file, output):
     """Create a comma-separated-value file from the build order file
 
@@ -33,42 +32,43 @@ def as_csv(build_order_file, output):
 
     """
     fields = [
-        ('dist', 'Distribution Name'),
-        ('version', 'Version'),
-        ('req', 'Original Requirement'),
-        ('type', 'Dependency Type'),
-        ('prebuilt', 'Pre-built Package'),
-        ('order', 'Build Order'),
-        ('why', 'Dependency Chain'),
+        ("dist", "Distribution Name"),
+        ("version", "Version"),
+        ("req", "Original Requirement"),
+        ("type", "Dependency Type"),
+        ("prebuilt", "Pre-built Package"),
+        ("order", "Build Order"),
+        ("why", "Dependency Chain"),
     ]
     headers = {n: v for n, v in fields}
     fieldkeys = [f[0] for f in fields]
     fieldnames = [f[1] for f in fields]
 
     build_order = []
-    with open(build_order_file, 'r') as f:
+    with open(build_order_file, "r") as f:
         for i, entry in enumerate(json.load(f), 1):
             # Add an order column, not in the original source file, in
             # case someone wants to sort the output on another field.
-            entry['order'] = i
+            entry["order"] = i
             # Replace the short keys with the longer human-readable
             # headers we want in the CSV output.
             new_entry = {headers[f]: entry[f] for f in fieldkeys}
             # Reformat the why field
-            new_entry['Dependency Chain'] = ' '.join(
-                f'-{dep_type}-> {Requirement(req).name}({version})'
-                for dep_type, req, version
-                in entry['why']
+            new_entry["Dependency Chain"] = " ".join(
+                f"-{dep_type}-> {Requirement(req).name}({version})"
+                for dep_type, req, version in entry["why"]
             )
             build_order.append(new_entry)
 
     if output:
-        outfile = open(output, 'w')
+        outfile = open(output, "w")
     else:
         outfile = sys.stdout
 
     try:
-        writer = csv.DictWriter(outfile, fieldnames=fieldnames, quoting=csv.QUOTE_NONNUMERIC)
+        writer = csv.DictWriter(
+            outfile, fieldnames=fieldnames, quoting=csv.QUOTE_NONNUMERIC
+        )
         writer.writeheader()
         writer.writerows(build_order)
     finally:
@@ -77,9 +77,8 @@ def as_csv(build_order_file, output):
 
 
 @build_order.command()
-@click.option('-o', '--output', type=click.Path(),
-              help='output file to create')
-@click.argument('build_order_file', nargs=-1)
+@click.option("-o", "--output", type=click.Path(), help="output file to create")
+@click.argument("build_order_file", nargs=-1)
 def summary(build_order_file, output):
     """Summarize the build order files
 
@@ -92,22 +91,21 @@ def summary(build_order_file, output):
     """
     dist_to_input_file = collections.defaultdict(dict)
     for filename in build_order_file:
-        with open(filename, 'r') as f:
+        with open(filename, "r") as f:
             build_order = json.load(f)
         for step in build_order:
-            key = overrides.pkgname_to_override_module(step['dist'])
-            dist_to_input_file[key][filename] = step['version']
+            key = overrides.pkgname_to_override_module(step["dist"])
+            dist_to_input_file[key][filename] = step["version"]
 
     if output:
-        outfile = open(output, 'w')
+        outfile = open(output, "w")
     else:
         outfile = sys.stdout
 
     # The build order files are organized in directories named for the
     # image. Pull those names out of the files given.
     image_column_names = tuple(
-        pathlib.Path(filename).parent.name
-        for filename in build_order_file
+        pathlib.Path(filename).parent.name for filename in build_order_file
     )
 
     writer = csv.writer(outfile, quoting=csv.QUOTE_NONNUMERIC)
@@ -128,9 +126,8 @@ def summary(build_order_file, output):
 
 
 @build_order.command()
-@click.option('-o', '--output', type=click.Path(),
-              help='output file to create')
-@click.argument('build_order_file', nargs=-1)
+@click.option("-o", "--output", type=click.Path(), help="output file to create")
+@click.argument("build_order_file", nargs=-1)
 def graph(build_order_file, output):
     """Write a graphviz-compatible dot file representing the build order dependencies
 
@@ -141,20 +138,22 @@ def graph(build_order_file, output):
     def fmt_req(req, version):
         req = Requirement(req)
         name = overrides.pkgname_to_override_module(req.name)
-        return f'{name}{"[" + ",".join(req.extras) + "]" if req.extras else ""}=={version}'
+        return (
+            f'{name}{"[" + ",".join(req.extras) + "]" if req.extras else ""}=={version}'
+        )
 
     def new_node(req):
         if req not in nodes:
             nodes[req] = {
-                'nid': 'node' + str(next(node_ids)),
-                'prebuilt': False,
+                "nid": "node" + str(next(node_ids)),
+                "prebuilt": False,
             }
         return nodes[req]
 
     def update_node(req, prebuilt=False):
         node_details = new_node(req)
-        if (not node_details['prebuilt']) and prebuilt:
-            node_details['prebuilt'] = True
+        if (not node_details["prebuilt"]) and prebuilt:
+            node_details["prebuilt"] = True
         return req
 
     # Track unique ids for nodes since the labels may not be
@@ -165,13 +164,15 @@ def graph(build_order_file, output):
     edges = []
 
     for filename in build_order_file:
-        with open(filename, 'r') as f:
+        with open(filename, "r") as f:
             build_order = json.load(f)
 
         for step in build_order:
-            update_node(fmt_req(step['dist'], step['version']), prebuilt=step['prebuilt'])
+            update_node(
+                fmt_req(step["dist"], step["version"]), prebuilt=step["prebuilt"]
+            )
             try:
-                why = step['why']
+                why = step["why"]
                 if len(why) == 0:
                     # should not happen
                     continue
@@ -189,50 +190,53 @@ def graph(build_order_file, output):
                             edges.append(edge)
                         parent_info = child_info
             except Exception as err:
-                raise Exception(f'Error processing {filename} at {step}') from err
+                raise Exception(f"Error processing {filename} at {step}") from err
 
     if output:
-        outfile = open(output, 'w')
+        outfile = open(output, "w")
     else:
         outfile = sys.stdout
     try:
-
-        outfile.write('digraph {\n')
+        outfile.write("digraph {\n")
 
         # Determine some nodes with special characteristics
-        all_nodes = set(n['nid'] for n in nodes.values())
+        all_nodes = set(n["nid"] for n in nodes.values())
         # left = set(nodes[p]['nid'] for p, _ in edges)
-        right = set(nodes[c]['nid'] for _, c in edges)
+        right = set(nodes[c]["nid"] for _, c in edges)
         # Toplevel nodes have no incoming connections
         toplevel_nodes = all_nodes - right
         # Leaves have no outgoing connections
         # leaves = all_nodes - left
 
         for req, node_details in nodes.items():
-            nid = node_details['nid']
+            nid = node_details["nid"]
 
-            node_attrs = [('label', req)]
-            if node_details['prebuilt']:
-                node_attrs.extend([
-                    ('style', 'filled'),
-                    ('color', 'darkred'),
-                    ('fontcolor', 'white'),
-                    ('tooltip', 'pre-built package'),
-                ])
+            node_attrs = [("label", req)]
+            if node_details["prebuilt"]:
+                node_attrs.extend(
+                    [
+                        ("style", "filled"),
+                        ("color", "darkred"),
+                        ("fontcolor", "white"),
+                        ("tooltip", "pre-built package"),
+                    ]
+                )
             elif nid in toplevel_nodes:
-                node_attrs.extend([
-                    ('style', 'filled'),
-                    ('color', 'darkgreen'),
-                    ('fontcolor', 'white'),
-                    ('tooltip', 'toplevel package'),
-                ])
-            node_attr_text = ','.join(f'{a}="{b}"' for a, b in node_attrs)
+                node_attrs.extend(
+                    [
+                        ("style", "filled"),
+                        ("color", "darkgreen"),
+                        ("fontcolor", "white"),
+                        ("tooltip", "toplevel package"),
+                    ]
+                )
+            node_attr_text = ",".join(f'{a}="{b}"' for a, b in node_attrs)
 
-            outfile.write(f'  {nid} [{node_attr_text}];\n')
+            outfile.write(f"  {nid} [{node_attr_text}];\n")
 
-        outfile.write('\n')
+        outfile.write("\n")
         if len(toplevel_nodes) > 1:
-            outfile.write('  /* toplevel nodes should all be at the same level */\n')
+            outfile.write("  /* toplevel nodes should all be at the same level */\n")
             outfile.write(f"  {{rank=same; {' '.join(toplevel_nodes)};}}\n\n")
         # if len(leaves) > 1:
         #     outfile.write('  /* leaf nodes should all be at the same level */\n')
@@ -240,12 +244,12 @@ def graph(build_order_file, output):
 
         for parent_req, child_req in edges:
             parent_node = nodes[parent_req]
-            parent_nid = parent_node['nid']
+            parent_nid = parent_node["nid"]
             child_node = nodes[child_req]
-            child_nid = child_node['nid']
-            outfile.write(f'  {parent_nid} -> {child_nid};\n')
+            child_nid = child_node["nid"]
+            outfile.write(f"  {parent_nid} -> {child_nid};\n")
 
-        outfile.write('}\n')
+        outfile.write("}\n")
     finally:
         if output:
             outfile.close()

--- a/src/fromager/commands/canonicalize.py
+++ b/src/fromager/commands/canonicalize.py
@@ -4,7 +4,7 @@ from .. import overrides
 
 
 @click.command()
-@click.argument('dist_name', nargs=-1)
+@click.argument("dist_name", nargs=-1)
 def canonicalize(dist_name):
     """convert a package name to its canonical form for use in override paths"""
     for name in dist_name:

--- a/src/fromager/commands/download_sequence.py
+++ b/src/fromager/commands/download_sequence.py
@@ -10,8 +10,8 @@ logger = logging.getLogger(__name__)
 
 
 @click.command()
-@click.argument('build_order_file')
-@click.argument('sdist_server_url')
+@click.argument("build_order_file")
+@click.argument("sdist_server_url")
 @click.pass_obj
 def download_sequence(wkctx, build_order_file, sdist_server_url):
     """Download a sequence of source distributions in order.
@@ -24,7 +24,7 @@ def download_sequence(wkctx, build_order_file, sdist_server_url):
     the build order file.
 
     """
-    with open(build_order_file, 'r') as f:
+    with open(build_order_file, "r") as f:
         for entry in json.load(f):
             if entry["prebuilt"]:
                 continue

--- a/src/fromager/commands/download_sequence.py
+++ b/src/fromager/commands/download_sequence.py
@@ -1,5 +1,5 @@
-import logging
 import json
+import logging
 
 import click
 from packaging.requirements import Requirement

--- a/src/fromager/commands/step.py
+++ b/src/fromager/commands/step.py
@@ -16,9 +16,9 @@ def step():
 
 
 @step.command()
-@click.argument('dist_name')
-@click.argument('dist_version')
-@click.argument('sdist_server_url')
+@click.argument("dist_name")
+@click.argument("dist_version")
+@click.argument("sdist_server_url")
 @click.pass_obj
 def download_source_archive(wkctx, dist_name, dist_version, sdist_server_url):
     """download the source code archive for one version of one package
@@ -30,14 +30,16 @@ def download_source_archive(wkctx, dist_name, dist_version, sdist_server_url):
     SDIST_SERVER_URL is the URL for a PyPI-compatible package index hosting sdists
 
     """
-    req = Requirement(f'{dist_name}=={dist_version}')
-    filename, version, source_url, _ = sources.download_source(wkctx, req, [sdist_server_url])
+    req = Requirement(f"{dist_name}=={dist_version}")
+    filename, version, source_url, _ = sources.download_source(
+        wkctx, req, [sdist_server_url]
+    )
     print(filename)
 
 
 @step.command()
-@click.argument('dist_name')
-@click.argument('dist_version')
+@click.argument("dist_name")
+@click.argument("dist_version")
 @click.pass_obj
 def prepare_source(wkctx, dist_name, dist_version):
     """ensure the source code is in a form ready for building a wheel
@@ -49,15 +51,15 @@ def prepare_source(wkctx, dist_name, dist_version):
     SDIST_SERVER_URL is the URL for a PyPI-compatible package index hosting sdists
 
     """
-    req = Requirement(f'{dist_name}=={dist_version}')
-    sdists_downloads = pathlib.Path(wkctx.sdists_repo) / 'downloads'
+    req = Requirement(f"{dist_name}=={dist_version}")
+    sdists_downloads = pathlib.Path(wkctx.sdists_repo) / "downloads"
     source_filename = finders.find_sdist(wkctx.sdists_downloads, req, dist_version)
     if source_filename is None:
         dir_contents = []
-        for ext in ['*.tar.gz', '*.zip']:
+        for ext in ["*.tar.gz", "*.zip"]:
             dir_contents.extend(str(e) for e in wkctx.sdists_downloads.glob(ext))
         raise RuntimeError(
-            f'Cannot find sdist for {req.name} version {dist_version} in {sdists_downloads} among {dir_contents}'
+            f"Cannot find sdist for {req.name} version {dist_version} in {sdists_downloads} among {dir_contents}"
         )
     # FIXME: Does the version need to be a Version instead of str?
     source_root_dir = sources.prepare_source(wkctx, req, source_filename, dist_version)
@@ -68,15 +70,15 @@ def _find_source_root_dir(work_dir, req, dist_version):
     source_root_dir = finders.find_source_dir(pathlib.Path(work_dir), req, dist_version)
     if source_root_dir:
         return source_root_dir
-    work_dir_contents = list(str(e) for e in work_dir.glob('*'))
+    work_dir_contents = list(str(e) for e in work_dir.glob("*"))
     raise RuntimeError(
-        f'Cannot find source directory for {req.name} version {dist_version} among {work_dir_contents}'
+        f"Cannot find source directory for {req.name} version {dist_version} among {work_dir_contents}"
     )
 
 
 @step.command()
-@click.argument('dist_name')
-@click.argument('dist_version')
+@click.argument("dist_name")
+@click.argument("dist_version")
 @click.pass_obj
 def prepare_build(wkctx, dist_name, dist_version):
     """set up build environment to build the package
@@ -87,14 +89,14 @@ def prepare_build(wkctx, dist_name, dist_version):
 
     """
     server.start_wheel_server(wkctx)
-    req = Requirement(f'{dist_name}=={dist_version}')
+    req = Requirement(f"{dist_name}=={dist_version}")
     source_root_dir = _find_source_root_dir(wkctx.work_dir, req, dist_version)
     sdist.prepare_build_environment(wkctx, req, source_root_dir)
 
 
 @step.command()
-@click.argument('dist_name')
-@click.argument('dist_version')
+@click.argument("dist_name")
+@click.argument("dist_version")
 @click.pass_obj
 def build_wheel(wkctx, dist_name, dist_version):
     """build a wheel from prepared source
@@ -104,7 +106,7 @@ def build_wheel(wkctx, dist_name, dist_version):
     DIST_VERSION is the version to process
 
     """
-    req = Requirement(f'{dist_name}=={dist_version}')
+    req = Requirement(f"{dist_name}=={dist_version}")
     source_root_dir = _find_source_root_dir(wkctx.work_dir, req, dist_version)
     build_env = wheels.BuildEnvironment(wkctx, source_root_dir.parent, None)
     wheel_filename = wheels.build_wheel(wkctx, req, source_root_dir, build_env)

--- a/src/fromager/dependencies.py
+++ b/src/fromager/dependencies.py
@@ -125,13 +125,14 @@ def get_build_backend(pyproject_toml):
 def get_build_backend_hook_caller(sdist_root_dir, pyproject_toml, override_environ):
     backend = get_build_backend(pyproject_toml)
 
-    def _run_hook_with_extra_environ(cmd, cwd=None, extra_environ={}):
+    def _run_hook_with_extra_environ(cmd, cwd=None, extra_environ=None):
         """The BuildBackendHookCaller is going to pass extra_environ
         and our build system may want to set some values, too. Merge
         the 2 sets of values before calling the actual runner function.
         """
         full_environ = {}
-        full_environ.update(extra_environ)
+        if extra_environ is not None:
+            full_environ.update(extra_environ)
         full_environ.update(override_environ)
         return external_commands.run(cmd, cwd=cwd, extra_environ=full_environ)
 

--- a/src/fromager/dependencies.py
+++ b/src/fromager/dependencies.py
@@ -15,8 +15,10 @@ logger = logging.getLogger(__name__)
 
 
 def get_build_system_dependencies(ctx, req, sdist_root_dir):
-    logger.info(f'{req.name}: getting build system dependencies for {req} in {sdist_root_dir}')
-    dep_func = overrides.find_override_method(req.name, 'get_build_system_dependencies')
+    logger.info(
+        f"{req.name}: getting build system dependencies for {req} in {sdist_root_dir}"
+    )
+    dep_func = overrides.find_override_method(req.name, "get_build_system_dependencies")
     if not dep_func:
         dep_func = default_get_build_system_dependencies
     deps = _filter_requirements(req, dep_func(ctx, req, sdist_root_dir))
@@ -35,12 +37,16 @@ def _filter_requirements(req, requirements):
 
 def default_get_build_system_dependencies(ctx, req, sdist_root_dir):
     pyproject_toml = _get_pyproject_contents(sdist_root_dir)
-    return get_build_backend(pyproject_toml)['requires']
+    return get_build_backend(pyproject_toml)["requires"]
 
 
 def get_build_backend_dependencies(ctx, req, sdist_root_dir):
-    logger.info(f'{req.name}: getting build backend dependencies for {req} in {sdist_root_dir}')
-    dep_func = overrides.find_override_method(req.name, 'get_build_backend_dependencies')
+    logger.info(
+        f"{req.name}: getting build backend dependencies for {req} in {sdist_root_dir}"
+    )
+    dep_func = overrides.find_override_method(
+        req.name, "get_build_backend_dependencies"
+    )
     if not dep_func:
         dep_func = default_get_build_backend_dependencies
     deps = _filter_requirements(req, dep_func(ctx, req, sdist_root_dir))
@@ -50,14 +56,17 @@ def get_build_backend_dependencies(ctx, req, sdist_root_dir):
 def default_get_build_backend_dependencies(ctx, req, sdist_root_dir):
     pyproject_toml = _get_pyproject_contents(sdist_root_dir)
     extra_environ = overrides.extra_environ_for_pkg(ctx.envs_dir, req.name, ctx.variant)
-    hook_caller = get_build_backend_hook_caller(sdist_root_dir, pyproject_toml,
-                                                override_environ=extra_environ)
+    hook_caller = get_build_backend_hook_caller(
+        sdist_root_dir, pyproject_toml, override_environ=extra_environ
+    )
     return hook_caller.get_requires_for_build_wheel()
 
 
 def get_install_dependencies(ctx, req, sdist_root_dir):
-    logger.info(f'{req.name}: getting installation dependencies for {req} in {sdist_root_dir}')
-    dep_func = overrides.find_override_method(req.name, 'get_install_dependencies')
+    logger.info(
+        f"{req.name}: getting installation dependencies for {req} in {sdist_root_dir}"
+    )
+    dep_func = overrides.find_override_method(req.name, "get_install_dependencies")
     if not dep_func:
         dep_func = default_get_install_dependencies
     deps = _filter_requirements(req, dep_func(ctx, req, sdist_root_dir))
@@ -65,7 +74,7 @@ def get_install_dependencies(ctx, req, sdist_root_dir):
 
 
 def get_install_dependencies_of_wheel(req, wheel_filename):
-    logger.info(f'{req.name}: getting installation dependencies from {wheel_filename}')
+    logger.info(f"{req.name}: getting installation dependencies from {wheel_filename}")
     wheel = pkginfo.Wheel(wheel_filename)
     return _filter_requirements(req, wheel.requires_dist)
 
@@ -74,25 +83,26 @@ def default_get_install_dependencies(ctx, req, sdist_root_dir):
     pyproject_toml = _get_pyproject_contents(sdist_root_dir)
     requires = set()
     extra_environ = overrides.extra_environ_for_pkg(ctx.envs_dir, req.name, ctx.variant)
-    hook_caller = get_build_backend_hook_caller(sdist_root_dir, pyproject_toml,
-                                                override_environ=extra_environ)
+    hook_caller = get_build_backend_hook_caller(
+        sdist_root_dir, pyproject_toml, override_environ=extra_environ
+    )
 
     # Clean up any existing dist-info so we don't get an error regenerating it.
-    for info_dir in sdist_root_dir.glob('*.dist-info'):
-        logger.debug(f'{req.name}: removing existing dist-info dir {info_dir}')
+    for info_dir in sdist_root_dir.glob("*.dist-info"):
+        logger.debug(f"{req.name}: removing existing dist-info dir {info_dir}")
         shutil.rmtree(info_dir)
 
     metadata_path = hook_caller.prepare_metadata_for_build_wheel(sdist_root_dir)
     with open(os.path.join(sdist_root_dir, metadata_path, "METADATA"), "r") as f:
         parsed = metadata.Metadata.from_email(f.read(), validate=False)
-        for r in (parsed.requires_dist or []):
+        for r in parsed.requires_dist or []:
             if evaluate_marker(r, req.extras):
                 requires.add(r)
     return requires
 
 
 def _get_pyproject_contents(sdist_root_dir):
-    pyproject_toml_filename = sdist_root_dir / 'pyproject.toml'
+    pyproject_toml_filename = sdist_root_dir / "pyproject.toml"
     if not os.path.exists(pyproject_toml_filename):
         return {}
     return toml.loads(pyproject_toml_filename.read_text())
@@ -100,9 +110,9 @@ def _get_pyproject_contents(sdist_root_dir):
 
 # From pypa/build/src/build/__main__.py
 _DEFAULT_BACKEND = {
-    'build-backend': 'setuptools.build_meta:__legacy__',
-    'backend-path': None,
-    'requires': ['setuptools >= 40.8.0'],
+    "build-backend": "setuptools.build_meta:__legacy__",
+    "backend-path": None,
+    "requires": ["setuptools >= 40.8.0"],
 }
 
 
@@ -115,9 +125,9 @@ def get_build_backend(pyproject_toml):
     # Override it with local settings. This allows for some projects
     # like pyarrow, that don't have 'build-backend' set but *do* have
     # 'requires' set.
-    for key in ['build-backend', 'backend-path', 'requires']:
-        if key in pyproject_toml.get('build-system', {}):
-            backend_settings[key] = pyproject_toml['build-system'][key]
+    for key in ["build-backend", "backend-path", "requires"]:
+        if key in pyproject_toml.get("build-system", {}):
+            backend_settings[key] = pyproject_toml["build-system"][key]
 
     return backend_settings
 
@@ -138,8 +148,8 @@ def get_build_backend_hook_caller(sdist_root_dir, pyproject_toml, override_envir
 
     return pyproject_hooks.BuildBackendHookCaller(
         source_dir=sdist_root_dir,
-        build_backend=backend['build-backend'],
-        backend_path=backend['backend-path'],
+        build_backend=backend["build-backend"],
+        backend_path=backend["backend-path"],
         runner=_run_hook_with_extra_environ,
     )
 
@@ -152,12 +162,16 @@ def evaluate_marker(req, extras=None):
     if not extras:
         marker_envs = [default_env]
     else:
-        marker_envs = [default_env.copy() | {'extra': e} for e in extras]
+        marker_envs = [default_env.copy() | {"extra": e} for e in extras]
 
     for marker_env in marker_envs:
         if req.marker.evaluate(marker_env):
-            logger.debug(f'adding {req} -- marker evaluates true with extras={extras} and default_env={default_env}')
+            logger.debug(
+                f"adding {req} -- marker evaluates true with extras={extras} and default_env={default_env}"
+            )
             return True
 
-    logger.debug(f'ignoring {req} -- marker evaluates false with extras={extras} and default_env={default_env}')
+    logger.debug(
+        f"ignoring {req} -- marker evaluates false with extras={extras} and default_env={default_env}"
+    )
     return False

--- a/src/fromager/example_override.py
+++ b/src/fromager/example_override.py
@@ -1,6 +1,6 @@
 def expected_source_archive_name(req, dist_version):
-    return f'fromager-test-{dist_version}.tar.gz'
+    return f"fromager-test-{dist_version}.tar.gz"
 
 
 def expected_source_directory_name(req, dist_version):
-    return f'fromager-test-{dist_version}/different-prefix-fromager-test-{dist_version}'
+    return f"fromager-test-{dist_version}/different-prefix-fromager-test-{dist_version}"

--- a/src/fromager/external_commands.py
+++ b/src/fromager/external_commands.py
@@ -7,15 +7,17 @@ logger = logging.getLogger(__name__)
 
 
 # based on pyproject_hooks/_impl.py: quiet_subprocess_runner
-def run(cmd, cwd=None, extra_environ={}, log_filename=None):
+def run(cmd, cwd=None, extra_environ=None, log_filename=None):
     """Call the subprocess while logging output
     """
+    if extra_environ is None:
+        extra_environ = {}
     env = os.environ.copy()
     env.update(extra_environ)
 
     logger.debug(
         'running: %s %s in %s',
-        ' '.join('%s=%s' % x for x in extra_environ.items()),
+        ' '.join(f"{k}={v}" for k, v in extra_environ.items()),
         ' '.join(shlex.quote(str(s)) for s in cmd),
         cwd or '.',
     )

--- a/src/fromager/external_commands.py
+++ b/src/fromager/external_commands.py
@@ -8,21 +8,20 @@ logger = logging.getLogger(__name__)
 
 # based on pyproject_hooks/_impl.py: quiet_subprocess_runner
 def run(cmd, cwd=None, extra_environ=None, log_filename=None):
-    """Call the subprocess while logging output
-    """
+    """Call the subprocess while logging output"""
     if extra_environ is None:
         extra_environ = {}
     env = os.environ.copy()
     env.update(extra_environ)
 
     logger.debug(
-        'running: %s %s in %s',
-        ' '.join(f"{k}={v}" for k, v in extra_environ.items()),
-        ' '.join(shlex.quote(str(s)) for s in cmd),
-        cwd or '.',
+        "running: %s %s in %s",
+        " ".join(f"{k}={v}" for k, v in extra_environ.items()),
+        " ".join(shlex.quote(str(s)) for s in cmd),
+        cwd or ".",
     )
     if log_filename:
-        with open(log_filename, 'w') as log_file:
+        with open(log_filename, "w") as log_file:
             completed = subprocess.run(
                 cmd,
                 cwd=cwd,
@@ -30,7 +29,7 @@ def run(cmd, cwd=None, extra_environ=None, log_filename=None):
                 stdout=log_file,
                 stderr=subprocess.STDOUT,
             )
-        with open(log_filename, 'r', encoding='utf-8') as f:
+        with open(log_filename, "r", encoding="utf-8") as f:
             output = f.read()
     else:
         completed = subprocess.run(
@@ -40,9 +39,9 @@ def run(cmd, cwd=None, extra_environ=None, log_filename=None):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )
-        output = completed.stdout.decode('utf-8') if completed.stdout else ''
+        output = completed.stdout.decode("utf-8") if completed.stdout else ""
     if completed.returncode != 0:
-        logger.error('%s failed with %s', cmd, output)
+        logger.error("%s failed with %s", cmd, output)
         raise subprocess.CalledProcessError(completed.returncode, cmd, output)
-    logger.debug('output: %s', output)
+    logger.debug("output: %s", output)
     return output

--- a/src/fromager/extras_provider.py
+++ b/src/fromager/extras_provider.py
@@ -39,7 +39,7 @@ class ExtrasProvider(AbstractProvider):
         raise NotImplementedError
 
     def identify(self, requirement_or_candidate):
-        base = super(ExtrasProvider, self).identify(requirement_or_candidate)
+        base = super().identify(requirement_or_candidate)
         extras = self.get_extras_for(requirement_or_candidate)
         if extras:
             return (base, extras)
@@ -47,7 +47,7 @@ class ExtrasProvider(AbstractProvider):
             return base
 
     def get_dependencies(self, candidate):
-        deps = super(ExtrasProvider, self).get_dependencies(candidate)
+        deps = super().get_dependencies(candidate)
         if candidate.extras:
             req = self.get_base_requirement(candidate)
             deps.append(req)

--- a/src/fromager/finders.py
+++ b/src/fromager/finders.py
@@ -16,7 +16,7 @@ def _dist_name_to_filename(dist_name):
     Following https://peps.python.org/pep-0427/
     """
     canonical_name = canonicalize_name(dist_name)
-    return re.sub(r"[^\w\d.]+", "_", canonical_name, re.UNICODE)
+    return re.sub(r"[^\w\d.]+", "_", canonical_name, flags=re.UNICODE)
 
 
 def find_sdist(downloads_dir, req, dist_version):

--- a/src/fromager/finders.py
+++ b/src/fromager/finders.py
@@ -20,7 +20,9 @@ def _dist_name_to_filename(dist_name):
 
 
 def find_sdist(downloads_dir, req, dist_version):
-    sdist_name_func = overrides.find_override_method(req.name, 'expected_source_archive_name')
+    sdist_name_func = overrides.find_override_method(
+        req.name, "expected_source_archive_name"
+    )
 
     if sdist_name_func:
         # The file must exist exactly as given.
@@ -32,62 +34,65 @@ def find_sdist(downloads_dir, req, dist_version):
         filename_prefix = _dist_name_to_filename(req.name)
         canonical_name = canonicalize_name(req.name)
 
-        candidate_bases = set([
-            # First check if the file is there using the canonically
-            # transformed name.
-            f'{filename_prefix}-{dist_version}',
-            # If that didn't work, try the canonical dist name. That's not
-            # "correct" but we do see it. (charset-normalizer-3.3.2.tar.gz
-            # and setuptools-scm-8.0.4.tar.gz) for example
-            f'{canonical_name}-{dist_version}',
-            # If *that* didn't work, try the dist name we've been
-            # given as a dependency. That's not "correct", either but we do
-            # see it. (oslo.messaging-14.7.0.tar.gz) for example
-            f'{req.name}-{dist_version}',
-            # Sometimes the sdist uses '.' instead of '-' in the
-            # package name portion.
-            f'{req.name.replace("-", ".")}-{dist_version}',
-        ])
+        candidate_bases = set(
+            [
+                # First check if the file is there using the canonically
+                # transformed name.
+                f"{filename_prefix}-{dist_version}",
+                # If that didn't work, try the canonical dist name. That's not
+                # "correct" but we do see it. (charset-normalizer-3.3.2.tar.gz
+                # and setuptools-scm-8.0.4.tar.gz) for example
+                f"{canonical_name}-{dist_version}",
+                # If *that* didn't work, try the dist name we've been
+                # given as a dependency. That's not "correct", either but we do
+                # see it. (oslo.messaging-14.7.0.tar.gz) for example
+                f"{req.name}-{dist_version}",
+                # Sometimes the sdist uses '.' instead of '-' in the
+                # package name portion.
+                f'{req.name.replace("-", ".")}-{dist_version}',
+            ]
+        )
         # Case-insensitive globbing was added to Python 3.12, but we
         # have to run with older versions, too, so do our own name
         # comparison.
         for base in candidate_bases:
-            for ext in ['.tar.gz', '.zip']:
+            for ext in [".tar.gz", ".zip"]:
                 logger.debug('looking for %s sdist as "%s%s"', req.name, base, ext)
-                for filename in downloads_dir.glob('*' + ext):
-                    if str(filename.name).lower()[:-len(ext)] == base.lower():
+                for filename in downloads_dir.glob("*" + ext):
+                    if str(filename.name).lower()[: -len(ext)] == base.lower():
                         return filename
 
     return None
 
 
 def find_wheel(downloads_dir, req, dist_version):
-
     filename_prefix = _dist_name_to_filename(req.name)
     canonical_name = canonicalize_name(req.name)
 
-    candidate_bases = set([
-        # First check if the file is there using the canonically
-        # transformed name.
-        f'{filename_prefix}-{dist_version}-',
-        # If that didn't work, try the canonical dist name. That's not
-        # "correct" but we do see it. (charset-normalizer-3.3.2-
-        # and setuptools-scm-8.0.4-) for example
-        f'{canonical_name}-{dist_version}-',
-        # If *that* didn't work, try the dist name we've been
-        # given as a dependency. That's not "correct", either but we do
-        # see it. (oslo.messaging-14.7.0-) for example
-        f'{req.name}-{dist_version}-',
-        # Sometimes the sdist uses '.' instead of '-' in the
-        # package name portion.
-        f'{req.name.replace("-", ".")}-{dist_version}-',
-    ])
+    candidate_bases = set(
+        [
+            # First check if the file is there using the canonically
+            # transformed name.
+            f"{filename_prefix}-{dist_version}-",
+            # If that didn't work, try the canonical dist name. That's not
+            # "correct" but we do see it. (charset-normalizer-3.3.2-
+            # and setuptools-scm-8.0.4-) for example
+            f"{canonical_name}-{dist_version}-",
+            # If *that* didn't work, try the dist name we've been
+            # given as a dependency. That's not "correct", either but we do
+            # see it. (oslo.messaging-14.7.0-) for example
+            f"{req.name}-{dist_version}-",
+            # Sometimes the sdist uses '.' instead of '-' in the
+            # package name portion.
+            f'{req.name.replace("-", ".")}-{dist_version}-',
+        ]
+    )
     # Case-insensitive globbing was added to Python 3.12, but we
     # have to run with older versions, too, so do our own name
     # comparison.
     for base in candidate_bases:
         logger.debug('looking for %s wheel as "%s"', req.name, base)
-        for filename in downloads_dir.glob('*'):
+        for filename in downloads_dir.glob("*"):
             if str(filename.name).lower().startswith(base.lower()):
                 return filename
 
@@ -95,61 +100,66 @@ def find_wheel(downloads_dir, req, dist_version):
 
 
 def find_source_dir(work_dir, req, dist_version):
-
-    sdir_name_func = overrides.find_override_method(req.name, 'expected_source_directory_name')
+    sdir_name_func = overrides.find_override_method(
+        req.name, "expected_source_directory_name"
+    )
     if sdir_name_func:
         # The directory must exist exactly as given, inside the work_dir.
         source_dir = work_dir / sdir_name_func(req, dist_version)
         if source_dir.exists():
             return source_dir
-        raise ValueError(f'looked for {source_dir} and did not find')
+        raise ValueError(f"looked for {source_dir} and did not find")
 
-    sdist_name_func = overrides.find_override_method(req.name, 'expected_source_archive_name')
+    sdist_name_func = overrides.find_override_method(
+        req.name, "expected_source_archive_name"
+    )
     if sdist_name_func:
         # The directory must exist exactly as given.
         sdist_name = sdist_name_func(req, dist_version)
-        if sdist_name.endswith('.tar.gz'):
-            ext_to_strip = '.tar.gz'
-        elif sdist_name.endswith('.zip'):
-            ext_to_strip = '.zip'
+        if sdist_name.endswith(".tar.gz"):
+            ext_to_strip = ".tar.gz"
+        elif sdist_name.endswith(".zip"):
+            ext_to_strip = ".zip"
         else:
-            raise ValueError(f'Unrecognized extension on {sdist_name}')
-        sdist_base_name = sdist_name[:-len(ext_to_strip)]
+            raise ValueError(f"Unrecognized extension on {sdist_name}")
+        sdist_base_name = sdist_name[: -len(ext_to_strip)]
         source_dir = work_dir / sdist_base_name / sdist_base_name
         if source_dir.exists():
             return source_dir
-        raise ValueError(f'looked for {source_dir} and did not find')
+        raise ValueError(f"looked for {source_dir} and did not find")
 
     filename_prefix = _dist_name_to_filename(req.name)
-    filename_based = f'{filename_prefix}-{dist_version}'
+    filename_based = f"{filename_prefix}-{dist_version}"
     canonical_name = canonicalize_name(req.name)
-    canonical_based = f'{canonical_name}-{dist_version}'
-    name_based = f'{req.name}-{dist_version}'
+    canonical_based = f"{canonical_name}-{dist_version}"
+    name_based = f"{req.name}-{dist_version}"
     dotted_name = f'{req.name.replace("-", ".")}-{dist_version}'
 
-    candidate_bases = set([
-        # First check if the file is there using the canonically
-        # transformed name.
-        filename_based,
-        # If that didn't work, try the canonical dist name. That's not
-        # "correct" but we do see it. (charset-normalizer-3.3.2.tar.gz
-        # and setuptools-scm-8.0.4.tar.gz) for example
-        canonical_based,
-        # If *that* didn't work, try the dist name we've been
-        # given as a dependency. That's not "correct", either but we do
-        # see it. (oslo.messaging-14.7.0.tar.gz) for example
-        name_based,
-        # Sometimes the sdist uses '.' instead of '-' in the
-        # package name portion.
-        dotted_name,
-    ])
+    candidate_bases = set(
+        [
+            # First check if the file is there using the canonically
+            # transformed name.
+            filename_based,
+            # If that didn't work, try the canonical dist name. That's not
+            # "correct" but we do see it. (charset-normalizer-3.3.2.tar.gz
+            # and setuptools-scm-8.0.4.tar.gz) for example
+            canonical_based,
+            # If *that* didn't work, try the dist name we've been
+            # given as a dependency. That's not "correct", either but we do
+            # see it. (oslo.messaging-14.7.0.tar.gz) for example
+            name_based,
+            # Sometimes the sdist uses '.' instead of '-' in the
+            # package name portion.
+            dotted_name,
+        ]
+    )
 
     # Case-insensitive globbing was added to Python 3.12, but we
     # have to run with older versions, too, so do our own name
     # comparison.
     for base in candidate_bases:
-        logger.debug('looking for source directory for %s as %s', req.name, base)
-        for dirname in work_dir.glob('*'):
+        logger.debug("looking for source directory for %s as %s", req.name, base)
+        for dirname in work_dir.glob("*"):
             if str(dirname.name).lower() == base.lower():
                 # We expect the unpack directory and the source
                 # root directory to be the same. We don't know

--- a/src/fromager/overrides.py
+++ b/src/fromager/overrides.py
@@ -10,11 +10,11 @@ from stevedore import extension
 
 
 def _die_on_plugin_load_failure(mgr, ep, err):
-    raise RuntimeError(f'failed to load overrides for {ep.name}') from err
+    raise RuntimeError(f"failed to load overrides for {ep.name}") from err
 
 
 _mgr = extension.ExtensionManager(
-    namespace='fromager.project_overrides',
+    namespace="fromager.project_overrides",
     invoke_on_load=False,
     on_load_failure_callback=_die_on_plugin_load_failure,
 )
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 def log_overrides():
-    logger.debug('loaded overrides for %s', _mgr.entry_points_names())
+    logger.debug("loaded overrides for %s", _mgr.entry_points_names())
 
 
 def patches_for_source_dir(patches_dir, source_dir_name):
@@ -37,7 +37,7 @@ def patches_for_source_dir(patches_dir, source_dir_name):
     the filenames.
 
     """
-    return sorted(patches_dir.glob(source_dir_name + '*.patch'))
+    return sorted(patches_dir.glob(source_dir_name + "*.patch"))
 
 
 def extra_environ_for_pkg(envs_dir, pkgname, variant):
@@ -51,21 +51,22 @@ def extra_environ_for_pkg(envs_dir, pkgname, variant):
 
     pkgname = pkgname_to_override_module(pkgname)
     variant_dir = envs_dir / variant
-    env_file = variant_dir / (pkgname + '.env')
+    env_file = variant_dir / (pkgname + ".env")
 
     if env_file.exists():
-        logger.debug('found %s environment settings for %s in %s',
-                     variant, pkgname, env_file)
-        with open(env_file, 'r') as f:
+        logger.debug(
+            "found %s environment settings for %s in %s", variant, pkgname, env_file
+        )
+        with open(env_file, "r") as f:
             for line in f:
-                key, _, value = line.strip().partition('=')
+                key, _, value = line.strip().partition("=")
                 extra_environ[key.strip()] = value.strip()
     return extra_environ
 
 
 def pkgname_to_override_module(pkgname):
     canonical_name = canonicalize_name(pkgname)
-    module_name = canonical_name.replace('-', '_')
+    module_name = canonical_name.replace("-", "_")
     return module_name
 
 
@@ -80,10 +81,12 @@ def find_override_method(distname, method):
     try:
         mod = _mgr[distname].plugin
     except KeyError:
-        logger.debug('no override module for %s among %s', distname, _mgr.entry_points_names())
+        logger.debug(
+            "no override module for %s among %s", distname, _mgr.entry_points_names()
+        )
         return None
     if not hasattr(mod, method):
-        logger.debug('no %s override for %s', method, distname)
+        logger.debug("no %s override for %s", method, distname)
         return None
-    logger.info('found %s override for %s', method, distname)
+    logger.info("found %s override for %s", method, distname)
     return getattr(mod, method)

--- a/src/fromager/resolver.py
+++ b/src/fromager/resolver.py
@@ -189,7 +189,7 @@ class PyPIProvider(ExtrasProvider):
         return tuple(sorted(requirement_or_candidate.extras))
 
     def get_base_requirement(self, candidate):
-        return Requirement("{}=={}".format(candidate.name, candidate.version))
+        return Requirement(f"{candidate.name}=={candidate.version}")
 
     def get_preference(self, identifier, resolutions, candidates, information, **kwds):
         return sum(1 for _ in candidates[identifier])

--- a/src/fromager/resolver.py
+++ b/src/fromager/resolver.py
@@ -18,8 +18,11 @@ import requests
 from packaging.requirements import Requirement
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.tags import sys_tags
-from packaging.utils import (canonicalize_name, parse_sdist_filename,
-                             parse_wheel_filename)
+from packaging.utils import (
+    canonicalize_name,
+    parse_sdist_filename,
+    parse_wheel_filename,
+)
 from packaging.version import Version
 
 from .extras_provider import ExtrasProvider
@@ -27,7 +30,7 @@ from .extras_provider import ExtrasProvider
 logger = logging.getLogger(__name__)
 
 PYTHON_VERSION = Version(python_version())
-DEBUG_RESOLVER = os.environ.get('DEBUG_RESOLVER', '')
+DEBUG_RESOLVER = os.environ.get("DEBUG_RESOLVER", "")
 SUPPORTED_TAGS = set(sys_tags())
 
 
@@ -79,8 +82,10 @@ class Candidate:
 
 def get_project_from_pypi(project, extras, sdist_server_url):
     """Return candidates created from the project name and extras."""
-    simple_index_url = sdist_server_url.rstrip('/') + '/' + project + '/'
-    logger.debug('get available versions of project %s from %s', project, simple_index_url)
+    simple_index_url = sdist_server_url.rstrip("/") + "/" + project + "/"
+    logger.debug(
+        "get available versions of project %s from %s", project, simple_index_url
+    )
     data = requests.get(simple_index_url).content
     doc = html5lib.parse(data, namespaceHTMLElements=False)
     for i in doc.findall(".//a"):
@@ -98,17 +103,21 @@ def get_project_from_pypi(project, extras, sdist_server_url):
                 # Ignore files with invalid python specifiers
                 # e.g. shellingham has files with ">= '2.7'"
                 if DEBUG_RESOLVER:
-                    logger.debug(f'skipping {filename} because of an invalid python version specifier {py_req}: {err}')
+                    logger.debug(
+                        f"skipping {filename} because of an invalid python version specifier {py_req}: {err}"
+                    )
                 continue
             if PYTHON_VERSION not in spec:
                 if DEBUG_RESOLVER:
-                    logger.debug(f'skipping {filename} because of python version {py_req}')
+                    logger.debug(
+                        f"skipping {filename} because of python version {py_req}"
+                    )
                 continue
 
         # TODO: Handle compatibility tags?
 
         try:
-            if filename.endswith('.tar.gz') or filename.endswith('.zip'):
+            if filename.endswith(".tar.gz") or filename.endswith(".zip"):
                 is_sdist = True
                 name, version = parse_sdist_filename(filename)
                 tags = set()
@@ -121,7 +130,7 @@ def get_project_from_pypi(project, extras, sdist_server_url):
                 matching_tags = SUPPORTED_TAGS.intersection(tags)
                 if not matching_tags:
                     if DEBUG_RESOLVER:
-                        logger.debug(f'ignoring {filename} with tags {tags}')
+                        logger.debug(f"ignoring {filename} with tags {tags}")
                     continue
         except Exception as err:
             # Ignore files with invalid versions
@@ -140,9 +149,11 @@ def get_project_from_pypi(project, extras, sdist_server_url):
                 logger.debug(f'skipping invalid filename "{filename}"')
             continue
 
-        c = Candidate(name, version, url=candidate_url, extras=extras, is_sdist=is_sdist)
+        c = Candidate(
+            name, version, url=candidate_url, extras=extras, is_sdist=is_sdist
+        )
         if DEBUG_RESOLVER:
-            logger.debug('candidate %s (%s) %s', filename, c, candidate_url)
+            logger.debug("candidate %s (%s) %s", filename, c, candidate_url)
         yield c
 
 
@@ -159,8 +170,12 @@ def get_metadata_for_wheel(url):
 
 
 class PyPIProvider(ExtrasProvider):
-    def __init__(self, include_sdists=True, include_wheels=True,
-                 sdist_server_url='https://pypi.org/simple/'):
+    def __init__(
+        self,
+        include_sdists=True,
+        include_wheels=True,
+        sdist_server_url="https://pypi.org/simple/",
+    ):
         super().__init__()
         self.include_sdists = include_sdists
         self.include_wheels = include_wheels
@@ -187,7 +202,9 @@ class PyPIProvider(ExtrasProvider):
         # are added to the candidate at creation - we
         # treat candidates as immutable once created.
         candidates = []
-        for candidate in get_project_from_pypi(identifier, set(), self.sdist_server_url):
+        for candidate in get_project_from_pypi(
+            identifier, set(), self.sdist_server_url
+        ):
             # Skip versions that are known bad
             if candidate.version in bad_versions:
                 continue

--- a/src/fromager/sdist.py
+++ b/src/fromager/sdist.py
@@ -19,7 +19,7 @@ _pip_missing_dependency_pattern = re.compile(
 )
 
 
-class MissingDependency(Exception):
+class MissingDependency(Exception):  # noqa: N818
 
     def __init__(self, req_type, req, all_reqs):
         self.missing_req = req

--- a/src/fromager/sdist.py
+++ b/src/fromager/sdist.py
@@ -7,20 +7,26 @@ import subprocess
 import sys
 from urllib.parse import urlparse
 
-from . import (dependencies, external_commands, finders, overrides, server,
-               sources, wheels)
+from . import (
+    dependencies,
+    external_commands,
+    finders,
+    overrides,
+    server,
+    sources,
+    wheels,
+)
 
 logger = logging.getLogger(__name__)
 
 # Pip has no API, so parse its output looking for what it couldn't
 # install.
 _pip_missing_dependency_pattern = re.compile(
-    r'Could not find a version that satisfies the requirement (\w+)',
+    r"Could not find a version that satisfies the requirement (\w+)",
 )
 
 
 class MissingDependency(Exception):  # noqa: N818
-
     def __init__(self, req_type, req, all_reqs):
         self.missing_req = req
         self.all_reqs = all_reqs
@@ -29,44 +35,51 @@ class MissingDependency(Exception):  # noqa: N818
             try:
                 url, version = sources.resolve_dist(r, sources.PYPI_SERVER_URL)
             except Exception as err:
-                resolutions.append(f'{r} -> {err}')
+                resolutions.append(f"{r} -> {err}")
             else:
-                resolutions.append(f'{r} -> {version}')
-        formatted_reqs = '\n'.join(resolutions)
+                resolutions.append(f"{r} -> {version}")
+        formatted_reqs = "\n".join(resolutions)
         msg = (
-            f'Failed to install {req_type} dependency {req}. '
-            f'Check all {req_type} dependencies:\n{formatted_reqs}'
+            f"Failed to install {req_type} dependency {req}. "
+            f"Check all {req_type} dependencies:\n{formatted_reqs}"
         )
         super().__init__(f'\n{"*" * 40}\n{msg}\n{"*" * 40}\n')
 
 
-def handle_requirement(ctx, req, req_type='toplevel', why=None):
+def handle_requirement(ctx, req, req_type="toplevel", why=None):
     if why is None:
         why = []
-    logger.info(f'{req.name}: {"*" * (len(why) + 1)} handling {req_type} requirement {req} {why}')
+    logger.info(
+        f'{req.name}: {"*" * (len(why) + 1)} handling {req_type} requirement {req} {why}'
+    )
 
-    pre_built = overrides.pkgname_to_override_module(req.name) in ctx.settings.pre_built(ctx.variant)
+    pre_built = overrides.pkgname_to_override_module(
+        req.name
+    ) in ctx.settings.pre_built(ctx.variant)
 
     # Resolve the dependency and get either the pre-built wheel our
     # the source code.
     if not pre_built:
-        source_filename, resolved_version, source_url, source_url_type = sources.download_source(
-            ctx, req, sources.DEFAULT_SDIST_SERVER_URLS)
+        source_filename, resolved_version, source_url, source_url_type = (
+            sources.download_source(ctx, req, sources.DEFAULT_SDIST_SERVER_URLS)
+        )
 
     else:
-        logger.info(f'{req.name}: {req_type} requirement {req} uses a pre-built wheel')
+        logger.info(f"{req.name}: {req_type} requirement {req} uses a pre-built wheel")
         servers = [sources.PYPI_SERVER_URL]
         if ctx.wheel_server_url:
             servers.insert(0, ctx.wheel_server_url)
         wheel_url, resolved_version = _resolve_prebuilt_wheel(req, servers)
         source_url = wheel_url
-        source_url_type = 'prebuilt'
-        wheel_filename = ctx.wheels_prebuilt / os.path.basename(urlparse(wheel_url).path)
+        source_url_type = "prebuilt"
+        wheel_filename = ctx.wheels_prebuilt / os.path.basename(
+            urlparse(wheel_url).path
+        )
         if not wheel_filename.exists():
-            logger.info(f'{req.name}: downloading pre-built wheel {wheel_url}')
+            logger.info(f"{req.name}: downloading pre-built wheel {wheel_url}")
             wheel_filename = sources.download_url(ctx.wheels_prebuilt, wheel_url)
         else:
-            logger.info(f'{req.name}: have pre-built wheel {wheel_filename}')
+            logger.info(f"{req.name}: have pre-built wheel {wheel_filename}")
         # Add the wheel to the mirror so it is available to anything
         # that needs to install it. We leave a copy in the prebuilt
         # directory to make it easy to remove the wheel from the
@@ -74,20 +87,24 @@ def handle_requirement(ctx, req, req_type='toplevel', why=None):
         # index.
         dest_name = ctx.wheels_downloads / wheel_filename.name
         if not dest_name.exists():
-            logger.info(f'{req.name}: updating temporary mirror with pre-built wheel')
+            logger.info(f"{req.name}: updating temporary mirror with pre-built wheel")
             shutil.copy(wheel_filename, dest_name)
             server.update_wheel_mirror(ctx)
-        unpack_dir = ctx.work_dir / f'{req.name}-{resolved_version}'
+        unpack_dir = ctx.work_dir / f"{req.name}-{resolved_version}"
         if not unpack_dir.exists():
             unpack_dir.mkdir()
 
     # Avoid cyclic dependencies and redundant processing.
     if ctx.has_been_seen(req, resolved_version):
-        logger.debug(f'{req.name}: redundant {req_type} requirement {why} -> {req} resolves to {resolved_version}')
+        logger.debug(
+            f"{req.name}: redundant {req_type} requirement {why} -> {req} resolves to {resolved_version}"
+        )
         return resolved_version
     ctx.mark_as_seen(req, resolved_version)
 
-    logger.info(f'{req.name}: new {req_type} dependency {req} resolves to {resolved_version}')
+    logger.info(
+        f"{req.name}: new {req_type} dependency {req} resolves to {resolved_version}"
+    )
 
     # Build the dependency chain up to the point of this new
     # requirement using a new list so we can avoid modifying the list
@@ -99,14 +116,20 @@ def handle_requirement(ctx, req, req_type='toplevel', why=None):
     sdist_root_dir = None
 
     if not pre_built:
-        sdist_root_dir = sources.prepare_source(ctx, req, source_filename, resolved_version)
+        sdist_root_dir = sources.prepare_source(
+            ctx, req, source_filename, resolved_version
+        )
         unpack_dir = sdist_root_dir.parent
 
-        next_req_type = 'build_system'
-        build_system_dependencies = _handle_build_system_requirements(ctx, req, why, sdist_root_dir)
+        next_req_type = "build_system"
+        build_system_dependencies = _handle_build_system_requirements(
+            ctx, req, why, sdist_root_dir
+        )
 
-        next_req_type = 'build_backend'
-        build_backend_dependencies = _handle_build_backend_requirements(ctx, req, why, sdist_root_dir)
+        next_req_type = "build_backend"
+        build_backend_dependencies = _handle_build_backend_requirements(
+            ctx, req, why, sdist_root_dir
+        )
 
     # Add the new package to the build order list before trying to
     # build it so we have a record of the dependency even if the build
@@ -127,11 +150,16 @@ def handle_requirement(ctx, req, req_type='toplevel', why=None):
         # actual name without doing most of the work to build the wheel.
         wheel_filename = finders.find_wheel(ctx.wheels_downloads, req, resolved_version)
         if wheel_filename:
-            logger.info(f'{req.name}: have wheel version {resolved_version}: {wheel_filename}')
+            logger.info(
+                f"{req.name}: have wheel version {resolved_version}: {wheel_filename}"
+            )
         else:
-            logger.info(f'{req.name}: preparing to build wheel for version {resolved_version}')
+            logger.info(
+                f"{req.name}: preparing to build wheel for version {resolved_version}"
+            )
             build_env = wheels.BuildEnvironment(
-                ctx, sdist_root_dir.parent,
+                ctx,
+                sdist_root_dir.parent,
                 build_system_dependencies | build_backend_dependencies,
             )
             built_filename = wheels.build_wheel(ctx, req, sdist_root_dir, build_env)
@@ -139,32 +167,38 @@ def handle_requirement(ctx, req, req_type='toplevel', why=None):
             # When we update the mirror, the built file moves to the
             # downloads directory.
             wheel_filename = ctx.wheels_downloads / built_filename.name
-            logger.info(f'{req.name}: built wheel for version {resolved_version}: {wheel_filename}')
+            logger.info(
+                f"{req.name}: built wheel for version {resolved_version}: {wheel_filename}"
+            )
 
     # Process installation dependencies for all wheels.
-    next_req_type = 'install'
-    install_dependencies = dependencies.get_install_dependencies_of_wheel(req, wheel_filename)
+    next_req_type = "install"
+    install_dependencies = dependencies.get_install_dependencies_of_wheel(
+        req, wheel_filename
+    )
     _write_requirements_file(
         install_dependencies,
-        unpack_dir / 'requirements.txt',
+        unpack_dir / "requirements.txt",
     )
     for dep in install_dependencies:
         try:
             handle_requirement(ctx, dep, next_req_type, why)
         except Exception as err:
-            raise ValueError(f'could not handle {next_req_type} dependency {dep} for {why}') from err
+            raise ValueError(
+                f"could not handle {next_req_type} dependency {dep} for {why}"
+            ) from err
 
     # Cleanup the source tree and build environment, leaving any other
     # artifacts that were created.
     if ctx.cleanup:
         if sdist_root_dir:
-            logger.debug(f'{req.name}: cleaning up source tree {sdist_root_dir}')
+            logger.debug(f"{req.name}: cleaning up source tree {sdist_root_dir}")
             shutil.rmtree(sdist_root_dir)
-            logger.debug(f'{req.name}: cleaned up source tree {sdist_root_dir}')
+            logger.debug(f"{req.name}: cleaned up source tree {sdist_root_dir}")
         if build_env:
-            logger.debug(f'{req.name}: cleaning up build environment {build_env.path}')
+            logger.debug(f"{req.name}: cleaning up build environment {build_env.path}")
             shutil.rmtree(build_env.path)
-            logger.debug('{req.name}: cleaned up build environment {build_env.path}')
+            logger.debug("{req.name}: cleaned up build environment {build_env.path}")
 
     return resolved_version
 
@@ -173,60 +207,72 @@ def _resolve_prebuilt_wheel(req, wheel_server_urls):
     "Return URL to wheel and its version."
     for url in wheel_server_urls:
         try:
-            wheel_url, resolved_version = sources.resolve_dist(req, url,
-                                                               include_sdists=False,
-                                                               include_wheels=True)
+            wheel_url, resolved_version = sources.resolve_dist(
+                req, url, include_sdists=False, include_wheels=True
+            )
         except Exception:
             continue
         if wheel_url and resolved_version:
             return (wheel_url, resolved_version)
-    raise ValueError(f'Could not find a prebuilt wheel for {req} on {" or ".join(wheel_server_urls)}')
+    raise ValueError(
+        f'Could not find a prebuilt wheel for {req} on {" or ".join(wheel_server_urls)}'
+    )
 
 
 def _handle_build_system_requirements(ctx, req, why, sdist_root_dir):
-    build_system_dependencies = dependencies.get_build_system_dependencies(ctx, req, sdist_root_dir)
+    build_system_dependencies = dependencies.get_build_system_dependencies(
+        ctx, req, sdist_root_dir
+    )
     _write_requirements_file(
         build_system_dependencies,
-        sdist_root_dir.parent / 'build-system-requirements.txt',
+        sdist_root_dir.parent / "build-system-requirements.txt",
     )
     for dep in build_system_dependencies:
         try:
-            resolved = handle_requirement(ctx, dep, 'build-system', why)
+            resolved = handle_requirement(ctx, dep, "build-system", why)
         except Exception as err:
-            raise ValueError(f'could not handle build-system dependency {dep} for {why}') from err
+            raise ValueError(
+                f"could not handle build-system dependency {dep} for {why}"
+            ) from err
         # We may need these dependencies installed in order to run build hooks
         # Example: frozenlist build-system.requires includes expandvars because
         # it is used by the packaging/pep517_backend/ build backend
-        _maybe_install(ctx, dep, 'build-system', resolved)
+        _maybe_install(ctx, dep, "build-system", resolved)
     return build_system_dependencies
 
 
 def _handle_build_backend_requirements(ctx, req, why, sdist_root_dir):
-    build_backend_dependencies = dependencies.get_build_backend_dependencies(ctx, req, sdist_root_dir)
+    build_backend_dependencies = dependencies.get_build_backend_dependencies(
+        ctx, req, sdist_root_dir
+    )
     _write_requirements_file(
         build_backend_dependencies,
-        sdist_root_dir.parent / 'build-backend-requirements.txt',
+        sdist_root_dir.parent / "build-backend-requirements.txt",
     )
     for dep in build_backend_dependencies:
         try:
-            resolved = handle_requirement(ctx, dep, 'build-backend', why)
+            resolved = handle_requirement(ctx, dep, "build-backend", why)
         except Exception as err:
-            raise ValueError(f'could not handle build-backend dependency {dep} for {why}') from err
+            raise ValueError(
+                f"could not handle build-backend dependency {dep} for {why}"
+            ) from err
         # Build backends are often used to package themselves, so in
         # order to determine their dependencies they may need to be
         # installed.
-        _maybe_install(ctx, dep, 'build-backend', resolved)
+        _maybe_install(ctx, dep, "build-backend", resolved)
     return build_backend_dependencies
 
 
 def prepare_build_environment(ctx, req, sdist_root_dir):
-    logger.info(f'{req.name}: preparing build environment')
+    logger.info(f"{req.name}: preparing build environment")
 
-    next_req_type = 'build_system'
-    build_system_dependencies = dependencies.get_build_system_dependencies(ctx, req, sdist_root_dir)
+    next_req_type = "build_system"
+    build_system_dependencies = dependencies.get_build_system_dependencies(
+        ctx, req, sdist_root_dir
+    )
     _write_requirements_file(
         build_system_dependencies,
-        sdist_root_dir.parent / 'build-system-requirements.txt',
+        sdist_root_dir.parent / "build-system-requirements.txt",
     )
     for dep in build_system_dependencies:
         # We may need these dependencies installed in order to run build hooks
@@ -235,14 +281,20 @@ def prepare_build_environment(ctx, req, sdist_root_dir):
         try:
             _maybe_install(ctx, dep, next_req_type, None)
         except Exception as err:
-            logger.error(f'{req.name}: failed to install {next_req_type} dependency {dep}: {err}')
-            raise MissingDependency(next_req_type, dep, build_system_dependencies) from err
+            logger.error(
+                f"{req.name}: failed to install {next_req_type} dependency {dep}: {err}"
+            )
+            raise MissingDependency(
+                next_req_type, dep, build_system_dependencies
+            ) from err
 
-    next_req_type = 'build_backend'
-    build_backend_dependencies = dependencies.get_build_backend_dependencies(ctx, req, sdist_root_dir)
+    next_req_type = "build_backend"
+    build_backend_dependencies = dependencies.get_build_backend_dependencies(
+        ctx, req, sdist_root_dir
+    )
     _write_requirements_file(
         build_backend_dependencies,
-        sdist_root_dir.parent / 'build-backend-requirements.txt',
+        sdist_root_dir.parent / "build-backend-requirements.txt",
     )
     for dep in build_backend_dependencies:
         # Build backends are often used to package themselves, so in
@@ -251,23 +303,28 @@ def prepare_build_environment(ctx, req, sdist_root_dir):
         try:
             _maybe_install(ctx, dep, next_req_type, None)
         except Exception as err:
-            logger.error(f'{req.name}: failed to install {next_req_type} dependency {dep}: {err}')
-            raise MissingDependency(next_req_type, dep, build_backend_dependencies) from err
+            logger.error(
+                f"{req.name}: failed to install {next_req_type} dependency {dep}: {err}"
+            )
+            raise MissingDependency(
+                next_req_type, dep, build_backend_dependencies
+            ) from err
 
     try:
         build_env = wheels.BuildEnvironment(
-            ctx, sdist_root_dir.parent,
+            ctx,
+            sdist_root_dir.parent,
             build_system_dependencies | build_backend_dependencies,
         )
     except subprocess.CalledProcessError as err:
         # Pip has no API, so parse its output looking for what it
         # couldn't install. If we don't find something, just re-raise
         # the exception we already have.
-        logger.error(f'{req.name}: failed to create build environment for {dep}: {err}')
+        logger.error(f"{req.name}: failed to create build environment for {dep}: {err}")
         match = _pip_missing_dependency_pattern.search(err.output)
         if match:
             raise MissingDependency(
-                'build',
+                "build",
                 match.groups()[0],
                 build_system_dependencies | build_backend_dependencies,
             ) from err
@@ -276,9 +333,9 @@ def prepare_build_environment(ctx, req, sdist_root_dir):
 
 
 def _write_requirements_file(requirements, filename):
-    with open(filename, 'w') as f:
+    with open(filename, "w") as f:
         for r in requirements:
-            f.write(f'{r}\n')
+            f.write(f"{r}\n")
 
 
 def _maybe_install(ctx, req, req_type, resolved_version):
@@ -287,25 +344,38 @@ def _maybe_install(ctx, req, req_type, resolved_version):
         try:
             actual_version = importlib.metadata.version(req.name)
             if str(resolved_version) == actual_version:
-                logger.debug(f'{req.name}: already have {req.name} version {resolved_version} installed')
+                logger.debug(
+                    f"{req.name}: already have {req.name} version {resolved_version} installed"
+                )
                 return
-            logger.info(f'{req.name}: found {req.name} {actual_version} installed, updating to {resolved_version}')
+            logger.info(
+                f"{req.name}: found {req.name} {actual_version} installed, updating to {resolved_version}"
+            )
         except importlib.metadata.PackageNotFoundError as err:
-            logger.debug(f'{req.name}: could not determine version of {req.name}, will install: {err}')
+            logger.debug(
+                f"{req.name}: could not determine version of {req.name}, will install: {err}"
+            )
     safe_install(ctx, req, req_type)
 
 
 def safe_install(ctx, req, req_type):
-    logger.debug('installing %s %s', req_type, req)
-    external_commands.run([
-        sys.executable, '-m', 'pip',
-        '-vvv',
-        'install',
-        '--disable-pip-version-check',
-        '--upgrade',
-        '--only-binary', ':all:',
-    ] + ctx.pip_wheel_server_args + [
-        f'{req}',
-    ])
+    logger.debug("installing %s %s", req_type, req)
+    external_commands.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "-vvv",
+            "install",
+            "--disable-pip-version-check",
+            "--upgrade",
+            "--only-binary",
+            ":all:",
+        ]
+        + ctx.pip_wheel_server_args
+        + [
+            f"{req}",
+        ]
+    )
     version = importlib.metadata.version(req.name)
-    logger.info('installed %s %s using %s', req_type, req, version)
+    logger.info("installed %s %s using %s", req_type, req, version)

--- a/src/fromager/settings.py
+++ b/src/fromager/settings.py
@@ -9,12 +9,11 @@ logger = logging.getLogger(__name__)
 
 
 class Settings:
-
     def __init__(self, data):
         self._data = data
 
     def pre_built(self, variant):
-        p = self._data.get('pre_built') or {}
+        p = self._data.get("pre_built") or {}
         names = p.get(variant) or []
         return set(overrides.pkgname_to_override_module(n) for n in names)
 
@@ -27,8 +26,8 @@ def _parse(content):
 def load(filename):
     filepath = pathlib.Path(filename)
     if not filepath.exists():
-        logger.debug('settings file %s does not exist, ignoring', filepath.absolute())
+        logger.debug("settings file %s does not exist, ignoring", filepath.absolute())
         return Settings({})
-    with open(filepath, 'r') as f:
-        logger.info('loading settings from %s', filepath.absolute())
+    with open(filepath, "r") as f:
+        logger.info("loading settings from %s", filepath.absolute())
         return _parse(f)

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -71,7 +71,7 @@ def resolve_dist(req, sdist_server_url, include_sdists=True, include_wheels=True
         logger.warning(f'{req.name}: could not resolve {req}: {err}')
         raise
 
-    for name, candidate in result.mapping.items():
+    for candidate in result.mapping.values():
         return (candidate.url, candidate.version)
     return (None, None)
 
@@ -145,7 +145,7 @@ def unpack_source(ctx, source_filename):
             zf.extractall(path=unpack_dir)
     else:
         raise ValueError(f'Do not know how to unpack source archive {source_filename}')
-    return (list(unpack_dir.glob('*'))[0], True)
+    return (next(iter(unpack_dir.glob('*'))), True)
 
 
 def _patch_source(ctx, source_root_dir):

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -16,8 +16,10 @@ from . import overrides, resolver, vendor_rust
 
 logger = logging.getLogger(__name__)
 
-PYPI_SERVER_URL = 'https://pypi.org/simple'
-PYAI_SOURCE_SERVER_URL = 'https://pyai.fedorainfracloud.org/experimental/sources/+simple/'
+PYPI_SERVER_URL = "https://pypi.org/simple"
+PYAI_SOURCE_SERVER_URL = (
+    "https://pyai.fedorainfracloud.org/experimental/sources/+simple/"
+)
 DEFAULT_SDIST_SERVER_URLS = [
     PYPI_SERVER_URL,
     PYAI_SOURCE_SERVER_URL,
@@ -25,33 +27,37 @@ DEFAULT_SDIST_SERVER_URLS = [
 
 
 def download_source(ctx, req, sdist_server_urls):
-    downloader = overrides.find_override_method(req.name, 'download_source')
-    source_type = 'override'
+    downloader = overrides.find_override_method(req.name, "download_source")
+    source_type = "override"
     if not downloader:
         downloader = default_download_source
-        source_type = 'sdist'
+        source_type = "sdist"
     for url in sdist_server_urls:
         try:
-            logger.debug(f'{req.name}: trying to resolve and download {req} using {url}')
+            logger.debug(
+                f"{req.name}: trying to resolve and download {req} using {url}"
+            )
             download_details = downloader(ctx, req, url)
             if len(download_details) == 3:
                 source_filename, version, source_url = download_details
             elif len(download_details) == 2:
                 source_filename, version = download_details
-                source_url = 'override'
+                source_url = "override"
             else:
-                raise ValueError(f'do not know how to unpack {download_details}, expected 2 or 3 members')
+                raise ValueError(
+                    f"do not know how to unpack {download_details}, expected 2 or 3 members"
+                )
         except Exception as err:
-            logger.debug(f'{req.name}: failed to resolve {req} using {url}: {err}')
+            logger.debug(f"{req.name}: failed to resolve {req} using {url}: {err}")
             continue
         return (source_filename, version, source_url, source_type)
-    servers = ', '.join(sdist_server_urls)
-    raise ValueError(f'failed to find source for {req} at {servers}')
+    servers = ", ".join(sdist_server_urls)
+    raise ValueError(f"failed to find source for {req} at {servers}")
 
 
 def resolve_dist(req, sdist_server_url, include_sdists=True, include_wheels=True):
     "Return URL to source and its version."
-    logger.debug(f'{req.name}: resolving requirement {req} using {sdist_server_url}')
+    logger.debug(f"{req.name}: resolving requirement {req} using {sdist_server_url}")
 
     # Create the (reusable) resolver. Limit to sdists.
     provider = resolver.PyPIProvider(
@@ -65,10 +71,12 @@ def resolve_dist(req, sdist_server_url, include_sdists=True, include_wheels=True
     # Kick off the resolution process, and get the final result.
     try:
         result = rslvr.resolve([req])
-    except (resolvelib.InconsistentCandidate,
-            resolvelib.RequirementsConflicted,
-            resolvelib.ResolutionImpossible) as err:
-        logger.warning(f'{req.name}: could not resolve {req}: {err}')
+    except (
+        resolvelib.InconsistentCandidate,
+        resolvelib.RequirementsConflicted,
+        resolvelib.ResolutionImpossible,
+    ) as err:
+        logger.warning(f"{req.name}: could not resolve {req}: {err}")
         raise
 
     for candidate in result.mapping.values():
@@ -78,40 +86,44 @@ def resolve_dist(req, sdist_server_url, include_sdists=True, include_wheels=True
 
 def default_download_source(ctx, req, sdist_server_url):
     "Download the requirement and return the name of the output path."
-    url, version = resolve_dist(req, sdist_server_url, include_sdists=True, include_wheels=False)
+    url, version = resolve_dist(
+        req, sdist_server_url, include_sdists=True, include_wheels=False
+    )
     source_filename = download_url(ctx.sdists_downloads, url)
-    logger.debug(f'{req.name}: have source for {req} version {version} in {source_filename}')
+    logger.debug(
+        f"{req.name}: have source for {req} version {version} in {source_filename}"
+    )
     return (source_filename, version, url)
 
 
 def download_url(destination_dir, url):
     outfile = pathlib.Path(destination_dir) / os.path.basename(urlparse(url).path)
-    logger.debug('looking for %s %s',
-                 outfile,
-                 '(exists)' if outfile.exists() else '(not there)')
+    logger.debug(
+        "looking for %s %s", outfile, "(exists)" if outfile.exists() else "(not there)"
+    )
     if outfile.exists():
-        logger.debug(f'already have {outfile}')
+        logger.debug(f"already have {outfile}")
         return outfile
     # Open the URL first in case that fails, so we don't end up with an empty file.
-    logger.debug(f'reading from {url}')
+    logger.debug(f"reading from {url}")
     with requests.get(url, stream=True) as r:
-        with open(outfile, 'wb') as f:
-            logger.debug(f'writing to {outfile}')
-            for chunk in r.iter_content(chunk_size=1024*1024):
+        with open(outfile, "wb") as f:
+            logger.debug(f"writing to {outfile}")
+            for chunk in r.iter_content(chunk_size=1024 * 1024):
                 f.write(chunk)
-    logger.info(f'saved {outfile}')
+    logger.info(f"saved {outfile}")
     return outfile
 
 
 def _sdist_root_name(source_filename):
     base_name = pathlib.Path(source_filename).name
-    if base_name.endswith('.tar.gz'):
-        ext_to_strip = '.tar.gz'
-    elif base_name.endswith('.zip'):
-        ext_to_strip = '.zip'
+    if base_name.endswith(".tar.gz"):
+        ext_to_strip = ".tar.gz"
+    elif base_name.endswith(".zip"):
+        ext_to_strip = ".zip"
     else:
-        raise ValueError(f'Do not know how to work with {source_filename}')
-    return base_name[:-len(ext_to_strip)]
+        raise ValueError(f"Do not know how to work with {source_filename}")
+    return base_name[: -len(ext_to_strip)]
 
 
 def _takes_arg(f, arg_name):
@@ -123,45 +135,45 @@ def unpack_source(ctx, source_filename):
     unpack_dir = ctx.work_dir / _sdist_root_name(source_filename)
     if unpack_dir.exists():
         if ctx.cleanup:
-            logger.debug('cleaning up %s', unpack_dir)
+            logger.debug("cleaning up %s", unpack_dir)
             shutil.rmtree(unpack_dir)
         else:
-            logger.info('reusing %s', unpack_dir)
+            logger.info("reusing %s", unpack_dir)
             return (unpack_dir / unpack_dir.name, False)
     # We create a unique directory based on the sdist name, but that
     # may not be the same name as the root directory of the content in
     # the sdist (due to case, punctuation, etc.), so after we unpack
     # it look for what was created.
-    logger.debug('unpacking %s to %s', source_filename, unpack_dir)
-    if str(source_filename).endswith('.tar.gz'):
-        with tarfile.open(source_filename, 'r') as t:
-            if _takes_arg(t.extractall, 'filter'):
-                t.extractall(unpack_dir, filter='data')
+    logger.debug("unpacking %s to %s", source_filename, unpack_dir)
+    if str(source_filename).endswith(".tar.gz"):
+        with tarfile.open(source_filename, "r") as t:
+            if _takes_arg(t.extractall, "filter"):
+                t.extractall(unpack_dir, filter="data")
             else:
                 logger.debug('unpacking without filter="data"')
                 t.extractall(unpack_dir)
-    elif str(source_filename).endswith('.zip'):
+    elif str(source_filename).endswith(".zip"):
         with zipfile.ZipFile(source_filename) as zf:
             zf.extractall(path=unpack_dir)
     else:
-        raise ValueError(f'Do not know how to unpack source archive {source_filename}')
-    return (next(iter(unpack_dir.glob('*'))), True)
+        raise ValueError(f"Do not know how to unpack source archive {source_filename}")
+    return (next(iter(unpack_dir.glob("*"))), True)
 
 
 def _patch_source(ctx, source_root_dir):
     for p in overrides.patches_for_source_dir(ctx.patches_dir, source_root_dir.name):
-        logger.info('applying patch file %s to %s', p, source_root_dir)
-        with open(p, 'r') as f:
+        logger.info("applying patch file %s to %s", p, source_root_dir)
+        with open(p, "r") as f:
             subprocess.check_call(
-                ['patch', '-p1'],
+                ["patch", "-p1"],
                 stdin=f,
                 cwd=source_root_dir,
             )
 
 
 def write_build_meta(unpack_dir, req, source_filename, version):
-    meta_file = unpack_dir / 'build-meta.json'
-    with open(meta_file, 'w') as f:
+    meta_file = unpack_dir / "build-meta.json"
+    with open(meta_file, "w") as f:
         json.dump(
             {
                 "req": str(req),
@@ -170,25 +182,25 @@ def write_build_meta(unpack_dir, req, source_filename, version):
             },
             f,
         )
-    logger.debug('wrote build metadata to %s', meta_file)
+    logger.debug("wrote build metadata to %s", meta_file)
     return meta_file
 
 
 def read_build_meta(unpack_dir):
-    meta_file = unpack_dir / 'build-meta.json'
-    with open(meta_file, 'r') as f:
+    meta_file = unpack_dir / "build-meta.json"
+    with open(meta_file, "r") as f:
         return json.load(f)
 
 
 def prepare_source(ctx, req, source_filename, version):
-    logger.info(f'{req.name}: preparing source for {req} from {source_filename}')
-    preparer = overrides.find_override_method(req.name, 'prepare_source')
+    logger.info(f"{req.name}: preparing source for {req} from {source_filename}")
+    preparer = overrides.find_override_method(req.name, "prepare_source")
     if not preparer:
         preparer = _default_prepare_source
     source_root_dir = preparer(ctx, req, source_filename, version)
     write_build_meta(source_root_dir.parent, req, source_filename, version)
     if source_root_dir is not None:
-        logger.info(f'{req.name}: prepared source for {req} at {source_root_dir}')
+        logger.info(f"{req.name}: prepared source for {req} at {source_root_dir}")
     return source_root_dir
 
 

--- a/src/fromager/vendor_rust.py
+++ b/src/fromager/vendor_rust.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
-"""Vendor Rust crates into an sdist
-"""
+"""Vendor Rust crates into an sdist"""
+
 import json
 import logging
 import pathlib
@@ -29,7 +29,7 @@ def _cargo_vendor(
     project_dir: pathlib.Path,
 ) -> typing.Iterable[pathlib.Path]:
     """Run cargo vendor"""
-    logger.info(f'{req.name}: updating vendored rust dependencies in {project_dir}')
+    logger.info(f"{req.name}: updating vendored rust dependencies in {project_dir}")
     args = ["cargo", "vendor", f"--manifest-path={manifests[0]}"]
     for manifest in manifests[1:]:
         args.append(f"--sync={manifest}")
@@ -83,7 +83,9 @@ def _cargo_config(project_dir: pathlib.Path):
         toml.dump(cfg, f)
 
 
-def vendor_rust(req: Requirement, project_dir: pathlib.Path, *, shrink_vendored: bool = True) -> bool:
+def vendor_rust(
+    req: Requirement, project_dir: pathlib.Path, *, shrink_vendored: bool = True
+) -> bool:
     """Vendor Rust crates into a source directory
 
     Returns ``True`` if the project has a ``Cargo.toml``, otherwise
@@ -92,7 +94,7 @@ def vendor_rust(req: Requirement, project_dir: pathlib.Path, *, shrink_vendored:
     # check for Cargo.toml
     manifests = list(project_dir.glob("**/Cargo.toml"))
     if not manifests:
-        logger.debug(f'{req.name}: has no Cargo.toml files')
+        logger.debug(f"{req.name}: has no Cargo.toml files")
         return False
 
     # setuptools-rust and maturin-based projects have a pyproject.toml
@@ -100,11 +102,11 @@ def vendor_rust(req: Requirement, project_dir: pathlib.Path, *, shrink_vendored:
         raise ValueError("pyproject.toml is missing")
 
     the_manifests = sorted(str(d.relative_to(project_dir)) for d in manifests)
-    logger.debug(f'{req.name}: {project_dir} has cargo manifests: {the_manifests}')
+    logger.debug(f"{req.name}: {project_dir} has cargo manifests: {the_manifests}")
 
     # fetch and vendor Rust crates
     vendored = _cargo_vendor(req, manifests, project_dir)
-    logger.debug(f'{req.name}: vendored crates: {sorted(d.name for d in vendored)}')
+    logger.debug(f"{req.name}: vendored crates: {sorted(d.name for d in vendored)}")
 
     # remove unnecessary pre-compiled files for Windows, macOS, and iOS.
     if shrink_vendored:

--- a/src/fromager/vendor_rust.py
+++ b/src/fromager/vendor_rust.py
@@ -25,7 +25,7 @@ CARGO_CONFIG = {
 
 def _cargo_vendor(
     req: Requirement,
-    manifests: typing.List[pathlib.Path],
+    manifests: list[pathlib.Path],
     project_dir: pathlib.Path,
 ) -> typing.Iterable[pathlib.Path]:
     """Run cargo vendor"""
@@ -45,7 +45,7 @@ def _cargo_shrink(crate_dir: pathlib.Path):
     bundle up to 60% smaller. If we ever need these files, then we have to
     figure out how to compile them from sources, too.
     """
-    removed_files: typing.List[str] = []
+    removed_files: list[str] = []
     for pattern in ["**/*.a", "**/*.lib"]:
         for filename in crate_dir.glob(pattern):
             logger.debug("Removing '%s'", filename.relative_to(crate_dir.parent))

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -10,8 +10,10 @@ logger = logging.getLogger(__name__)
 
 
 def build_wheel(ctx, req, sdist_root_dir, build_env):
-    logger.info(f'{req.name}: building wheel for {req} in {sdist_root_dir} writing to {ctx.wheels_build}')
-    builder = overrides.find_override_method(req.name, 'build_wheel')
+    logger.info(
+        f"{req.name}: building wheel for {req} in {sdist_root_dir} writing to {ctx.wheels_build}"
+    )
+    builder = overrides.find_override_method(req.name, "build_wheel")
     if not builder:
         builder = default_build_wheel
     extra_environ = overrides.extra_environ_for_pkg(ctx.envs_dir, req.name, ctx.variant)
@@ -19,14 +21,14 @@ def build_wheel(ctx, req, sdist_root_dir, build_env):
     # Build Rust without network access
     extra_environ["CARGO_NET_OFFLINE"] = "true"
     builder(ctx, build_env, extra_environ, req, sdist_root_dir)
-    wheels = list(ctx.wheels_build.glob('*.whl'))
+    wheels = list(ctx.wheels_build.glob("*.whl"))
     if wheels:
         return wheels[0]
     return None
 
 
 def default_build_wheel(ctx, build_env, extra_environ, req, sdist_root_dir):
-    logger.debug(f'{req.name}: building wheel in {sdist_root_dir} with {extra_environ}')
+    logger.debug(f"{req.name}: building wheel in {sdist_root_dir} with {extra_environ}")
 
     # Activate the virtualenv for the subprocess:
     # 1. Put the build environment at the front of the PATH to ensure
@@ -34,27 +36,34 @@ def default_build_wheel(ctx, build_env, extra_environ, req, sdist_root_dir):
     #    versions. If the caller has already set a path, start there.
     # 2. Set VIRTUAL_ENV so tools looking for that (for example,
     #    maturin) find it.
-    existing_path = extra_environ.get('PATH') or os.environ.get('PATH') or ''
+    existing_path = extra_environ.get("PATH") or os.environ.get("PATH") or ""
     path_parts = [str(build_env.python.parent)]
     if existing_path:
         path_parts.append(existing_path)
-    updated_path = ':'.join(path_parts)
+    updated_path = ":".join(path_parts)
     override_env = {}
     override_env.update(extra_environ)
-    override_env['PATH'] = updated_path
-    override_env['VIRTUAL_ENV'] = str(build_env.path)
+    override_env["PATH"] = updated_path
+    override_env["VIRTUAL_ENV"] = str(build_env.path)
 
     with tempfile.TemporaryDirectory() as dir_name:
         cmd = [
-            build_env.python, '-m', 'pip', '-vvv',
-            '--disable-pip-version-check',
-            'wheel',
-            '--no-build-isolation',
-            '--only-binary', ':all:',
-            '--wheel-dir', ctx.wheels_build,
-            '--no-deps',
-            '--index-url', ctx.wheel_server_url,  # probably redundant, but just in case
-            '--log', sdist_root_dir.parent / 'build.log',
+            build_env.python,
+            "-m",
+            "pip",
+            "-vvv",
+            "--disable-pip-version-check",
+            "wheel",
+            "--no-build-isolation",
+            "--only-binary",
+            ":all:",
+            "--wheel-dir",
+            ctx.wheels_build,
+            "--no-deps",
+            "--index-url",
+            ctx.wheel_server_url,  # probably redundant, but just in case
+            "--log",
+            sdist_root_dir.parent / "build.log",
             sdist_root_dir,
         ]
         external_commands.run(cmd, cwd=dir_name, extra_environ=override_env)
@@ -65,39 +74,46 @@ class BuildEnvironment:
 
     def __init__(self, ctx, parent_dir, build_requirements):
         self._ctx = ctx
-        self.path = parent_dir / f'build-{platform.python_version()}'
+        self.path = parent_dir / f"build-{platform.python_version()}"
         self._build_requirements = build_requirements
         self._createenv()
 
     @property
     def python(self):
-        return (self.path / 'bin/python3').absolute()
+        return (self.path / "bin/python3").absolute()
 
     def _createenv(self):
         if self.path.exists():
-            logger.info('reusing build environment in %s', self.path)
+            logger.info("reusing build environment in %s", self.path)
             return
 
-        logger.debug('creating build environment in %s', self.path)
-        external_commands.run([sys.executable, '-m', 'virtualenv', self.path])
-        logger.info('created build environment in %s', self.path)
+        logger.debug("creating build environment in %s", self.path)
+        external_commands.run([sys.executable, "-m", "virtualenv", self.path])
+        logger.info("created build environment in %s", self.path)
 
-        req_filename = self.path / 'requirements.txt'
+        req_filename = self.path / "requirements.txt"
         # FIXME: Ensure each requirement is pinned to a specific version.
-        with open(req_filename, 'w') as f:
+        with open(req_filename, "w") as f:
             if self._build_requirements:
                 for r in self._build_requirements:
-                    f.write(f'{r}\n')
+                    f.write(f"{r}\n")
         if not self._build_requirements:
             return
         external_commands.run(
-            [self.python, '-m', 'pip',
-             'install',
-             '--disable-pip-version-check',
-             '--only-binary', ':all:',
-             ] + self._ctx.pip_wheel_server_args + [
-                 '-r', req_filename.absolute(),
-             ],
+            [
+                self.python,
+                "-m",
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+                "--only-binary",
+                ":all:",
+            ]
+            + self._ctx.pip_wheel_server_args
+            + [
+                "-r",
+                req_filename.absolute(),
+            ],
             cwd=self.path.parent,
         )
-        logger.info('installed dependencies into build environment in %s', self.path)
+        logger.info("installed dependencies into build environment in %s", self.path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,12 +7,12 @@ from fromager import context, settings
 def tmp_context(tmp_path):
     ctx = context.WorkContext(
         settings=settings.Settings({}),
-        patches_dir='overrides/patches',
-        envs_dir='overrides/envs',
-        sdists_repo=tmp_path / 'sdists-repo',
-        wheels_repo=tmp_path / 'wheels-repo',
-        work_dir=tmp_path / 'work-dir',
-        wheel_server_url='',
+        patches_dir="overrides/patches",
+        envs_dir="overrides/envs",
+        sdists_repo=tmp_path / "sdists-repo",
+        wheels_repo=tmp_path / "wheels-repo",
+        work_dir=tmp_path / "work-dir",
+        wheel_server_url="",
     )
     ctx.setup()
     return ctx

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -4,55 +4,69 @@ from fromager.commands import bootstrap
 
 
 def test_get_requirements_single_arg():
-    requirements = bootstrap._get_requirements_from_args(['a'], [])
-    assert [('toplevel', 'a')] == requirements
+    requirements = bootstrap._get_requirements_from_args(["a"], [])
+    assert [("toplevel", "a")] == requirements
 
 
 def test_get_requirements_multiple_args():
-    requirements = bootstrap._get_requirements_from_args(['a', 'b'], [])
-    assert [('toplevel', 'a'), ('toplevel', 'b')] == requirements
+    requirements = bootstrap._get_requirements_from_args(["a", "b"], [])
+    assert [("toplevel", "a"), ("toplevel", "b")] == requirements
 
 
 def test_get_requirements_requirements_file(tmp_path):
-    requirements_file = tmp_path / 'requirements.txt'
-    requirements_file.write_text('c\n')
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.write_text("c\n")
     requirements = bootstrap._get_requirements_from_args([], [requirements_file])
-    assert [(str(requirements_file), 'c')] == requirements
+    assert [(str(requirements_file), "c")] == requirements
 
 
 def test_get_requirements_requirements_file_comments(tmp_path):
-    requirements_file = tmp_path / 'requirements.txt'
+    requirements_file = tmp_path / "requirements.txt"
     requirements_file.write_text(
-        textwrap.dedent('''
+        textwrap.dedent("""
         c
         d # with comment
         # ignore comment
 
-        '''),
+        """),
     )
     requirements = bootstrap._get_requirements_from_args([], [requirements_file])
-    assert [(str(requirements_file), 'c'), (str(requirements_file), 'd')] == requirements
+    assert [
+        (str(requirements_file), "c"),
+        (str(requirements_file), "d"),
+    ] == requirements
 
 
 def test_get_requirements_requirements_file_multiple(tmp_path):
-    requirements1_file = tmp_path / 'requirements1.txt'
-    requirements1_file.write_text('a\n')
-    requirements2_file = tmp_path / 'requirements2.txt'
-    requirements2_file.write_text('b\n')
-    requirements = bootstrap._get_requirements_from_args([], [requirements1_file, requirements2_file])
-    assert [(str(requirements1_file), 'a'), (str(requirements2_file), 'b')] == requirements
+    requirements1_file = tmp_path / "requirements1.txt"
+    requirements1_file.write_text("a\n")
+    requirements2_file = tmp_path / "requirements2.txt"
+    requirements2_file.write_text("b\n")
+    requirements = bootstrap._get_requirements_from_args(
+        [], [requirements1_file, requirements2_file]
+    )
+    assert [
+        (str(requirements1_file), "a"),
+        (str(requirements2_file), "b"),
+    ] == requirements
 
 
 def test_get_requirements_file_with_comments_and_blanks(tmp_path):
-    requirements_file = tmp_path / 'requirements.txt'
-    requirements_file.write_text('a\n\n# ignore\nb\nc\n')
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.write_text("a\n\n# ignore\nb\nc\n")
     requirements = bootstrap._get_requirements_from_args([], [requirements_file])
     f = str(requirements_file)
-    assert [(f, 'a'), (f, 'b'), (f, 'c')] == requirements
+    assert [(f, "a"), (f, "b"), (f, "c")] == requirements
 
 
 def test_get_requirements_args_and_file(tmp_path):
-    requirements_file = tmp_path / 'requirements.txt'
-    requirements_file.write_text('c\n')
-    requirements = bootstrap._get_requirements_from_args(['a', 'b'], [requirements_file])
-    assert [('toplevel', 'a'), ('toplevel', 'b'), (str(requirements_file), 'c')] == requirements
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.write_text("c\n")
+    requirements = bootstrap._get_requirements_from_args(
+        ["a", "b"], [requirements_file]
+    )
+    assert [
+        ("toplevel", "a"),
+        ("toplevel", "b"),
+        (str(requirements_file), "c"),
+    ] == requirements

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -4,17 +4,17 @@ from packaging.requirements import Requirement
 
 
 def test_seen(tmp_context):
-    req = Requirement('testdist')
-    version = '1.2'
+    req = Requirement("testdist")
+    version = "1.2"
     assert not tmp_context.has_been_seen(req, version)
     tmp_context.mark_as_seen(req, version)
     assert tmp_context.has_been_seen(req, version)
 
 
 def test_seen_extras(tmp_context):
-    req1 = Requirement('testdist')
-    req2 = Requirement('testdist[extra]')
-    version = '1.2'
+    req1 = Requirement("testdist")
+    req2 = Requirement("testdist[extra]")
+    version = "1.2"
     assert not tmp_context.has_been_seen(req1, version)
     tmp_context.mark_as_seen(req1, version)
     assert tmp_context.has_been_seen(req1, version)
@@ -25,8 +25,8 @@ def test_seen_extras(tmp_context):
 
 
 def test_seen_name_canonicalization(tmp_context):
-    req = Requirement('flit_core')
-    version = '1.2'
+    req = Requirement("flit_core")
+    version = "1.2"
     assert not tmp_context.has_been_seen(req, version)
     tmp_context.mark_as_seen(req, version)
     assert tmp_context.has_been_seen(req, version)
@@ -34,31 +34,38 @@ def test_seen_name_canonicalization(tmp_context):
 
 def test_build_order(tmp_context):
     tmp_context.add_to_build_order(
-        'build_backend', Requirement('buildme>1.0'), '6.0', ' -> buildme', 'url', 'sdist')
+        "build_backend",
+        Requirement("buildme>1.0"),
+        "6.0",
+        " -> buildme",
+        "url",
+        "sdist",
+    )
     tmp_context.add_to_build_order(
-        'dependency', Requirement('testdist>1.0'), '1.2', ' -> testdist', 'url', 'sdist')
+        "dependency", Requirement("testdist>1.0"), "1.2", " -> testdist", "url", "sdist"
+    )
     contents_str = tmp_context._build_order_filename.read_text()
     contents = json.loads(contents_str)
     expected = [
         {
-            'type': 'build_backend',
-            'req': 'buildme>1.0',
-            'dist': 'buildme',
-            'version': '6.0',
-            'why': ' -> buildme',
-            'prebuilt': False,
-            'source_url': 'url',
-            'source_url_type': 'sdist',
+            "type": "build_backend",
+            "req": "buildme>1.0",
+            "dist": "buildme",
+            "version": "6.0",
+            "why": " -> buildme",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
         },
         {
-            'type': 'dependency',
-            'req': 'testdist>1.0',
-            'dist': 'testdist',
-            'version': '1.2',
-            'why': ' -> testdist',
-            'prebuilt': False,
-            'source_url': 'url',
-            'source_url_type': 'sdist',
+            "type": "dependency",
+            "req": "testdist>1.0",
+            "dist": "testdist",
+            "version": "1.2",
+            "why": " -> testdist",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
         },
     ]
     assert expected == contents
@@ -66,26 +73,41 @@ def test_build_order(tmp_context):
 
 def test_build_order_repeats(tmp_context):
     tmp_context.add_to_build_order(
-        'build_backend', Requirement('buildme>1.0'), '6.0', ' -> buildme',
-        'url', 'sdist')
+        "build_backend",
+        Requirement("buildme>1.0"),
+        "6.0",
+        " -> buildme",
+        "url",
+        "sdist",
+    )
     tmp_context.add_to_build_order(
-        'build_backend', Requirement('buildme>1.0'), '6.0', ' -> buildme',
-        'url', 'sdist')
+        "build_backend",
+        Requirement("buildme>1.0"),
+        "6.0",
+        " -> buildme",
+        "url",
+        "sdist",
+    )
     tmp_context.add_to_build_order(
-        'build_backend', Requirement('buildme[extra]>1.0'), '6.0', ' -> buildme[extra]',
-        'url', 'sdist')
+        "build_backend",
+        Requirement("buildme[extra]>1.0"),
+        "6.0",
+        " -> buildme[extra]",
+        "url",
+        "sdist",
+    )
     contents_str = tmp_context._build_order_filename.read_text()
     contents = json.loads(contents_str)
     expected = [
         {
-            'type': 'build_backend',
-            'req': 'buildme>1.0',
-            'dist': 'buildme',
-            'version': '6.0',
-            'why': ' -> buildme',
-            'prebuilt': False,
-            'source_url': 'url',
-            'source_url_type': 'sdist',
+            "type": "build_backend",
+            "req": "buildme>1.0",
+            "dist": "buildme",
+            "version": "6.0",
+            "why": " -> buildme",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
         },
     ]
     assert expected == contents
@@ -93,23 +115,33 @@ def test_build_order_repeats(tmp_context):
 
 def test_build_order_name_canonicalization(tmp_context):
     tmp_context.add_to_build_order(
-        'build_backend', Requirement('flit-core>1.0'), '3.9.0', ' -> buildme',
-        'url', 'sdist')
+        "build_backend",
+        Requirement("flit-core>1.0"),
+        "3.9.0",
+        " -> buildme",
+        "url",
+        "sdist",
+    )
     tmp_context.add_to_build_order(
-        'build_backend', Requirement('flit_core>1.0'), '3.9.0', ' -> buildme',
-        'url', 'sdist')
+        "build_backend",
+        Requirement("flit_core>1.0"),
+        "3.9.0",
+        " -> buildme",
+        "url",
+        "sdist",
+    )
     contents_str = tmp_context._build_order_filename.read_text()
     contents = json.loads(contents_str)
     expected = [
         {
-            'type': 'build_backend',
-            'req': 'flit-core>1.0',
-            'dist': 'flit-core',
-            'version': '3.9.0',
-            'why': ' -> buildme',
-            'prebuilt': False,
-            'source_url': 'url',
-            'source_url_type': 'sdist',
+            "type": "build_backend",
+            "req": "flit-core>1.0",
+            "dist": "flit-core",
+            "version": "3.9.0",
+            "why": " -> buildme",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
         },
     ]
     assert expected == contents

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -3,29 +3,36 @@ import pytest
 from fromager import dependencies
 
 
-@pytest.mark.parametrize('build_system,expected_results', [
-    # Empty
-    ({}, dependencies._DEFAULT_BACKEND),
-    # Only specify requirements (pyarrow)
-    ({'requires': ['a-dep']},
-     {
-         'build-backend': 'setuptools.build_meta:__legacy__',
-         'backend-path': None,
-         'requires': ['a-dep'],
-     }),
-    # Specify everything
-    ({
-        'build-backend': 'setuptools.build_meta:__legacy__',
-        'backend-path': None,
-        'requires': ['a-dep'],
-    },
-     {
-         'build-backend': 'setuptools.build_meta:__legacy__',
-         'backend-path': None,
-         'requires': ['a-dep'],
-     }),
-])
+@pytest.mark.parametrize(
+    "build_system,expected_results",
+    [
+        # Empty
+        ({}, dependencies._DEFAULT_BACKEND),
+        # Only specify requirements (pyarrow)
+        (
+            {"requires": ["a-dep"]},
+            {
+                "build-backend": "setuptools.build_meta:__legacy__",
+                "backend-path": None,
+                "requires": ["a-dep"],
+            },
+        ),
+        # Specify everything
+        (
+            {
+                "build-backend": "setuptools.build_meta:__legacy__",
+                "backend-path": None,
+                "requires": ["a-dep"],
+            },
+            {
+                "build-backend": "setuptools.build_meta:__legacy__",
+                "backend-path": None,
+                "requires": ["a-dep"],
+            },
+        ),
+    ],
+)
 def test_get_build_backend(build_system, expected_results):
-    pyproject_toml = {'build-system': build_system}
+    pyproject_toml = {"build-system": build_system}
     actual = dependencies.get_build_backend(pyproject_toml)
     assert expected_results == actual

--- a/tests/test_external_commands.py
+++ b/tests/test_external_commands.py
@@ -10,7 +10,7 @@ def test_external_commands_environ():
 
 
 def test_external_commands_log_file(tmp_path):
-    log_filename = pathlib.Path(tmp_path) / 'test.log'
+    log_filename = pathlib.Path(tmp_path) / "test.log"
     env = {"BLAH": "test"}
     output = external_commands.run(
         ["sh", "-c", "echo $BLAH"],

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -7,19 +7,22 @@ from packaging.version import Version
 from fromager import finders
 
 
-@pytest.mark.parametrize('dist_name,version_string,expected_base', [
-    ('mypkg', '1.2', 'mypkg-1.2.tar.gz'),
-    ('oslo.messaging', '14.7.0', 'oslo.messaging-14.7.0.tar.gz'),
-    ('cython', '3.0.10', 'Cython-3.0.10.tar.gz'),
-    ('fromage_test', '9.9.9', 'fromage-test-9.9.9.tar.gz'),
-    ('ruamel-yaml', '0.18.6', 'ruamel.yaml-0.18.6.tar.gz'),
-])
+@pytest.mark.parametrize(
+    "dist_name,version_string,expected_base",
+    [
+        ("mypkg", "1.2", "mypkg-1.2.tar.gz"),
+        ("oslo.messaging", "14.7.0", "oslo.messaging-14.7.0.tar.gz"),
+        ("cython", "3.0.10", "Cython-3.0.10.tar.gz"),
+        ("fromage_test", "9.9.9", "fromage-test-9.9.9.tar.gz"),
+        ("ruamel-yaml", "0.18.6", "ruamel.yaml-0.18.6.tar.gz"),
+    ],
+)
 def test_find_sdist(tmp_path, dist_name, version_string, expected_base):
     sdists_repo = pathlib.Path(tmp_path)
-    downloads = sdists_repo / 'downloads'
+    downloads = sdists_repo / "downloads"
     downloads.mkdir()
     archive = downloads / expected_base
-    archive.write_text('not-empty')
+    archive.write_text("not-empty")
 
     req = Requirement(dist_name)
     ver = Version(version_string)
@@ -27,19 +30,22 @@ def test_find_sdist(tmp_path, dist_name, version_string, expected_base):
     assert str(archive) == str(actual)
 
 
-@pytest.mark.parametrize('dist_name,version_string,expected_base', [
-    ('mypkg', '1.2', 'mypkg-1.2-py2.py3-none-any.whl'),
-    ('oslo.messaging', '14.7.0', 'oslo.messaging-14.7.0-py2.py3-none-any.whl'),
-    ('cython', '3.0.10', 'Cython-3.0.10-cp311-cp311-linux_aarch64.whl'),
-    ('fromage_test', '9.9.9', 'fromage-test-9.9.9-cp311-cp311-linux_aarch64.whl'),
-    ('ruamel-yaml', '0.18.6', 'ruamel.yaml-0.18.6-py3-none-any.whl'),
-])
+@pytest.mark.parametrize(
+    "dist_name,version_string,expected_base",
+    [
+        ("mypkg", "1.2", "mypkg-1.2-py2.py3-none-any.whl"),
+        ("oslo.messaging", "14.7.0", "oslo.messaging-14.7.0-py2.py3-none-any.whl"),
+        ("cython", "3.0.10", "Cython-3.0.10-cp311-cp311-linux_aarch64.whl"),
+        ("fromage_test", "9.9.9", "fromage-test-9.9.9-cp311-cp311-linux_aarch64.whl"),
+        ("ruamel-yaml", "0.18.6", "ruamel.yaml-0.18.6-py3-none-any.whl"),
+    ],
+)
 def test_find_wheel(tmp_path, dist_name, version_string, expected_base):
     wheels_repo = pathlib.Path(tmp_path)
-    downloads = wheels_repo / 'downloads'
+    downloads = wheels_repo / "downloads"
     downloads.mkdir()
     wheel = downloads / expected_base
-    wheel.write_text('not-empty')
+    wheel.write_text("not-empty")
 
     req = Requirement(dist_name)
     ver = Version(version_string)
@@ -47,21 +53,28 @@ def test_find_wheel(tmp_path, dist_name, version_string, expected_base):
     assert str(wheel) == str(actual)
 
 
-@pytest.mark.parametrize('dist_name,version_string,unpack_base,source_base', [
-    ('mypkg', '1.2', 'mypkg-1.2', 'mypkg-1.2'),
-    ('oslo.messaging', '14.7.0', 'oslo.messaging-14.7.0', 'oslo.messaging-14.7.0'),
-    ('cython', '3.0.10', 'Cython-3.0.10', 'Cython-3.0.10'),
-    ('fromager_test', '9.9.9', 'fromager-test-9.9.9',
-     'different-prefix-fromager-test-9.9.9'),
-    ('ruamel-yaml', '0.18.6', 'ruamel.yaml-0.18.6', 'ruamel.yaml-0.18.6'),
-])
+@pytest.mark.parametrize(
+    "dist_name,version_string,unpack_base,source_base",
+    [
+        ("mypkg", "1.2", "mypkg-1.2", "mypkg-1.2"),
+        ("oslo.messaging", "14.7.0", "oslo.messaging-14.7.0", "oslo.messaging-14.7.0"),
+        ("cython", "3.0.10", "Cython-3.0.10", "Cython-3.0.10"),
+        (
+            "fromager_test",
+            "9.9.9",
+            "fromager-test-9.9.9",
+            "different-prefix-fromager-test-9.9.9",
+        ),
+        ("ruamel-yaml", "0.18.6", "ruamel.yaml-0.18.6", "ruamel.yaml-0.18.6"),
+    ],
+)
 def test_find_source_dir(tmp_path, dist_name, version_string, unpack_base, source_base):
     work_dir = pathlib.Path(tmp_path)
     unpack_dir = work_dir / unpack_base
     unpack_dir.mkdir()
     source_dir = unpack_dir / source_base
     source_dir.mkdir()
-    print(f'created {source_dir}')
+    print(f"created {source_dir}")
 
     req = Requirement(dist_name)
     ver = Version(version_string)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -4,7 +4,7 @@ from packaging.requirements import Requirement
 
 from fromager import resolver
 
-_hydra_core_simple_response = '''
+_hydra_core_simple_response = """
 <!DOCTYPE html>
 <html>
 <head>
@@ -20,40 +20,48 @@ _hydra_core_simple_response = '''
 </body>
 </html>
 <!--SERIAL 22812307-->
-'''
+"""
 
 
 def test_provider_choose_wheel():
     with requests_mock.Mocker() as r:
-        r.get('https://pypi.org/simple/hydra-core/',
-              text=_hydra_core_simple_response,
-              )
+        r.get(
+            "https://pypi.org/simple/hydra-core/",
+            text=_hydra_core_simple_response,
+        )
 
         provider = resolver.PyPIProvider(include_sdists=False)
         reporter = resolvelib.BaseReporter()
         rslvr = resolvelib.Resolver(provider, reporter)
 
-        result = rslvr.resolve([Requirement('hydra-core')])
-        assert 'hydra-core' in result.mapping
+        result = rslvr.resolve([Requirement("hydra-core")])
+        assert "hydra-core" in result.mapping
 
-        candidate = result.mapping['hydra-core']
-        assert candidate.url == 'https://files.pythonhosted.org/packages/c6/50/e0edd38dcd63fb26a8547f13d28f7a008bc4a3fd4eb4ff030673f22ad41a/hydra_core-1.3.2-py3-none-any.whl#sha256=fa0238a9e31df3373b35b0bfb672c34cc92718d21f81311d8996a16de1141d8b'
-        assert str(candidate.version) == '1.3.2'
+        candidate = result.mapping["hydra-core"]
+        assert (
+            candidate.url
+            == "https://files.pythonhosted.org/packages/c6/50/e0edd38dcd63fb26a8547f13d28f7a008bc4a3fd4eb4ff030673f22ad41a/hydra_core-1.3.2-py3-none-any.whl#sha256=fa0238a9e31df3373b35b0bfb672c34cc92718d21f81311d8996a16de1141d8b"
+        )
+        assert str(candidate.version) == "1.3.2"
 
 
 def test_provider_choose_sdist():
     with requests_mock.Mocker() as r:
-        r.get('https://pypi.org/simple/hydra-core/',
-              text=_hydra_core_simple_response,
-              )
+        r.get(
+            "https://pypi.org/simple/hydra-core/",
+            text=_hydra_core_simple_response,
+        )
 
         provider = resolver.PyPIProvider(include_wheels=False)
         reporter = resolvelib.BaseReporter()
         rslvr = resolvelib.Resolver(provider, reporter)
 
-        result = rslvr.resolve([Requirement('hydra-core')])
-        assert 'hydra-core' in result.mapping
+        result = rslvr.resolve([Requirement("hydra-core")])
+        assert "hydra-core" in result.mapping
 
-        candidate = result.mapping['hydra-core']
-        assert candidate.url == 'https://files.pythonhosted.org/packages/6d/8e/07e42bc434a847154083b315779b0a81d567154504624e181caf2c71cd98/hydra-core-1.3.2.tar.gz#sha256=8a878ed67216997c3e9d88a8e72e7b4767e81af37afb4ea3334b269a4390a824'
-        assert str(candidate.version) == '1.3.2'
+        candidate = result.mapping["hydra-core"]
+        assert (
+            candidate.url
+            == "https://files.pythonhosted.org/packages/6d/8e/07e42bc434a847154083b315779b0a81d567154504624e181caf2c71cd98/hydra-core-1.3.2.tar.gz#sha256=8a878ed67216997c3e9d88a8e72e7b4767e81af37afb4ea3334b269a4390a824"
+        )
+        assert str(candidate.version) == "1.3.2"

--- a/tests/test_sdist.py
+++ b/tests/test_sdist.py
@@ -6,24 +6,24 @@ from packaging.version import Version
 from fromager import sdist
 
 
-@patch('fromager.sources.resolve_dist')
+@patch("fromager.sources.resolve_dist")
 def test_missing_dependency_format(resolve_dist):
     resolutions = {
-        'flit_core': '3.9.0',
-        'setuptools': '69.5.1',
+        "flit_core": "3.9.0",
+        "setuptools": "69.5.1",
     }
-    resolve_dist.side_effect = lambda req, url: ('', Version(resolutions[req.name]))
+    resolve_dist.side_effect = lambda req, url: ("", Version(resolutions[req.name]))
 
-    req = Requirement('setuptools>=40.8.0')
+    req = Requirement("setuptools>=40.8.0")
     other_reqs = [
-        Requirement('flit_core'),
+        Requirement("flit_core"),
         req,
     ]
-    ex = sdist.MissingDependency('test', req, other_reqs)
+    ex = sdist.MissingDependency("test", req, other_reqs)
     s = str(ex)
     # Ensure we report the thing we're actually missing
-    assert 'Failed to install test dependency setuptools>=40.8.0. ' in s
+    assert "Failed to install test dependency setuptools>=40.8.0. " in s
     # Ensure we report what version we expected of that thing
-    assert 'setuptools>=40.8.0 -> 69.5.1' in s
+    assert "setuptools>=40.8.0 -> 69.5.1" in s
     # Ensure we report what version we expect of all of the other dependencies
-    assert 'flit_core -> 3.9.0' in s
+    assert "flit_core -> 3.9.0" in s

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -5,21 +5,25 @@ from fromager import settings
 
 def test_empty():
     s = settings.Settings({})
-    assert s.pre_built('cuda') == set()
+    assert s.pre_built("cuda") == set()
 
 
 def test_no_pre_built():
-    s = settings._parse(textwrap.dedent('''
+    s = settings._parse(
+        textwrap.dedent("""
     pre_built:
-    '''))
-    assert s.pre_built('cuda') == set()
+    """)
+    )
+    assert s.pre_built("cuda") == set()
 
 
 def test_with_pre_built():
-    s = settings._parse(textwrap.dedent('''
+    s = settings._parse(
+        textwrap.dedent("""
     pre_built:
       cuda:
         - a
         - b
-    '''))
-    assert s.pre_built('cuda') == set(['a', 'b'])
+    """)
+    )
+    assert s.pre_built("cuda") == set(["a", "b"])

--- a/tox.ini
+++ b/tox.ini
@@ -16,13 +16,22 @@ commands =
 [testenv:linter]
 base_python=python3.11
 deps=
-    flake8==7.0.0
-    flake8-debug==0.2.0
-    isort>=5.0.1
+    ruff
 commands =
-    flake8 src tests
-    isort --check --diff fromager tests
+    ruff check src tests
+    ruff format --check src tests
 skip_install = true
+skip_sdist = true
+
+[testenv:fix]
+base_python=python3.11
+deps=
+    ruff
+commands =
+    ruff format src tests
+    ruff check --fix src tests
+skip_install = true
+skip_sdist = true
 
 [testenv:cli]
 base_python=python3.11
@@ -43,6 +52,3 @@ commands=
     twine check dist/*.tar.gz dist/*.whl
     check-python-versions --only pyproject.toml,.github/workflows/test.yml
     python ./e2e/mergify_lint.py
-
-[flake8]
-extend-ignore = E501,E129,DB100


### PR DESCRIPTION
Replace flake8 and isort with Ruff linter. The `linter` tox environment
now checks code style and formatting with Ruff. `tox -e fix` can be used
to automatically fix format and most style violations.

Configure Ruff to lint code and auto-fix violations. Besides flake8 and
isort, additional rules from pycodestyle, pep8-naming, pyupgrade, and
Ruff are enabled.

Introduce Ruff as a code formatter with black-compatible configuration.