### PR TITLE
trap fewer exceptions when resolving a dependency

### DIFF
--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -54,7 +54,11 @@ def download_source(
                 raise ValueError(
                     f"do not know how to unpack {download_details}, expected 2 or 3 members"
                 )
-        except Exception as err:
+        except (
+            resolvelib.InconsistentCandidate,
+            resolvelib.RequirementsConflicted,
+            resolvelib.ResolutionImpossible,
+        ) as err:
             logger.debug(f"{req.name}: failed to resolve {req} using {url}: {err}")
             continue
         return (source_filename, version, source_url, source_type)


### PR DESCRIPTION
download_source() tries to resolve the source using multiple
servers. As part of the trial loop, it captures exceptions, logs them,
and continues with the next server. When there is a coding error in a
plugin, the capture behavior can mask the error. Instead of trapping
all exceptions, only catch the ones coming from resolvelib that are
also caught, and re-raised, in resolve_dist().