### PR TITLE
Added credentials for GitHub Resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,16 @@ issue](https://gitlab.com/gitlab-org/gitlab/-/issues/350582):
 
 ```plaintext
 machine gitlab.com login oauth2 password $token
+```  
+
+## Determining versions via GitHub tags  
+
+In some cases, the builder might have to use tags on GitHub to determine the version of a project instead of looking at
+pypi.org. To avoid rate limit or to access private GitHub repository, a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) can be passed to fromager by setting
+the following environment variable:  
+
+```shell
+GITHUB_TOKEN=<access_token>
 ```
 
 ## Additional docs

--- a/src/fromager/resolver.py
+++ b/src/fromager/resolver.py
@@ -255,7 +255,9 @@ class GitHubTagProvider(ExtrasProvider):
         super().__init__()
         self.organization = organization
         self.repo = repo
-        self.client = github.Github()
+        token = os.getenv("GITHUB_TOKEN")
+        auth = github.Auth.Token(token) if token else None
+        self.client = github.Github(auth=auth)
 
     def identify(self, requirement_or_candidate: Requirement | Candidate) -> str:
         return canonicalize_name(requirement_or_candidate.name)


### PR DESCRIPTION
fixes #118 

If `GITHUB_TOKEN` is defined in the current environment then use it to create an authenticated instance of GitHub client and then use it in the resolver.