### PR TITLE
fix: only download sdist sources in download-sequence

### DIFF
--- a/src/fromager/commands/download_sequence.py
+++ b/src/fromager/commands/download_sequence.py
@@ -29,6 +29,14 @@ def download_sequence(
     with open(build_order_file, "r") as f:
         for entry in json.load(f):
             if entry["prebuilt"]:
+                logger.info(f"{entry['dist']} uses a pre-built wheel, skipping")
                 continue
+
+            if entry["source_url_type"] != "sdist":
+                logger.info(
+                    f"{entry['dist']} uses a {entry['source_url_type']} downloader, skipping"
+                )
+                continue
+
             req = Requirement(f"{entry['dist']}=={entry['version']}")
             sources.download_source(wkctx, req, [sdist_server_url])


### PR DESCRIPTION
If the package has an override configured for download_source(), do
not try to download the sdist.