### PR TITLE
Add an option to pass the number of max jobs that are available

### DIFF
--- a/src/fromager/__main__.py
+++ b/src/fromager/__main__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import logging
+import os
 import pathlib
 
 import click
@@ -79,6 +80,12 @@ VERBOSE_LOG_FMT = "%(levelname)s:%(name)s:%(lineno)d: %(message)s"
     help="control removal of working files when a build completes successfully",
 )
 @click.option("--variant", default="cpu", help="the build variant name")
+@click.option(
+    "-j",
+    "--jobs",
+    type=int,
+    help="number of jobs available to run in parallel",
+)
 @click.pass_context
 def main(
     ctx,
@@ -93,6 +100,7 @@ def main(
     wheel_server_url: str,
     cleanup: bool,
     variant: str,
+    jobs: int,
 ):
     # Configure console and log output.
     stream_handler = logging.StreamHandler()
@@ -123,6 +131,7 @@ def main(
         wheel_server_url=wheel_server_url,
         cleanup=cleanup,
         variant=variant,
+        jobs=jobs if jobs is None or jobs > 0 else os.cpu_count(),
     )
     wkctx.setup()
     ctx.obj = wkctx

--- a/src/fromager/context.py
+++ b/src/fromager/context.py
@@ -24,6 +24,7 @@ class WorkContext:
         wheel_server_url: str,
         cleanup: bool = True,
         variant: str = "cpu",
+        jobs: int | None = None,
     ):
         self.settings = active_settings
         self.patches_dir = pathlib.Path(patches_dir).absolute()
@@ -40,6 +41,7 @@ class WorkContext:
         self.wheel_server_url = wheel_server_url
         self.cleanup = cleanup
         self.variant = variant
+        self.jobs = jobs
 
         self._build_order_filename = self.work_dir / "build-order.json"
         self._constraints_filename = self.work_dir / "constraints.txt"

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -84,6 +84,14 @@ def build_wheel(
     # TODO: refactor?
     # Build Rust without network access
     extra_environ["CARGO_NET_OFFLINE"] = "true"
+    # configure max jobs settings. should cover most of the cases, if not then the user can use ctx.jobs in their plugin
+    if ctx.jobs:
+        extra_environ["MAKEFLAGS"] = (
+            f"{extra_environ.get('MAKEFLAGS', '')} -j{ctx.jobs}"
+        )
+        extra_environ["CMAKE_BUILD_PARALLEL_LEVEL"] = f"{ctx.jobs}"
+        extra_environ["MAX_JOBS"] = f"{ctx.jobs}"
+
     builder(ctx, build_env, extra_environ, req, sdist_root_dir)
     wheels = list(ctx.wheels_build.glob("*.whl"))
     if wheels:


### PR DESCRIPTION
fixes #127 

Implemented the first method where a max number of jobs is passed to fromager via CLI and is exposed to the plugins via context