### PR TITLE
feature: let overrides do version resolution

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -155,10 +155,10 @@ https://pypi.org.
 For examples, refer to `fromager.resolver.PyPIProvider` and
 `fromager.resolver.GitHubTagProvider`.
 
-The arguments are the `Requirement` being evaluated, a boolean
-indicating whether source distributions should be included, a boolean
-indicating whether built wheels should be included, and the URL for
-the sdist server.
+The arguments are the `WorkContext`, the `Requirement` being
+evaluated, a boolean indicating whether source distributions should be
+included, a boolean indicating whether built wheels should be
+included, and the URL for the sdist server.
 
 The return value must be an instance of a class that implements the
 `resolvelib.providers.AbstractProvider` API.
@@ -173,7 +173,7 @@ name in case that is different from the version number encoded within
 that tag name.
 
 ```
-def get_resolver_provider(include_sdists, include_wheels, sdist_server_url):
+def get_resolver_provider(ctx, req, include_sdists, include_wheels, sdist_server_url):
     ...
 ```
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -172,7 +172,7 @@ download. For example, the `GitHubTagProvider` returns the actual tag
 name in case that is different from the version number encoded within
 that tag name.
 
-```
+```python
 def get_resolver_provider(ctx, req, include_sdists, include_wheels, sdist_server_url):
     ...
 ```

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -143,6 +143,40 @@ def download_source(ctx, req, sdist_server_url):
     return source_filename, version
 ```
 
+### get_resolver_provider
+
+The `get_resolver_provider()` function allows an override to change
+the way requirement specifications are converted to fixed
+versions. The default implementation looks for published versions on a
+Python package index. Most overrides do not need to implement this
+hook unless they are building versions of packages not released to
+https://pypi.org.
+
+For examples, refer to `fromager.resolver.PyPIProvider` and
+`fromager.resolver.GitHubTagProvider`.
+
+The arguments are the `Requirement` being evaluated, a boolean
+indicating whether source distributions should be included, a boolean
+indicating whether built wheels should be included, and the URL for
+the sdist server.
+
+The return value must be an instance of a class that implements the
+`resolvelib.providers.AbstractProvider` API.
+
+The expectation is that a `download_source()` override will call
+`sources.resolve_dist()`, which will call `get_resolver_provider()`,
+and then the return value of the resolution will be passed back to
+`download_source()` as a tuple of URL and version. The provider can
+therefore use any value as the "URL" that will help it decide what to
+download. For example, the `GitHubTagProvider` returns the actual tag
+name in case that is different from the version number encoded within
+that tag name.
+
+```
+def get_resolver_provider(include_sdists, include_wheels, sdist_server_url):
+    ...
+```
+
 ### prepare_source
 
 The `prepare_source()` function is responsible for setting up a tree

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "stevedore",
     "toml",
     "virtualenv",
+    "PyGithub",
 ]
 
 [project.optional-dependencies]

