### PR TITLE
feature: post-build hooks

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -347,3 +347,39 @@ command will print the correct form of a name.
 $ tox -e cli -- canonicalize flit-core
 flit_core
 ```
+
+## Process hooks
+
+Fromager supports plugging in Python hooks to be run after build events.
+
+### post_build
+
+The `post_build` hook runs after a wheel is successfully built and can be used
+to publish that wheel to a package index or take other post-build actions.
+
+Configure a `post_build` hook in your `pyproject.toml` like this:
+
+```toml
+[project.entry-points."fromager.hooks"]
+post_build = "package_plugins.module:function"
+```
+
+The input arguments to the `post_build` hook are the `WorkContext`,
+`Requirement` being built, the distribution name and version, and the sdist and
+wheel filenames.
+
+NOTE: The files should not be renamed or moved.
+
+```python
+def post_build(
+    ctx: context.WorkContext,
+    req: Requirement,
+    dist_name: str,
+    dist_version: str,
+    sdist_filename: pathlib.Path,
+    wheel_filename: pathlib.Path,
+):
+    logger.info(
+        f"{req.name}: running post build hook for {sdist_filename} and {wheel_filename}"
+    )
+```

--- a/e2e/post_build_hook/build/lib/package_plugins/post_build.py
+++ b/e2e/post_build_hook/build/lib/package_plugins/post_build.py
@@ -1,0 +1,24 @@
+import logging
+import pathlib
+
+from packaging.requirements import Requirement
+
+from fromager import context
+
+logger = logging.getLogger(__name__)
+
+
+def after_build_wheel(
+    ctx: context.WorkContext,
+    req: Requirement,
+    dist_name: str,
+    dist_version: str,
+    sdist_filename: pathlib.Path,
+    wheel_filename: pathlib.Path,
+):
+    logger.info(
+        f"{req.name}: running post build hook in {__name__} for {sdist_filename} and {wheel_filename}"
+    )
+    test_file = sdist_filename.parent / "test-output-file.txt"
+    logger.info(f"{req.name}: post-build hook writing to {test_file}")
+    test_file.write_text(f"{dist_name}=={dist_version}")

--- a/e2e/post_build_hook/pyproject.toml
+++ b/e2e/post_build_hook/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "flit-core-overrides"
+authors = [
+    {name = "Doug Hellmann", email="dhellmann@redhat.com"},
+]
+description = "test package"
+dynamic = ["version"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Utilities",
+]
+
+requires-python = ">=3.10"
+
+dependencies = []
+
+[project.entry-points."fromager.hooks"]
+post_build = "package_plugins.post_build:after_build_wheel"

--- a/e2e/post_build_hook/src/package_plugins/post_build.py
+++ b/e2e/post_build_hook/src/package_plugins/post_build.py
@@ -1,0 +1,24 @@
+import logging
+import pathlib
+
+from packaging.requirements import Requirement
+
+from fromager import context
+
+logger = logging.getLogger(__name__)
+
+
+def after_build_wheel(
+    ctx: context.WorkContext,
+    req: Requirement,
+    dist_name: str,
+    dist_version: str,
+    sdist_filename: pathlib.Path,
+    wheel_filename: pathlib.Path,
+):
+    logger.info(
+        f"{req.name}: running post build hook in {__name__} for {sdist_filename} and {wheel_filename}"
+    )
+    test_file = sdist_filename.parent / "test-output-file.txt"
+    logger.info(f"{req.name}: post-build hook writing to {test_file}")
+    test_file.write_text(f"{dist_name}=={dist_version}")

--- a/e2e/test_build.sh
+++ b/e2e/test_build.sh
@@ -24,6 +24,7 @@ mkdir -p "$OUTDIR/build-logs"
 # Set up virtualenv with the CLI and dependencies.
 tox -e e2e -n -r
 source ".tox/e2e/bin/activate"
+pip install e2e/post_build_hook
 
 # Bootstrap the test project
 fromager \
@@ -51,6 +52,8 @@ fromager \
 EXPECTED_FILES="
 wheels-repo/build/stevedore-5.2.0-py3-none-any.whl
 sdists-repo/downloads/stevedore-5.2.0.tar.gz
+sdists-repo/builds/stevedore-5.2.0.tar.gz
+sdists-repo/builds/test-output-file.txt
 build.log
 "
 
@@ -61,4 +64,12 @@ for f in $EXPECTED_FILES; do
     pass=false
   fi
 done
+
+if $pass; then
+  if ! grep -q "${DIST}==${VERSION}" $OUTDIR/sdists-repo/builds/test-output-file.txt; then
+    echo "FAIL: Did not find content in post-build hook output file" 1>&2
+    pass=false
+  fi
+fi
+
 $pass

--- a/src/fromager/hooks.py
+++ b/src/fromager/hooks.py
@@ -1,0 +1,57 @@
+import logging
+import pathlib
+
+from packaging.requirements import Requirement
+from stevedore import extension, hook
+
+from fromager import context
+
+_mgrs = {}
+logger = logging.getLogger(__name__)
+
+
+def _get_hooks(name: str) -> hook.HookManager:
+    mgr = _mgrs.get(name)
+    if mgr is None:
+        logger.debug(f"loading hooks for {name}")
+        mgr = hook.HookManager(
+            namespace="fromager.hooks",
+            name=name,
+            invoke_on_load=False,
+            on_load_failure_callback=_die_on_plugin_load_failure,
+        )
+        _mgrs[name] = mgr
+        logger.debug(f"{name} hooks: {mgr.names()}")
+    return mgr
+
+
+def _die_on_plugin_load_failure(
+    mgr: hook.HookManager,
+    ep: extension.Extension,
+    err: Exception,
+):
+    raise RuntimeError(f"failed to load overrides for {ep.name}") from err
+
+
+def run_post_build_hooks(
+    ctx: context.WorkContext,
+    req: Requirement,
+    dist_name: str,
+    dist_version: str,
+    sdist_filename: pathlib.Path,
+    wheel_filename: pathlib.Path,
+):
+    hook_mgr = _get_hooks("post_build")
+    if hook_mgr.names():
+        logger.info(f"{req.name}: starting post-build hooks")
+    for ext in hook_mgr:
+        # NOTE: Each hook is responsible for doing its own logging for
+        # start/stop because we don't have a good name to use here.
+        ext.plugin(
+            ctx=ctx,
+            req=req,
+            dist_name=dist_name,
+            dist_version=dist_version,
+            sdist_filename=sdist_filename,
+            wheel_filename=wheel_filename,
+        )


### PR DESCRIPTION
Add a new extension point for plugging in after a
wheel is built. The hook should have enough
information to, for example, publish the newly
build sdist and wheel to a package index.