### PR TITLE
Find duplicates from constraints.txt

### DIFF
--- a/e2e/test_bootstrap.sh
+++ b/e2e/test_bootstrap.sh
@@ -62,6 +62,8 @@ done
 # Verify that the constraints file matches the build order file.
 jq -r '.[] | .dist + "==" + .version' "$OUTDIR/work-dir/build-order.json" > "$OUTDIR/build-order-constraints.txt"
 cat "$OUTDIR/work-dir/constraints.txt" | sed 's/  #.*//g' > "$OUTDIR/constraints-without-comments.txt"
+sort -o "$OUTDIR/constraints-without-comments.txt" "$OUTDIR/constraints-without-comments.txt"
+sort -o "$OUTDIR/build-order-constraints.txt" "$OUTDIR/build-order-constraints.txt"
 if ! diff "$OUTDIR/constraints-without-comments.txt" "$OUTDIR/build-order-constraints.txt";
 then
   echo "FAIL: constraints do not match build order"

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -166,3 +166,315 @@ def test_build_order_name_canonicalization(tmp_context):
         },
     ]
     assert expected == contents
+
+
+def test_processing_alternate_repeating_constraints_file(tmp_context):
+    input = [
+        {
+            "type": "build_backend",
+            "req": "flit-core>1.0",
+            "dist": "flit-core",
+            "version": "3.9.0",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
+            "constraint": "",
+            "why": [
+                ["build_backend", "flit-core>1.0", "3.9.0"],
+            ],
+        },
+        {
+            "type": "build_backend",
+            "req": "wheel>1.0",
+            "dist": "wheel",
+            "version": "3.0.0",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
+            "constraint": "",
+            "why": [
+                ["build_backend", "wheel>1.0", "3.0.0"],
+            ],
+        },
+        {
+            "type": "build_backend",
+            "req": "flit-core>1.0",
+            "dist": "flit-core",
+            "version": "3.10.0",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
+            "constraint": "",
+            "why": [
+                ["build_backend", "flit-core>1.0", "3.10.0"],
+            ],
+        },
+        {
+            "type": "build_backend",
+            "req": "wheel>1.0",
+            "dist": "wheel",
+            "version": "3.4.0",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
+            "constraint": "",
+            "why": [
+                ["build_backend", "wheel>1.0", "3.4.0"],
+            ],
+        },
+        {
+            "type": "build_backend",
+            "req": "requests>1.0",
+            "dist": "requests",
+            "version": "20.0.0",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
+            "constraint": "",
+            "why": [
+                ["build_backend", "requests>1.0", "20.0.0"],
+            ],
+        },
+    ]
+
+    result = tmp_context._process_constraints(input)
+
+    assert result[0]["dist"] == input[0]["dist"]
+    assert result[1]["dist"] == input[2]["dist"]
+    assert result[2]["dist"] == input[1]["dist"]
+    assert result[3]["dist"] == input[3]["dist"]
+    assert result[4]["dist"] == input[4]["dist"]
+
+
+def test_processing_repeating_at_the_end_constraints_file(tmp_context):
+    input = [
+        {
+            "type": "build_backend",
+            "req": "flit-core>1.0",
+            "dist": "flit-core",
+            "version": "3.9.0",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
+            "constraint": "",
+            "why": [
+                ["build_backend", "flit-core>1.0", "3.9.0"],
+            ],
+        },
+        {
+            "type": "build_backend",
+            "req": "requests>1.0",
+            "dist": "requests",
+            "version": "20.0.0",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
+            "constraint": "",
+            "why": [
+                ["build_backend", "requests>1.0", "20.0.0"],
+            ],
+        },
+        {
+            "type": "build_backend",
+            "req": "wheel>1.0",
+            "dist": "wheel",
+            "version": "3.0.0",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
+            "constraint": "",
+            "why": [
+                ["build_backend", "wheel>1.0", "3.0.0"],
+            ],
+        },
+        {
+            "type": "build_backend",
+            "req": "flit-core>1.0",
+            "dist": "flit-core",
+            "version": "3.10.0",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
+            "constraint": "",
+            "why": [
+                ["build_backend", "flit-core>1.0", "3.10.0"],
+            ],
+        },
+        {
+            "type": "build_backend",
+            "req": "wheel>1.0",
+            "dist": "wheel",
+            "version": "3.4.0",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
+            "constraint": "",
+            "why": [
+                ["build_backend", "wheel>1.0", "3.4.0"],
+            ],
+        },
+    ]
+
+    result = tmp_context._process_constraints(input)
+
+    assert result[0]["dist"] == input[0]["dist"]
+    assert result[1]["dist"] == input[3]["dist"]
+    assert result[2]["dist"] == input[2]["dist"]
+    assert result[3]["dist"] == input[4]["dist"]
+    assert result[4]["dist"] == input[1]["dist"]
+
+
+def test_processing_duplicates_at_start_constraints_file(tmp_context):
+    input = [
+        {
+            "type": "build_backend",
+            "req": "flit-core>1.0",
+            "dist": "flit-core",
+            "version": "3.9.0",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
+            "constraint": "",
+            "why": [
+                ["build_backend", "flit-core>1.0", "3.9.0"],
+            ],
+        },
+        {
+            "type": "build_backend",
+            "req": "flit-core>1.0",
+            "dist": "flit-core",
+            "version": "3.10.0",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
+            "constraint": "",
+            "why": [
+                ["build_backend", "flit-core>1.0", "3.10.0"],
+            ],
+        },
+        {
+            "type": "build_backend",
+            "req": "wheel>1.0",
+            "dist": "wheel",
+            "version": "3.0.0",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
+            "constraint": "",
+            "why": [
+                ["build_backend", "wheel>1.0", "3.0.0"],
+            ],
+        },
+        {
+            "type": "build_backend",
+            "req": "wheel>1.0",
+            "dist": "wheel",
+            "version": "3.4.0",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
+            "constraint": "",
+            "why": [
+                ["build_backend", "wheel>1.0", "3.4.0"],
+            ],
+        },
+        {
+            "type": "build_backend",
+            "req": "requests>1.0",
+            "dist": "requests",
+            "version": "20.0.0",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
+            "constraint": "",
+            "why": [
+                ["build_backend", "requests>1.0", "20.0.0"],
+            ],
+        },
+    ]
+
+    result = tmp_context._process_constraints(input)
+
+    assert result[0]["dist"] == input[0]["dist"]
+    assert result[1]["dist"] == input[1]["dist"]
+    assert result[2]["dist"] == input[2]["dist"]
+    assert result[3]["dist"] == input[3]["dist"]
+    assert result[4]["dist"] == input[4]["dist"]
+
+
+def test_processing_repeating_groups_constraints_file(tmp_context):
+    input = [
+        {
+            "type": "build_backend",
+            "req": "flit-core>1.0",
+            "dist": "flit-core",
+            "version": "3.9.0",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
+            "constraint": "",
+            "why": [
+                ["build_backend", "flit-core>1.0", "3.9.0"],
+            ],
+        },
+        {
+            "type": "build_backend",
+            "req": "flit-core>1.0",
+            "dist": "flit-core",
+            "version": "3.10.0",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
+            "constraint": "",
+            "why": [
+                ["build_backend", "flit-core>1.0", "3.10.0"],
+            ],
+        },
+        {
+            "type": "build_backend",
+            "req": "requests>1.0",
+            "dist": "requests",
+            "version": "20.0.0",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
+            "constraint": "",
+            "why": [
+                ["build_backend", "requests>1.0", "20.0.0"],
+            ],
+        },
+        {
+            "type": "build_backend",
+            "req": "wheel>1.0",
+            "dist": "wheel",
+            "version": "3.4.0",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
+            "constraint": "",
+            "why": [
+                ["build_backend", "wheel>1.0", "3.4.0"],
+            ],
+        },
+        {
+            "type": "build_backend",
+            "req": "wheel>1.0",
+            "dist": "wheel",
+            "version": "3.0.0",
+            "prebuilt": False,
+            "source_url": "url",
+            "source_url_type": "sdist",
+            "constraint": "",
+            "why": [
+                ["build_backend", "wheel>1.0", "3.0.0"],
+            ],
+        },
+    ]
+
+    result = tmp_context._process_constraints(input)
+
+    assert result[0]["dist"] == input[0]["dist"]
+    assert result[1]["dist"] == input[1]["dist"]
+    assert result[2]["dist"] == input[3]["dist"]
+    assert result[3]["dist"] == input[4]["dist"]
+    assert result[4]["dist"] == input[2]["dist"]


### PR DESCRIPTION
In this commit, I have created a helper to process duplicate entries in constraints.txt file and shift those to the start of the file as per discussion in https://github.com/python-wheel-build/fromager/issues/151