--- a/src/fromager/example_override.py
+++ b/src/fromager/example_override.py
@@ -8,7 +8,7 @@ def get_resolver_provider(
     include_sdists: bool,
     include_wheels: bool,
     sdist_server_url: str,
-):
+) -> resolver.GitHubTagProvider:
     return resolver.GitHubTagProvider(
         organization="python-wheel-build",
         repo="fromager",

--- a/src/fromager/example_override.py
+++ b/src/fromager/example_override.py
@@ -1,5 +1,19 @@
 from packaging.requirements import Requirement
 
+from fromager import resolver
+
+
+def get_resolver_provider(
+    req: Requirement,
+    include_sdists: bool,
+    include_wheels: bool,
+    sdist_server_url: str,
+):
+    return resolver.GitHubTagProvider(
+        organization="python-wheel-build",
+        repo="fromager",
+    )
+
 
 def expected_source_archive_name(req: Requirement, dist_version: str) -> str:
     return f"fromager-test-{dist_version}.tar.gz"

--- a/src/fromager/resolver.py
+++ b/src/fromager/resolver.py
@@ -249,22 +249,24 @@ class PyPIProvider(ExtrasProvider):
 class GitHubTagProvider(ExtrasProvider):
     def __init__(
         self,
-        organization,
-        repo,
+        organization: str,
+        repo: str,
     ):
         super().__init__()
         self.organization = organization
         self.repo = repo
         self.client = github.Github()
 
-    def identify(self, requirement_or_candidate):
+    def identify(self, requirement_or_candidate: Requirement | Candidate) -> str:
         return canonicalize_name(requirement_or_candidate.name)
 
-    def get_extras_for(self, requirement_or_candidate):
+    def get_extras_for(
+        self, requirement_or_candidate: Requirement | Candidate
+    ) -> tuple[str]:
         # Extras is a set, which is not hashable
         return tuple(sorted(requirement_or_candidate.extras))
 
-    def get_base_requirement(self, candidate):
+    def get_base_requirement(self, candidate: Candidate) -> Requirement:
         return Requirement(f"{candidate.name}=={candidate.version}")
 
     def get_preference(self, identifier, resolutions, candidates, information, **kwds):
@@ -297,11 +299,11 @@ class GitHubTagProvider(ExtrasProvider):
             candidates.append(Candidate(identifier, version, url=tag.name))
         return sorted(candidates, key=attrgetter("version"), reverse=True)
 
-    def is_satisfied_by(self, requirement, candidate):
+    def is_satisfied_by(self, requirement: Requirement, candidate: Candidate) -> bool:
         if canonicalize_name(requirement.name) != candidate.name:
             return False
         return candidate.version in requirement.specifier
 
-    def get_dependencies(self, candidate):
+    def get_dependencies(self, candidate: Candidate) -> list[Requirement]:
         # return candidate.dependencies
         return []

--- a/src/fromager/resolver.py
+++ b/src/fromager/resolver.py
@@ -14,6 +14,7 @@ from platform import python_version
 from urllib.parse import urljoin, urlparse
 from zipfile import ZipFile
 
+import github
 import html5lib
 import requests
 from packaging.requirements import Requirement
@@ -241,5 +242,66 @@ class PyPIProvider(ExtrasProvider):
         return candidate.version in requirement.specifier
 
     def get_dependencies(self, candidate: Candidate) -> list:
+        # return candidate.dependencies
+        return []
+
+
+class GitHubTagProvider(ExtrasProvider):
+    def __init__(
+        self,
+        organization,
+        repo,
+    ):
+        super().__init__()
+        self.organization = organization
+        self.repo = repo
+        self.client = github.Github()
+
+    def identify(self, requirement_or_candidate):
+        return canonicalize_name(requirement_or_candidate.name)
+
+    def get_extras_for(self, requirement_or_candidate):
+        # Extras is a set, which is not hashable
+        return tuple(sorted(requirement_or_candidate.extras))
+
+    def get_base_requirement(self, candidate):
+        return Requirement(f"{candidate.name}=={candidate.version}")
+
+    def get_preference(self, identifier, resolutions, candidates, information, **kwds):
+        return sum(1 for _ in candidates[identifier])
+
+    def find_matches(self, identifier, requirements, incompatibilities):
+        repo = self.client.get_repo(f"{self.organization}/{self.repo}")
+
+        requirements = list(requirements[identifier])
+        bad_versions = {c.version for c in incompatibilities[identifier]}
+
+        # Need to pass the extras to the search, so they
+        # are added to the candidate at creation - we
+        # treat candidates as immutable once created.
+        candidates = []
+        for tag in repo.get_tags():
+            try:
+                version = Version(tag.name)
+            except Exception as err:
+                logger.debug(
+                    f"could not parse version from git tag {tag.name} on {repo.full_name}: {err}"
+                )
+                continue
+            # Skip versions that are known bad
+            if version in bad_versions:
+                continue
+            # Skip versions that do not match the requirement
+            if not all(version in r.specifier for r in requirements):
+                continue
+            candidates.append(Candidate(identifier, version, url=tag.name))
+        return sorted(candidates, key=attrgetter("version"), reverse=True)
+
+    def is_satisfied_by(self, requirement, candidate):
+        if canonicalize_name(requirement.name) != candidate.name:
+            return False
+        return candidate.version in requirement.specifier
+
+    def get_dependencies(self, candidate):
         # return candidate.dependencies
         return []

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -63,6 +63,7 @@ def download_source(
 
 
 def resolve_dist(
+    ctx: context.WorkContext,
     req: Requirement,
     sdist_server_url: str,
     include_sdists: bool = True,
@@ -76,6 +77,7 @@ def resolve_dist(
     if not provider_factory:
         provider_factory = default_resolver_provider
     provider = provider_factory(
+        ctx=ctx,
         req=req,
         include_sdists=include_sdists,
         include_wheels=include_wheels,
@@ -101,6 +103,7 @@ def resolve_dist(
 
 
 def default_resolver_provider(
+    ctx: context.WorkContext,
     req: Requirement,
     sdist_server_url: str,
     include_sdists: bool,
@@ -120,7 +123,7 @@ def default_download_source(
 ) -> tuple[pathlib.Path, str, str]:
     "Download the requirement and return the name of the output path."
     url, version = resolve_dist(
-        req, sdist_server_url, include_sdists=True, include_wheels=False
+        ctx, req, sdist_server_url, include_sdists=True, include_wheels=False
     )
     source_filename = download_url(ctx.sdists_downloads, url)
     logger.debug(

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -65,3 +65,282 @@ def test_provider_choose_sdist():
             == "https://files.pythonhosted.org/packages/6d/8e/07e42bc434a847154083b315779b0a81d567154504624e181caf2c71cd98/hydra-core-1.3.2.tar.gz#sha256=8a878ed67216997c3e9d88a8e72e7b4767e81af37afb4ea3334b269a4390a824"
         )
         assert str(candidate.version) == "1.3.2"
+
+
+_github_fromager_repo_response = """
+{
+  "id": 808690091,
+  "node_id": "R_kgDOMDOhqw",
+  "name": "fromager",
+  "full_name": "python-wheel-build/fromager",
+  "private": false,
+  "owner": {
+    "login": "python-wheel-build",
+    "id": 171364409,
+    "node_id": "O_kgDOCjbQOQ",
+    "avatar_url": "https://avatars.githubusercontent.com/u/171364409?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/python-wheel-build",
+    "html_url": "https://github.com/python-wheel-build",
+    "followers_url": "https://api.github.com/users/python-wheel-build/followers",
+    "following_url": "https://api.github.com/users/python-wheel-build/following{/other_user}",
+    "gists_url": "https://api.github.com/users/python-wheel-build/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/python-wheel-build/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/python-wheel-build/subscriptions",
+    "organizations_url": "https://api.github.com/users/python-wheel-build/orgs",
+    "repos_url": "https://api.github.com/users/python-wheel-build/repos",
+    "events_url": "https://api.github.com/users/python-wheel-build/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/python-wheel-build/received_events",
+    "type": "Organization",
+    "site_admin": false
+  },
+  "html_url": "https://github.com/python-wheel-build/fromager",
+  "description": "Build your own wheels",
+  "fork": false,
+  "url": "https://api.github.com/repos/python-wheel-build/fromager",
+  "forks_url": "https://api.github.com/repos/python-wheel-build/fromager/forks",
+  "keys_url": "https://api.github.com/repos/python-wheel-build/fromager/keys{/key_id}",
+  "collaborators_url": "https://api.github.com/repos/python-wheel-build/fromager/collaborators{/collaborator}",
+  "teams_url": "https://api.github.com/repos/python-wheel-build/fromager/teams",
+  "hooks_url": "https://api.github.com/repos/python-wheel-build/fromager/hooks",
+  "issue_events_url": "https://api.github.com/repos/python-wheel-build/fromager/issues/events{/number}",
+  "events_url": "https://api.github.com/repos/python-wheel-build/fromager/events",
+  "assignees_url": "https://api.github.com/repos/python-wheel-build/fromager/assignees{/user}",
+  "branches_url": "https://api.github.com/repos/python-wheel-build/fromager/branches{/branch}",
+  "tags_url": "https://api.github.com/repos/python-wheel-build/fromager/tags",
+  "blobs_url": "https://api.github.com/repos/python-wheel-build/fromager/git/blobs{/sha}",
+  "git_tags_url": "https://api.github.com/repos/python-wheel-build/fromager/git/tags{/sha}",
+  "git_refs_url": "https://api.github.com/repos/python-wheel-build/fromager/git/refs{/sha}",
+  "trees_url": "https://api.github.com/repos/python-wheel-build/fromager/git/trees{/sha}",
+  "statuses_url": "https://api.github.com/repos/python-wheel-build/fromager/statuses/{sha}",
+  "languages_url": "https://api.github.com/repos/python-wheel-build/fromager/languages",
+  "stargazers_url": "https://api.github.com/repos/python-wheel-build/fromager/stargazers",
+  "contributors_url": "https://api.github.com/repos/python-wheel-build/fromager/contributors",
+  "subscribers_url": "https://api.github.com/repos/python-wheel-build/fromager/subscribers",
+  "subscription_url": "https://api.github.com/repos/python-wheel-build/fromager/subscription",
+  "commits_url": "https://api.github.com/repos/python-wheel-build/fromager/commits{/sha}",
+  "git_commits_url": "https://api.github.com/repos/python-wheel-build/fromager/git/commits{/sha}",
+  "comments_url": "https://api.github.com/repos/python-wheel-build/fromager/comments{/number}",
+  "issue_comment_url": "https://api.github.com/repos/python-wheel-build/fromager/issues/comments{/number}",
+  "contents_url": "https://api.github.com/repos/python-wheel-build/fromager/contents/{+path}",
+  "compare_url": "https://api.github.com/repos/python-wheel-build/fromager/compare/{base}...{head}",
+  "merges_url": "https://api.github.com/repos/python-wheel-build/fromager/merges",
+  "archive_url": "https://api.github.com/repos/python-wheel-build/fromager/{archive_format}{/ref}",
+  "downloads_url": "https://api.github.com/repos/python-wheel-build/fromager/downloads",
+  "issues_url": "https://api.github.com/repos/python-wheel-build/fromager/issues{/number}",
+  "pulls_url": "https://api.github.com/repos/python-wheel-build/fromager/pulls{/number}",
+  "milestones_url": "https://api.github.com/repos/python-wheel-build/fromager/milestones{/number}",
+  "notifications_url": "https://api.github.com/repos/python-wheel-build/fromager/notifications{?since,all,participating}",
+  "labels_url": "https://api.github.com/repos/python-wheel-build/fromager/labels{/name}",
+  "releases_url": "https://api.github.com/repos/python-wheel-build/fromager/releases{/id}",
+  "deployments_url": "https://api.github.com/repos/python-wheel-build/fromager/deployments",
+  "created_at": "2024-05-31T15:49:02Z",
+  "updated_at": "2024-06-26T14:52:13Z",
+  "pushed_at": "2024-06-26T14:52:09Z",
+  "git_url": "git://github.com/python-wheel-build/fromager.git",
+  "ssh_url": "git@github.com:python-wheel-build/fromager.git",
+  "clone_url": "https://github.com/python-wheel-build/fromager.git",
+  "svn_url": "https://github.com/python-wheel-build/fromager",
+  "homepage": "https://pypi.org/project/fromager/",
+  "size": 907,
+  "stargazers_count": 1,
+  "watchers_count": 1,
+  "language": "Python",
+  "has_issues": true,
+  "has_projects": true,
+  "has_downloads": true,
+  "has_wiki": false,
+  "has_pages": false,
+  "has_discussions": false,
+  "forks_count": 4,
+  "mirror_url": null,
+  "archived": false,
+  "disabled": false,
+  "open_issues_count": 14,
+  "license": {
+    "key": "apache-2.0",
+    "name": "Apache License 2.0",
+    "spdx_id": "Apache-2.0",
+    "url": "https://api.github.com/licenses/apache-2.0",
+    "node_id": "MDc6TGljZW5zZTI="
+  },
+  "allow_forking": true,
+  "is_template": false,
+  "web_commit_signoff_required": false,
+  "topics": [
+
+  ],
+  "visibility": "public",
+  "forks": 4,
+  "open_issues": 14,
+  "watchers": 1,
+  "default_branch": "main",
+  "temp_clone_token": null,
+  "custom_properties": {
+
+  },
+  "organization": {
+    "login": "python-wheel-build",
+    "id": 171364409,
+    "node_id": "O_kgDOCjbQOQ",
+    "avatar_url": "https://avatars.githubusercontent.com/u/171364409?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/python-wheel-build",
+    "html_url": "https://github.com/python-wheel-build",
+    "followers_url": "https://api.github.com/users/python-wheel-build/followers",
+    "following_url": "https://api.github.com/users/python-wheel-build/following{/other_user}",
+    "gists_url": "https://api.github.com/users/python-wheel-build/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/python-wheel-build/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/python-wheel-build/subscriptions",
+    "organizations_url": "https://api.github.com/users/python-wheel-build/orgs",
+    "repos_url": "https://api.github.com/users/python-wheel-build/repos",
+    "events_url": "https://api.github.com/users/python-wheel-build/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/python-wheel-build/received_events",
+    "type": "Organization",
+    "site_admin": false
+  },
+  "network_count": 4,
+  "subscribers_count": 1
+}
+"""
+
+# This mock response text does not include the most recent release to
+# ensure we're actually using the mock data.
+_github_fromager_tag_response = """
+[
+  {
+    "name": "0.9.0",
+    "zipball_url": "https://api.github.com/repos/python-wheel-build/fromager/zipball/refs/tags/0.9.0",
+    "tarball_url": "https://api.github.com/repos/python-wheel-build/fromager/tarball/refs/tags/0.9.0",
+    "commit": {
+      "sha": "5fbdab491e983152f7e5c8200b4f7f62f714aedf",
+      "url": "https://api.github.com/repos/python-wheel-build/fromager/commits/5fbdab491e983152f7e5c8200b4f7f62f714aedf"
+    },
+    "node_id": "REF_kwDOMDOhq69yZWZzL3RhZ3MvMC45LjA"
+  },
+  {
+    "name": "0.8.1",
+    "zipball_url": "https://api.github.com/repos/python-wheel-build/fromager/zipball/refs/tags/0.8.1",
+    "tarball_url": "https://api.github.com/repos/python-wheel-build/fromager/tarball/refs/tags/0.8.1",
+    "commit": {
+      "sha": "a790c71adeb21a02e09173407339bc25085bdf4d",
+      "url": "https://api.github.com/repos/python-wheel-build/fromager/commits/a790c71adeb21a02e09173407339bc25085bdf4d"
+    },
+    "node_id": "REF_kwDOMDOhq69yZWZzL3RhZ3MvMC44LjE"
+  },
+  {
+    "name": "0.8.0",
+    "zipball_url": "https://api.github.com/repos/python-wheel-build/fromager/zipball/refs/tags/0.8.0",
+    "tarball_url": "https://api.github.com/repos/python-wheel-build/fromager/tarball/refs/tags/0.8.0",
+    "commit": {
+      "sha": "5e3b5595d2f8751eb3ba81c287045eac85441fc3",
+      "url": "https://api.github.com/repos/python-wheel-build/fromager/commits/5e3b5595d2f8751eb3ba81c287045eac85441fc3"
+    },
+    "node_id": "REF_kwDOMDOhq69yZWZzL3RhZ3MvMC44LjA"
+  },
+  {
+    "name": "0.7.0",
+    "zipball_url": "https://api.github.com/repos/python-wheel-build/fromager/zipball/refs/tags/0.7.0",
+    "tarball_url": "https://api.github.com/repos/python-wheel-build/fromager/tarball/refs/tags/0.7.0",
+    "commit": {
+      "sha": "d97a0520a7b21bc3d0617c77da0227a4e7656be0",
+      "url": "https://api.github.com/repos/python-wheel-build/fromager/commits/d97a0520a7b21bc3d0617c77da0227a4e7656be0"
+    },
+    "node_id": "REF_kwDOMDOhq69yZWZzL3RhZ3MvMC43LjA"
+  },
+  {
+    "name": "0.6.0",
+    "zipball_url": "https://api.github.com/repos/python-wheel-build/fromager/zipball/refs/tags/0.6.0",
+    "tarball_url": "https://api.github.com/repos/python-wheel-build/fromager/tarball/refs/tags/0.6.0",
+    "commit": {
+      "sha": "7935210bb23a9fd662273dc38e98dc13f8fa3243",
+      "url": "https://api.github.com/repos/python-wheel-build/fromager/commits/7935210bb23a9fd662273dc38e98dc13f8fa3243"
+    },
+    "node_id": "REF_kwDOMDOhq69yZWZzL3RhZ3MvMC42LjA"
+  },
+  {
+    "name": "0.5.0",
+    "zipball_url": "https://api.github.com/repos/python-wheel-build/fromager/zipball/refs/tags/0.5.0",
+    "tarball_url": "https://api.github.com/repos/python-wheel-build/fromager/tarball/refs/tags/0.5.0",
+    "commit": {
+      "sha": "de945241b85ae386203383e250d3b33032f9ff4b",
+      "url": "https://api.github.com/repos/python-wheel-build/fromager/commits/de945241b85ae386203383e250d3b33032f9ff4b"
+    },
+    "node_id": "REF_kwDOMDOhq69yZWZzL3RhZ3MvMC41LjA"
+  },
+  {
+    "name": "0.4.0",
+    "zipball_url": "https://api.github.com/repos/python-wheel-build/fromager/zipball/refs/tags/0.4.0",
+    "tarball_url": "https://api.github.com/repos/python-wheel-build/fromager/tarball/refs/tags/0.4.0",
+    "commit": {
+      "sha": "b1f79701cf95c1dfb098d83438afdd66661118e3",
+      "url": "https://api.github.com/repos/python-wheel-build/fromager/commits/b1f79701cf95c1dfb098d83438afdd66661118e3"
+    },
+    "node_id": "REF_kwDOMDOhq69yZWZzL3RhZ3MvMC40LjA"
+  },
+  {
+    "name": "0.3.0",
+    "zipball_url": "https://api.github.com/repos/python-wheel-build/fromager/zipball/refs/tags/0.3.0",
+    "tarball_url": "https://api.github.com/repos/python-wheel-build/fromager/tarball/refs/tags/0.3.0",
+    "commit": {
+      "sha": "f677a155e804a5b1a4bfbf6c28773a88a6d934c6",
+      "url": "https://api.github.com/repos/python-wheel-build/fromager/commits/f677a155e804a5b1a4bfbf6c28773a88a6d934c6"
+    },
+    "node_id": "REF_kwDOMDOhq69yZWZzL3RhZ3MvMC4zLjA"
+  },
+  {
+    "name": "0.2.0",
+    "zipball_url": "https://api.github.com/repos/python-wheel-build/fromager/zipball/refs/tags/0.2.0",
+    "tarball_url": "https://api.github.com/repos/python-wheel-build/fromager/tarball/refs/tags/0.2.0",
+    "commit": {
+      "sha": "7b80c36074af597f78850eb9247d7cd1d9b27fce",
+      "url": "https://api.github.com/repos/python-wheel-build/fromager/commits/7b80c36074af597f78850eb9247d7cd1d9b27fce"
+    },
+    "node_id": "REF_kwDOMDOhq69yZWZzL3RhZ3MvMC4yLjA"
+  },
+  {
+    "name": "0.1.0",
+    "zipball_url": "https://api.github.com/repos/python-wheel-build/fromager/zipball/refs/tags/0.1.0",
+    "tarball_url": "https://api.github.com/repos/python-wheel-build/fromager/tarball/refs/tags/0.1.0",
+    "commit": {
+      "sha": "e75facfd9dd9437fa5c19badeddd6e40e9197659",
+      "url": "https://api.github.com/repos/python-wheel-build/fromager/commits/e75facfd9dd9437fa5c19badeddd6e40e9197659"
+    },
+    "node_id": "REF_kwDOMDOhq69yZWZzL3RhZ3MvMC4xLjA"
+  },
+  {
+    "name": "0.0.1",
+    "zipball_url": "https://api.github.com/repos/python-wheel-build/fromager/zipball/refs/tags/0.0.1",
+    "tarball_url": "https://api.github.com/repos/python-wheel-build/fromager/tarball/refs/tags/0.0.1",
+    "commit": {
+      "sha": "39b0422377d0b405a8fe2ba32f384d677f1c06af",
+      "url": "https://api.github.com/repos/python-wheel-build/fromager/commits/39b0422377d0b405a8fe2ba32f384d677f1c06af"
+    },
+    "node_id": "REF_kwDOMDOhq69yZWZzL3RhZ3MvMC4wLjE"
+  }
+]
+"""
+
+
+def test_resolve_github():
+    with requests_mock.Mocker() as r:
+        r.get(
+            "https://api.github.com:443/repos/python-wheel-build/fromager",
+            text=_github_fromager_repo_response,
+        )
+        r.get(
+            "https://api.github.com:443/repos/python-wheel-build/fromager/tags",
+            text=_github_fromager_tag_response,
+        )
+
+        provider = resolver.GitHubTagProvider("python-wheel-build", "fromager")
+        reporter = resolvelib.BaseReporter()
+        rslvr = resolvelib.Resolver(provider, reporter)
+
+        result = rslvr.resolve([Requirement("fromager")])
+        assert "fromager" in result.mapping
+
+        candidate = result.mapping["fromager"]
+        assert str(candidate.version) == "0.9.0"
+        # check the "URL" in case tag syntax does not match version syntax
+        assert str(candidate.url) == "0.9.0"

--- a/tests/test_sdist.py
+++ b/tests/test_sdist.py
@@ -7,19 +7,22 @@ from fromager import sdist
 
 
 @patch("fromager.sources.resolve_dist")
-def test_missing_dependency_format(resolve_dist):
+def test_missing_dependency_format(resolve_dist, tmp_context):
     resolutions = {
         "flit_core": "3.9.0",
         "setuptools": "69.5.1",
     }
-    resolve_dist.side_effect = lambda req, url: ("", Version(resolutions[req.name]))
+    resolve_dist.side_effect = lambda ctx, req, url: (
+        "",
+        Version(resolutions[req.name]),
+    )
 
     req = Requirement("setuptools>=40.8.0")
     other_reqs = [
         Requirement("flit_core"),
         req,
     ]
-    ex = sdist.MissingDependency("test", req, other_reqs)
+    ex = sdist.MissingDependency(tmp_context, "test", req, other_reqs)
     s = str(ex)
     # Ensure we report the thing we're actually missing
     assert "Failed to install test dependency setuptools>=40.8.0. " in s


### PR DESCRIPTION
Some overrides are for doing things like building from a fork of a
project with fixes that aren't upstream. In those cases, the builder
might have to determine the version in some way other than looking at
pypi.org. Provide a hook for that, and include a sample implementation
that uses tags on github.com.

Resolves #103