### PR TITLE
remove fedora package index from default resolver

### DIFF
--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -20,12 +20,8 @@ from . import context, dependencies, overrides, resolver, tarballs, vendor_rust
 logger = logging.getLogger(__name__)
 
 PYPI_SERVER_URL = "https://pypi.org/simple"
-PYAI_SOURCE_SERVER_URL = (
-    "https://pyai.fedorainfracloud.org/experimental/sources/+simple/"
-)
 DEFAULT_SDIST_SERVER_URLS = [
     PYPI_SERVER_URL,
-    PYAI_SOURCE_SERVER_URL,
 ]
 
 


### PR DESCRIPTION
We had a package server set up for Fedora and were using it in the early prototypes, but it should not be included in the real versions of Fromager, now.

Fixes remove fedora package index from built-in sources #132