### PR TITLE
sort dependencies before recursing for consistent output

### DIFF
--- a/src/fromager/sdist.py
+++ b/src/fromager/sdist.py
@@ -1,5 +1,6 @@
 import importlib.metadata
 import logging
+import operator
 import os.path
 import re
 import shutil
@@ -193,7 +194,7 @@ def handle_requirement(ctx, req, req_type="toplevel", why=None):
         install_dependencies,
         unpack_dir / "requirements.txt",
     )
-    for dep in install_dependencies:
+    for dep in _sort_requirements(install_dependencies):
         try:
             handle_requirement(ctx, dep, next_req_type, why)
         except Exception as err:
@@ -214,6 +215,10 @@ def handle_requirement(ctx, req, req_type="toplevel", why=None):
             logger.debug("{req.name}: cleaned up build environment {build_env.path}")
 
     return resolved_version
+
+
+def _sort_requirements(requirements):
+    return sorted(requirements, key=operator.attrgetter("name"))
 
 
 def _resolve_prebuilt_wheel(req, wheel_server_urls):
@@ -240,7 +245,7 @@ def _handle_build_system_requirements(ctx, req, why, sdist_root_dir):
         build_system_dependencies,
         sdist_root_dir.parent / "build-system-requirements.txt",
     )
-    for dep in build_system_dependencies:
+    for dep in _sort_requirements(build_system_dependencies):
         try:
             resolved = handle_requirement(ctx, dep, "build-system", why)
         except Exception as err:
@@ -262,7 +267,7 @@ def _handle_build_backend_requirements(ctx, req, why, sdist_root_dir):
         build_backend_dependencies,
         sdist_root_dir.parent / "build-backend-requirements.txt",
     )
-    for dep in build_backend_dependencies:
+    for dep in _sort_requirements(build_backend_dependencies):
         try:
             resolved = handle_requirement(ctx, dep, "build-backend", why)
         except Exception as err:
@@ -284,7 +289,7 @@ def _handle_build_sdist_requirements(ctx, req, why, sdist_root_dir):
         build_sdist_dependencies,
         sdist_root_dir.parent / "build-sdist-requirements.txt",
     )
-    for dep in sorted(build_sdist_dependencies):
+    for dep in _sort_requirements(build_sdist_dependencies):
         try:
             resolved = handle_requirement(ctx, dep, "build-sdist", why)
         except Exception as err:


### PR DESCRIPTION
The dependencies are a set, and we might get them in different orders from
different invocations. Sorting the values makes the processing order
consistent and the build order output from run to run is therefore easier
to compare.