### PR TITLE
fix: pass environment variables from caller to build steps

### DIFF
--- a/src/fromager/overrides.py
+++ b/src/fromager/overrides.py
@@ -1,6 +1,5 @@
 import itertools
 import logging
-import os
 import pathlib
 import typing
 
@@ -72,7 +71,7 @@ def extra_environ_for_pkg(
 
     By default all packages have access to the environment variables in the current process
     """
-    extra_environ = dict(os.environ)
+    extra_environ = {}
 
     pkgname = pkgname_to_override_module(pkgname)
     variant_dir = envs_dir / variant

--- a/src/fromager/overrides.py
+++ b/src/fromager/overrides.py
@@ -68,8 +68,6 @@ def extra_environ_for_pkg(
 
     Extra environment variables are stored in per-package .env files in the
     envs package, with a key=value per line.
-
-    By default all packages have access to the environment variables in the current process
     """
     extra_environ = {}
 

--- a/src/fromager/overrides.py
+++ b/src/fromager/overrides.py
@@ -1,5 +1,6 @@
 import itertools
 import logging
+import os
 import pathlib
 import typing
 
@@ -69,8 +70,9 @@ def extra_environ_for_pkg(
     Extra environment variables are stored in per-package .env files in the
     envs package, with a key=value per line.
 
+    By default all packages have access to the environment variables in the current process
     """
-    extra_environ = {}
+    extra_environ = dict(os.environ)
 
     pkgname = pkgname_to_override_module(pkgname)
     variant_dir = envs_dir / variant

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -111,7 +111,7 @@ def default_build_wheel(
     if existing_path:
         path_parts.append(existing_path)
     updated_path = ":".join(path_parts)
-    override_env = {}
+    override_env = dict(os.environ)
     override_env.update(extra_environ)
     override_env["PATH"] = updated_path
     override_env["VIRTUAL_ENV"] = str(build_env.path)

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -1,4 +1,3 @@
-import os
 import pathlib
 
 from fromager import overrides
@@ -49,14 +48,10 @@ def test_extra_environ_for_pkg(tmp_path: pathlib.Path):
     variant_dir.mkdir()
 
     project_env = variant_dir / "project.env"
-    project_env.write_text("VAR1=OVERRIDEN\nVAR2=VALUE2")
-
-    os.environ.clear()
-    os.environ["VAR1"] = "VALUE1"
-    os.environ["VAR3"] = "VALUE3"
+    project_env.write_text("VAR1=VALUE1\nVAR2=VALUE2")
 
     result = overrides.extra_environ_for_pkg(env_dir, "project", "variant")
-    assert result == {"VAR1": "OVERRIDEN", "VAR2": "VALUE2", "VAR3": "VALUE3"}
+    assert result == {"VAR1": "VALUE1", "VAR2": "VALUE2"}
 
     result = overrides.extra_environ_for_pkg(env_dir, "non_existant_project", "variant")
-    assert result == {"VAR1": "VALUE1", "VAR3": "VALUE3"}
+    assert result == {}

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 
 from fromager import overrides
@@ -38,3 +39,24 @@ def test_patches_for_source_dir(tmp_path: pathlib.Path):
         overrides.patches_for_source_dir(patches_dir, "project-1.2.3-variant")
     )
     assert results == [p2, p5]
+
+
+def test_extra_environ_for_pkg(tmp_path: pathlib.Path):
+    env_dir = tmp_path / "env"
+    env_dir.mkdir()
+
+    variant_dir = env_dir / "variant"
+    variant_dir.mkdir()
+
+    project_env = variant_dir / "project.env"
+    project_env.write_text("VAR1=OVERRIDEN\nVAR2=VALUE2")
+
+    os.environ.clear()
+    os.environ["VAR1"] = "VALUE1"
+    os.environ["VAR3"] = "VALUE3"
+
+    result = overrides.extra_environ_for_pkg(env_dir, "project", "variant")
+    assert result == {"VAR1": "OVERRIDEN", "VAR2": "VALUE2", "VAR3": "VALUE3"}
+
+    result = overrides.extra_environ_for_pkg(env_dir, "non_existant_project", "variant")
+    assert result == {"VAR1": "VALUE1", "VAR3": "VALUE3"}


### PR DESCRIPTION
fixes #115 

Instead of initializing `extra_environ` as an empty dictionary we can initialize it with whatever environment variables the current process has access to. This keeps the flexibility of overriding these variables later on using the .env per package files or plugins.