### PR TITLE
feature: add wheels to download-sequence

### DIFF
--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -94,7 +94,7 @@ def resolve_dist(
         resolvelib.RequirementsConflicted,
         resolvelib.ResolutionImpossible,
     ) as err:
-        logger.warning(f"{req.name}: could not resolve {req}: {err}")
+        logger.debug(f"{req.name}: could not resolve {req}: {err}")
         raise
 
     for candidate in result.mapping.values():


### PR DESCRIPTION
Add an option to download wheels to
download-sequence. This is useful for
pre-populating a development environment with
built wheels to avoid building expensive
dependencies when debugging the bootstrap logic.

Fixes #153 