### PR TITLE
Consistently pass versions as `Version` object

### DIFF
--- a/src/fromager/commands/step.py
+++ b/src/fromager/commands/step.py
@@ -102,7 +102,7 @@ def build_sdist(
 def _find_source_root_dir(
     work_dir: pathlib.Path,
     req: Requirement,
-    dist_version: str,
+    dist_version: Version,
 ) -> pathlib.Path:
     source_root_dir = finders.find_source_dir(pathlib.Path(work_dir), req, dist_version)
     if source_root_dir:

--- a/src/fromager/example_override.py
+++ b/src/fromager/example_override.py
@@ -1,4 +1,5 @@
 from packaging.requirements import Requirement
+from packaging.version import Version
 
 from fromager import resolver
 
@@ -15,9 +16,9 @@ def get_resolver_provider(
     )
 
 
-def expected_source_archive_name(req: Requirement, dist_version: str) -> str:
+def expected_source_archive_name(req: Requirement, dist_version: Version) -> str:
     return f"fromager-test-{dist_version}.tar.gz"
 
 
-def expected_source_directory_name(req: Requirement, dist_version: str) -> str:
+def expected_source_directory_name(req: Requirement, dist_version: Version) -> str:
     return f"fromager-test-{dist_version}/different-prefix-fromager-test-{dist_version}"

--- a/src/fromager/finders.py
+++ b/src/fromager/finders.py
@@ -6,6 +6,7 @@ import re
 
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
+from packaging.version import Version
 
 from . import overrides
 
@@ -24,7 +25,7 @@ def _dist_name_to_filename(dist_name: str) -> str:
 def find_sdist(
     downloads_dir: pathlib.Path,
     req: Requirement,
-    dist_version: str,
+    dist_version: Version,
 ) -> pathlib.Path | None:
     sdist_name_func = overrides.find_override_method(
         req.name, "expected_source_archive_name"
@@ -74,7 +75,7 @@ def find_sdist(
 def find_wheel(
     downloads_dir: pathlib.Path,
     req: Requirement,
-    dist_version: str,
+    dist_version: Version,
 ) -> pathlib.Path | None:
     filename_prefix = _dist_name_to_filename(req.name)
     canonical_name = canonicalize_name(req.name)
@@ -112,7 +113,7 @@ def find_wheel(
 def find_source_dir(
     work_dir: pathlib.Path,
     req: Requirement,
-    dist_version: str,
+    dist_version: Version,
 ) -> pathlib.Path | None:
     sdir_name_func = overrides.find_override_method(
         req.name, "expected_source_directory_name"

--- a/src/fromager/resolver.py
+++ b/src/fromager/resolver.py
@@ -40,7 +40,7 @@ class Candidate:
     def __init__(
         self,
         name: str,
-        version: str,
+        version: Version,
         url: str | None = None,
         extras: dict | None = None,
         is_sdist: bool | None = None,
@@ -210,7 +210,9 @@ class PyPIProvider(ExtrasProvider):
     def get_preference(self, identifier, resolutions, candidates, information, **kwds):
         return sum(1 for _ in candidates[identifier])
 
-    def find_matches(self, identifier, requirements, incompatibilities):
+    def find_matches(
+        self, identifier, requirements, incompatibilities: typing.Iterable[Candidate]
+    ):
         requirements = list(requirements[identifier])
         bad_versions = {c.version for c in incompatibilities[identifier]}
 

--- a/src/fromager/sdist.py
+++ b/src/fromager/sdist.py
@@ -11,6 +11,7 @@ import typing
 from urllib.parse import urlparse
 
 from packaging.requirements import Requirement
+from packaging.version import Version
 
 from . import (
     context,
@@ -63,7 +64,7 @@ def handle_requirement(
     req: Requirement,
     req_type: str = "toplevel",
     why: list | None = None,
-) -> str:
+) -> Version:
     if why is None:
         why = []
     logger.info(
@@ -243,7 +244,7 @@ def _resolve_prebuilt_wheel(
     ctx: context.WorkContext,
     req: Requirement,
     wheel_server_urls: list[str],
-) -> tuple[str, str]:
+) -> tuple[str, Version]:
     "Return URL to wheel and its version."
     for url in wheel_server_urls:
         try:
@@ -458,13 +459,13 @@ def _maybe_install(
     ctx: context.WorkContext,
     req: Requirement,
     req_type: str,
-    resolved_version: str,
-):
+    resolved_version: Version | None,
+) -> None:
     "Install the package if it is not already installed."
     if resolved_version is not None:
         try:
-            actual_version = importlib.metadata.version(req.name)
-            if str(resolved_version) == actual_version:
+            actual_version = Version(importlib.metadata.version(req.name))
+            if resolved_version == actual_version:
                 logger.debug(
                     f"{req.name}: already have {req.name} version {resolved_version} installed"
                 )


### PR DESCRIPTION
Replace `str` with a packaging `Version` object for any version argument and variable.