### PR TITLE
Add unit test to ensure that extras are applied even with constraints

### DIFF
--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -39,3 +39,11 @@ def test_apply_constraint():
     new_req, constraint = c.get_constrained_requirement(old_req)
     assert new_req == Requirement("torch==2.3.0")
     assert constraint == Requirement("torch==2.3.0")
+
+
+def test_apply_constraint_to_req_with_extras():
+    c = constraints.Constraints({"foo": Requirement("foo==1.1")})
+    old_req = Requirement("foo[bar]>=1.0")
+    new_req, constraint = c.get_constrained_requirement(old_req)
+    assert new_req == Requirement("foo[bar]==1.1")
+    assert constraint == Requirement("foo==1.1")


### PR DESCRIPTION
Ensure that if we have a requirement `foo[bar]>=1.0` and constraint `foo==1.1` then we get a new requirement `foo[bar]==1.1` back i.e. the extra `bar` shouldn't be removed