### PR TITLE
Convert Path to str for external_commands.run()

### DIFF
--- a/src/fromager/server.py
+++ b/src/fromager/server.py
@@ -1,6 +1,7 @@
 import functools
 import http.server
 import logging
+import os
 import shutil
 import threading
 
@@ -54,8 +55,8 @@ def update_wheel_mirror(ctx: context.WorkContext):
             "pypi-mirror",
             "create",
             "-d",
-            ctx.wheels_downloads,
+            os.fspath(ctx.wheels_downloads),
             "-m",
-            ctx.wheel_server_dir,
+            os.fspath(ctx.wheel_server_dir),
         ]
     )

--- a/src/fromager/vendor_rust.py
+++ b/src/fromager/vendor_rust.py
@@ -3,6 +3,7 @@
 
 import json
 import logging
+import os
 import pathlib
 import typing
 
@@ -33,7 +34,7 @@ def _cargo_vendor(
     args = ["cargo", "vendor", f"--manifest-path={manifests[0]}"]
     for manifest in manifests[1:]:
         args.append(f"--sync={manifest}")
-    args.append(project_dir / VENDOR_DIR)
+    args.append(os.fspath(project_dir / VENDOR_DIR))
     external_commands.run(args)
     return sorted(project_dir.joinpath(VENDOR_DIR).iterdir())
 

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -118,7 +118,7 @@ def default_build_wheel(
 
     with tempfile.TemporaryDirectory() as dir_name:
         cmd = [
-            build_env.python,
+            os.fspath(build_env.python),
             "-m",
             "pip",
             "-vvv",
@@ -128,12 +128,12 @@ def default_build_wheel(
             "--only-binary",
             ":all:",
             "--wheel-dir",
-            ctx.wheels_build,
+            os.fspath(ctx.wheels_build),
             "--no-deps",
             "--index-url",
             ctx.wheel_server_url,  # probably redundant, but just in case
             "--log",
-            sdist_root_dir.parent / "build.log",
-            sdist_root_dir,
+            os.fspath(sdist_root_dir.parent / "build.log"),
+            os.fspath(sdist_root_dir),
         ]
         external_commands.run(cmd, cwd=dir_name, extra_environ=override_env)


### PR DESCRIPTION
`external_commands.run()` accepts a `list[str]`. Convert all occurances of `pathlib.Path` to `str`.