### PR TITLE
simplify mergify rules to only require one approval

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -72,10 +72,8 @@ pull_request_rules:
 
           - '-draft'
 
-          # At least 1 reviewer, without changes requested.
+          # At least 1 reviewer
           - "#approved-reviews-by>=1"
-          - "#review-requested=0"
-          - "#changes-requested-reviews-by=0"
 
     actions:
       merge:


### PR DESCRIPTION
I think the rules for no changes requested and no outstanding reviews requested are confusing the bot and causing it to not merge PRs.

Fixes mergify rules do not correctly merge PR after a re-review #131