### PR TITLE
Configure mypy checker in tox and GHA

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -26,6 +26,29 @@ jobs:
       - name: Run
         run: tox -e linter
 
+  mypy:
+    name: mypy
+    runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.ref, 'refs/tags') }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"  # minimum supported lang version
+
+      - name: Install dependencies
+        run: python -m pip install tox
+
+      # tox -e mypy is failing, ignore errors for now
+      - name: Check MyPy
+        continue-on-error: true
+        run: tox -e mypy
+
   pkglint:
     name: pkglint
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,3 +103,16 @@ ignore = [
 
 [tool.ruff.lint.isort]
 known-first-party = ["fromager"]
+
+[tool.mypy]
+mypy_path = ["src"]
+
+[[tool.mypy.overrides]]
+# packages without typing annotations and stubs
+module = [
+    "pyproject_hooks",
+    "requests_mock",
+    "resolver",
+    "stevedore",
+]
+ignore_missing_imports = true

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,19 @@ commands =
 [testenv:e2e]
 deps = .
 
+[testenv:mypy]
+description = Python type checking with mypy
+deps =
+  mypy
+  pytest
+  types-html5lib
+  types-PyYAML
+  types-requests
+  types-toml
+commands =
+  mypy -p fromager
+  mypy tests/
+
 [testenv:pkglint]
 base_python=python3.11
 deps=


### PR DESCRIPTION
- add `mypy` checker to tox
- configure mypy to ignore packages without type annotations and type stubs
- add mypy checker to GHA (ignoring errors)