### PR TITLE
evaluate marker expressions for toplevel dependencies

### DIFF
--- a/src/fromager/sdist.py
+++ b/src/fromager/sdist.py
@@ -66,6 +66,11 @@ def handle_requirement(
 ) -> str:
     if why is None:
         why = []
+    if not dependencies.evaluate_marker(req):
+        logger.info(
+            f"{req.name}: ignoring {req_type} dependency because of its marker expression"
+        )
+        return ""
     logger.info(
         f'{req.name}: {"*" * (len(why) + 1)} handling {req_type} requirement {req} {why}'
     )

--- a/tests/test_sdist.py
+++ b/tests/test_sdist.py
@@ -1,13 +1,18 @@
+import typing
 from unittest.mock import patch
 
 from packaging.requirements import Requirement
 from packaging.version import Version
 
 from fromager import sdist
+from fromager.context import WorkContext
 
 
 @patch("fromager.sources.resolve_dist")
-def test_missing_dependency_format(resolve_dist, tmp_context):
+def test_missing_dependency_format(
+    resolve_dist: typing.Callable,
+    tmp_context: WorkContext,
+):
     resolutions = {
         "flit_core": "3.9.0",
         "setuptools": "69.5.1",
@@ -30,3 +35,13 @@ def test_missing_dependency_format(resolve_dist, tmp_context):
     assert "setuptools>=40.8.0 -> 69.5.1" in s
     # Ensure we report what version we expect of all of the other dependencies
     assert "flit_core -> 3.9.0" in s
+
+
+def test_ignore_based_on_marker(tmp_context: WorkContext):
+    version = sdist.handle_requirement(
+        ctx=tmp_context,
+        req=Requirement('foo; python_version<"3.9"'),
+        req_type="toplevel",
+        why=[],
+    )
+    assert version == ""


### PR DESCRIPTION
If we are given a requirements file as the set of toplevel dependencies,
it is reasonable to expect some entries to have marker expressions
controlling when the dependency is relevant. This change ensures
those expressions are evaluated so that dependencies for different
versions of python or other platforms are ignored.