### PR TITLE
Define custom click params for path and versions

### DIFF
--- a/src/fromager/__main__.py
+++ b/src/fromager/__main__.py
@@ -5,7 +5,7 @@ import pathlib
 
 import click
 
-from . import commands, context, overrides, settings
+from . import clickext, commands, context, overrides, settings
 
 logger = logging.getLogger(__name__)
 
@@ -22,47 +22,49 @@ VERBOSE_LOG_FMT = "%(levelname)s:%(name)s:%(lineno)d: %(message)s"
     help="report more detail to the console",
 )
 @click.option(
-    "--log-file", type=click.Path(), help="save detailed report of actions to file"
+    "--log-file",
+    type=clickext.ClickPath(),
+    help="save detailed report of actions to file",
 )
 @click.option(
     "-o",
     "--sdists-repo",
     default=pathlib.Path("sdists-repo"),
-    type=click.Path(),
+    type=clickext.ClickPath(),
     help="location to manage source distributions",
 )
 @click.option(
     "-w",
     "--wheels-repo",
     default=pathlib.Path("wheels-repo"),
-    type=click.Path(),
+    type=clickext.ClickPath(),
     help="location to manage wheel repository",
 )
 @click.option(
     "-t",
     "--work-dir",
     default=pathlib.Path("work-dir"),
-    type=click.Path(),
+    type=clickext.ClickPath(),
     help="location to manage working files, including builds",
 )
 @click.option(
     "-p",
     "--patches-dir",
     default=pathlib.Path("overrides/patches"),
-    type=click.Path(),
+    type=clickext.ClickPath(),
     help="location of files for patching source before building",
 )
 @click.option(
     "-e",
     "--envs-dir",
     default=pathlib.Path("overrides/envs"),
-    type=click.Path(),
+    type=clickext.ClickPath(),
     help="location of environment override files",
 )
 @click.option(
     "--settings-file",
     default=pathlib.Path("overrides/settings.yaml"),
-    type=click.Path(),
+    type=clickext.ClickPath(),
     help="location of the application settings file",
 )
 @click.option(
@@ -81,13 +83,13 @@ VERBOSE_LOG_FMT = "%(levelname)s:%(name)s:%(lineno)d: %(message)s"
 def main(
     ctx,
     verbose: bool,
-    log_file: click.Path,
-    sdists_repo: click.Path,
-    wheels_repo: click.Path,
-    work_dir: click.Path,
-    patches_dir: click.Path,
-    envs_dir: click.Path,
-    settings_file: click.Path,
+    log_file: pathlib.Path,
+    sdists_repo: pathlib.Path,
+    wheels_repo: pathlib.Path,
+    work_dir: pathlib.Path,
+    patches_dir: pathlib.Path,
+    envs_dir: pathlib.Path,
+    settings_file: pathlib.Path,
     wheel_server_url: str,
     cleanup: bool,
     variant: str,

--- a/src/fromager/clickext.py
+++ b/src/fromager/clickext.py
@@ -1,0 +1,41 @@
+import os
+import pathlib
+
+import click
+from packaging.version import Version
+
+
+class ClickPath(click.Path):
+    """ClickPath that returns pathlib.Path"""
+
+    def convert(
+        self,
+        value: str | os.PathLike[str],
+        param: click.core.Parameter | None,
+        ctx: click.core.Context | None,
+    ) -> pathlib.Path:
+        path = super().convert(value=value, param=param, ctx=ctx)
+        if isinstance(path, bytes):
+            return pathlib.Path(os.fsdecode(path))
+        return pathlib.Path(path)
+
+
+class PackageVersion(click.ParamType):
+    """Package version type that returns a packaging version"""
+
+    name = "package_version"
+
+    def convert(
+        self,
+        value: str,
+        param: click.core.Parameter | None,
+        ctx: click.core.Context | None,
+    ) -> Version:
+        try:
+            return Version(value)
+        except Exception as e:
+            self.fail(
+                f"Invalid package version '{value}' ({e})",
+                param,
+                ctx,
+            )

--- a/src/fromager/commands/build.py
+++ b/src/fromager/commands/build.py
@@ -4,21 +4,22 @@ import pathlib
 
 import click
 from packaging.requirements import Requirement
+from packaging.version import Version
 
-from .. import context, sdist, server, sources, wheels
+from .. import clickext, context, sdist, server, sources, wheels
 
 logger = logging.getLogger(__name__)
 
 
 @click.command()
 @click.argument("dist_name")
-@click.argument("dist_version")
+@click.argument("dist_version", type=clickext.PackageVersion())
 @click.argument("sdist_server_url")
 @click.pass_obj
 def build(
     wkctx: context.WorkContext,
     dist_name: str,
-    dist_version: str,
+    dist_version: Version,
     sdist_server_url: str,
 ):
     """Build a single version of a single wheel
@@ -80,7 +81,7 @@ def build_sequence(
 def _build(
     wkctx: context.WorkContext,
     dist_name: str,
-    dist_version: str,
+    dist_version: Version,
     sdist_server_url: str,
 ) -> pathlib.Path:
     server.start_wheel_server(wkctx)

--- a/src/fromager/commands/build_order.py
+++ b/src/fromager/commands/build_order.py
@@ -8,7 +8,7 @@ import sys
 import click
 from packaging.requirements import Requirement
 
-from .. import overrides
+from .. import clickext, overrides
 
 
 @click.group()
@@ -18,9 +18,14 @@ def build_order():
 
 
 @build_order.command()
-@click.option("-o", "--output", type=click.Path(), help="output file to create")
+@click.option(
+    "-o",
+    "--output",
+    type=clickext.ClickPath(),
+    help="output file to create",
+)
 @click.argument("build_order_file")
-def as_csv(build_order_file: str, output: click.Path):
+def as_csv(build_order_file: str, output: pathlib.Path | None):
     """Create a comma-separated-value file from the build order file
 
     BUILD_ORDER_FILE is one or more build-order.json files to convert
@@ -77,9 +82,14 @@ def as_csv(build_order_file: str, output: click.Path):
 
 
 @build_order.command()
-@click.option("-o", "--output", type=click.Path(), help="output file to create")
+@click.option(
+    "-o",
+    "--output",
+    type=clickext.ClickPath(),
+    help="output file to create",
+)
 @click.argument("build_order_file", nargs=-1)
-def summary(build_order_file: list[str], output: click.Path):
+def summary(build_order_file: list[str], output: pathlib.Path | None):
     """Summarize the build order files
 
     BUILD_ORDER_FILE is one or more build-order.json files to convert
@@ -126,9 +136,14 @@ def summary(build_order_file: list[str], output: click.Path):
 
 
 @build_order.command()
-@click.option("-o", "--output", type=click.Path(), help="output file to create")
+@click.option(
+    "-o",
+    "--output",
+    type=clickext.ClickPath(),
+    help="output file to create",
+)
 @click.argument("build_order_file", nargs=-1)
-def graph(build_order_file: list[str], output: click.Path):
+def graph(build_order_file: list[str], output: pathlib.Path | None):
     """Write a graphviz-compatible dot file representing the build order dependencies
 
     BUILD_ORDER_FILE is one or more build-order.json files to convert

--- a/src/fromager/commands/step.py
+++ b/src/fromager/commands/step.py
@@ -3,8 +3,9 @@ import pathlib
 
 import click
 from packaging.requirements import Requirement
+from packaging.version import Version
 
-from .. import context, finders, sdist, server, sources, wheels
+from .. import clickext, context, finders, sdist, server, sources, wheels
 
 logger = logging.getLogger(__name__)
 
@@ -17,13 +18,13 @@ def step():
 
 @step.command()
 @click.argument("dist_name")
-@click.argument("dist_version")
+@click.argument("dist_version", type=clickext.PackageVersion())
 @click.argument("sdist_server_url")
 @click.pass_obj
 def download_source_archive(
     wkctx: context.WorkContext,
     dist_name: str,
-    dist_version: str,
+    dist_version: Version,
     sdist_server_url: str,
 ):
     """download the source code archive for one version of one package
@@ -44,12 +45,12 @@ def download_source_archive(
 
 @step.command()
 @click.argument("dist_name")
-@click.argument("dist_version")
+@click.argument("dist_version", type=clickext.PackageVersion())
 @click.pass_obj
 def prepare_source(
     wkctx: context.WorkContext,
     dist_name: str,
-    dist_version: str,
+    dist_version: Version,
 ):
     """ensure the source code is in a form ready for building a wheel
 
@@ -75,12 +76,12 @@ def prepare_source(
 
 @step.command()
 @click.argument("dist_name")
-@click.argument("dist_version")
+@click.argument("dist_version", type=clickext.PackageVersion())
 @click.pass_obj
 def build_sdist(
     wkctx: context.WorkContext,
     dist_name: str,
-    dist_version: str,
+    dist_version: Version,
 ):
     """build a new source distribution for the package
 
@@ -114,9 +115,13 @@ def _find_source_root_dir(
 
 @step.command()
 @click.argument("dist_name")
-@click.argument("dist_version")
+@click.argument("dist_version", type=clickext.PackageVersion())
 @click.pass_obj
-def prepare_build(wkctx: context.WorkContext, dist_name: str, dist_version: str):
+def prepare_build(
+    wkctx: context.WorkContext,
+    dist_name: str,
+    dist_version: Version,
+):
     """set up build environment to build the package
 
     DIST_NAME is the name of a distribution
@@ -132,9 +137,13 @@ def prepare_build(wkctx: context.WorkContext, dist_name: str, dist_version: str)
 
 @step.command()
 @click.argument("dist_name")
-@click.argument("dist_version")
+@click.argument("dist_version", type=clickext.PackageVersion())
 @click.pass_obj
-def build_wheel(wkctx: context.WorkContext, dist_name: str, dist_version: str):
+def build_wheel(
+    wkctx: context.WorkContext,
+    dist_name: str,
+    dist_version: Version,
+):
     """build a wheel from prepared source
 
     DIST_NAME is the name of a distribution


### PR DESCRIPTION
The new parameter type `ClickPath` is a subclass of `click.Path` that returns a pathlib.Path instead of a path-like object. All path paramemter now use `ClickPath` for handling input.

`PackageVersion` is a string input field that converts a version string to a packaging `Version` class with error checking.