### PR TITLE
Give the user an option to use predefined urls to download sdists from

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -424,3 +424,17 @@ def post_build(
         f"{req.name}: running post build hook for {sdist_filename} and {wheel_filename}"
     )
 ```
+
+## Customizations using settings.yaml  
+
+To use predefined urls to download sources from, instead of overriding the entire `download_source` function, a mapping of package to download source url can be provided directly in settings.yaml:
+
+```yaml
+download_source:
+  torch:
+      url: "https://github.com/pytorch/pytorch/releases/download/v${version}/pytorch-v${version}.tar.gz"
+      rename_to: "torch-${version}"
+```
+
+User can define a predefined url for a package from which all its sources will be downloaded from. Optionally they can rename the downloaded sdist to whatever they want. The only supported template variable is `version` - it is replaced by the version returned by the resolver.  
+**Important**: Providing a version mapping doesn't set the version of whats being built. It simply maps a version to something that can be applied to get the sdist download url. If you want to download something with version X and have it built thinking it is version Y, you have to provide your own patch to do that.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -433,8 +433,7 @@ To use predefined urls to download sources from, instead of overriding the entir
 download_source:
   torch:
       url: "https://github.com/pytorch/pytorch/releases/download/v${version}/pytorch-v${version}.tar.gz"
-      rename_to: "torch-${version}"
+      rename_to: "torch-${version}.tar.gz"
 ```
 
-User can define a predefined url for a package from which all its sources will be downloaded from. Optionally they can rename the downloaded sdist to whatever they want. The only supported template variable is `version` - it is replaced by the version returned by the resolver.  
-**Important**: Providing a version mapping doesn't set the version of whats being built. It simply maps a version to something that can be applied to get the sdist download url. If you want to download something with version X and have it built thinking it is version Y, you have to provide your own patch to do that.
+User can define a predefined url for a package from which all its sources will be downloaded from. Optionally they can rename the downloaded sdist to whatever they want. The only supported template variable is `version` - it is replaced by the version returned by the resolver.

--- a/src/fromager/commands/list_overrides.py
+++ b/src/fromager/commands/list_overrides.py
@@ -9,5 +9,7 @@ def list_overrides(
     wkctx: context.WorkContext,
 ):
     """List all of the packages with overrides in the current configuration."""
-    for name in overrides.list_all(wkctx.patches_dir, wkctx.envs_dir):
+    for name in overrides.list_all(
+        wkctx.patches_dir, wkctx.envs_dir, wkctx.settings.download_source()
+    ):
         print(name)

--- a/src/fromager/overrides.py
+++ b/src/fromager/overrides.py
@@ -128,7 +128,12 @@ def find_override_method(distname: str, method: str) -> typing.Callable:
     return getattr(mod, method)
 
 
-def list_all(patches_dir: pathlib.Path, envs_dir: pathlib.Path, test: bool = False):
+def list_all(
+    patches_dir: pathlib.Path,
+    envs_dir: pathlib.Path,
+    download_source: dict[str, dict[str, str]],
+    test: bool = False,
+):
     exts = _get_extensions()
 
     def patched_projects():
@@ -162,6 +167,9 @@ def list_all(patches_dir: pathlib.Path, envs_dir: pathlib.Path, test: bool = Fal
         for item in envs_dir.glob("*/*.env"):
             yield item.stem
 
+    def projects_with_predefined_download_source():
+        yield from download_source
+
     # Use canonicalize_name() to ensure we can correctly remove duplicate
     # entries from the return list.
     return sorted(
@@ -172,6 +180,7 @@ def list_all(patches_dir: pathlib.Path, envs_dir: pathlib.Path, test: bool = Fal
                 patched_projects(),
                 patched_projects_legacy(),
                 env_projects(),
+                projects_with_predefined_download_source(),
             )
             if not test
             or n != "fromager_test"  # filter out test package except in test mode

--- a/src/fromager/settings.py
+++ b/src/fromager/settings.py
@@ -17,6 +17,19 @@ class Settings:
         names = p.get(variant) or []
         return set(overrides.pkgname_to_override_module(n) for n in names)
 
+    def download_source(self) -> dict[str, dict[str, str]]:
+        return self._data.get("download_source") or {}
+
+    def sdist_download_url(self, pkg: str) -> str | None:
+        p = self.download_source()
+        download_source = p.get(pkg) or {}
+        return download_source.get("url")
+
+    def sdist_local_filename(self, pkg: str) -> str | None:
+        p = self.download_source()
+        download_source = p.get(pkg) or {}
+        return download_source.get("rename_to")
+
 
 def _parse(content: str) -> Settings:
     data = yaml.safe_load(content)

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -92,7 +92,7 @@ def test_extra_environ_for_pkg_expansion(tmp_path: pathlib.Path):
         extra_environ = overrides.extra_environ_for_pkg(tmp_path, pkg_name, variant)
 
 
-def test_list_all(tmp_path):
+def test_list_all(tmp_path: pathlib.Path):
     patches_dir = tmp_path / "patches"
     patches_dir.mkdir()
 
@@ -124,17 +124,25 @@ def test_list_all(tmp_path):
     project_env2 = variant_dir / "fromager_test.env"
     project_env2.write_text("VAR1=VALUE1\nVAR2=VALUE2")  # duplicate
 
+    download_source = {
+        "project-with-download-source": {"url": "url"},
+        "another-project-with-download-source": {"url": "url"},
+    }
+
     expected = [
         "project-with-patch",
         "legacy-project",
         "project-with-env",
         "fromager-test",
+        "project-with-download-source",
+        "another-project-with-download-source",
     ]
     expected.sort()
 
     packages = overrides.list_all(
         patches_dir=patches_dir,
         envs_dir=env_dir,
+        download_source=download_source,
         test=True,
     )
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -27,3 +27,28 @@ def test_with_pre_built():
     """)
     )
     assert s.pre_built("cuda") == set(["a", "b"])
+
+
+def test_with_download_source():
+    s = settings._parse(
+        textwrap.dedent("""
+    download_source:
+      foo:
+        url: url
+        rename_to: rename
+    """)
+    )
+    assert s.sdist_local_filename("foo") == "rename"
+    assert s.sdist_local_filename("bar") is None
+    assert s.sdist_download_url("foo") == "url"
+    assert s.sdist_download_url("bar") is None
+
+
+def test_no_download_source():
+    s = settings._parse(
+        textwrap.dedent("""
+    pre_built:
+    """)
+    )
+    assert s.sdist_local_filename("foo") is None
+    assert s.sdist_download_url("foo") is None

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,9 +1,11 @@
 import pathlib
+import typing
 from unittest.mock import patch
 
 import pytest
+from packaging.requirements import Requirement
 
-from fromager import sources
+from fromager import context, settings, sources
 
 
 @patch("fromager.sources.download_url")
@@ -16,3 +18,69 @@ def test_invalid_tarfile(mock_download_url, tmp_path: pathlib.Path):
     text_file.write_text("This is a test file")
     with pytest.raises(TypeError):
         sources._download_source_check(fake_dir, fake_url)
+
+
+def test_resolve_template_with_no_template():
+    req = Requirement("foo==1.0")
+    assert sources._resolve_template(None, req, "1.0") is None
+
+
+def test_resolve_template_with_version():
+    req = Requirement("foo==1.0")
+    assert sources._resolve_template("url-${version}", req, "1.0") == "url-1.0"
+
+
+def test_resolve_template_with_no_matching_template():
+    req = Requirement("foo==1.0")
+    with pytest.raises(KeyError):
+        sources._resolve_template("url-${flag}", req, "1.0")
+
+
+@patch("fromager.sources.resolve_dist")
+@patch("fromager.sources._download_source_check")
+@patch.object(settings.Settings, "sdist_download_url")
+@patch.object(settings.Settings, "sdist_local_filename")
+def test_default_download_source_no_predefined_url(
+    sdist_local_filename: typing.Callable,
+    sdist_download_url: typing.Callable,
+    download_source_check: typing.Callable,
+    resolve_dist: typing.Callable,
+    tmp_context: context.WorkContext,
+):
+    resolve_dist.return_value = ("url", "1.0")
+    download_source_check.return_value = pathlib.Path("filename.zip")
+    sdist_download_url.return_value = None
+    sdist_local_filename.return_value = None
+    req = Requirement("foo==1.0")
+    sdist_server_url = sources.PYPI_SERVER_URL
+
+    sources.default_download_source(tmp_context, req, sdist_server_url)
+
+    resolve_dist.assert_called_with(tmp_context, req, sdist_server_url, True, False)
+    download_source_check.assert_called_with(tmp_context.sdists_downloads, "url", None)
+
+
+@patch("fromager.sources.resolve_dist")
+@patch("fromager.sources._download_source_check")
+@patch.object(settings.Settings, "sdist_download_url")
+@patch.object(settings.Settings, "sdist_local_filename")
+def test_default_download_source_with_predefined_url(
+    sdist_local_filename: typing.Callable,
+    sdist_download_url: typing.Callable,
+    download_source_check: typing.Callable,
+    resolve_dist: typing.Callable,
+    tmp_context: context.WorkContext,
+):
+    resolve_dist.return_value = ("url", "1.0")
+    download_source_check.return_value = pathlib.Path("filename")
+    sdist_download_url.return_value = "predefined_url-${version}"
+    sdist_local_filename.return_value = "foo-${version}"
+    req = Requirement("foo==1.0")
+    sdist_server_url = sources.PYPI_SERVER_URL
+
+    sources.default_download_source(tmp_context, req, sdist_server_url)
+
+    resolve_dist.assert_called_with(tmp_context, req, sdist_server_url, False, True)
+    download_source_check.assert_called_with(
+        tmp_context.sdists_downloads, "predefined_url-1.0", "foo-1.0"
+    )


### PR DESCRIPTION
Fixes #138 

User can provide a mapping of package to download source url in `settings.yaml`:

```yaml
download_source:
  torch:
      url: "https://github.com/pytorch/pytorch/releases/download/v${version}/pytorch-v${version}.tar.gz"
      rename_to: "torch-${version}"
```

User can define a predefined url for a package from which all its sources will be downloaded from. Optionally they can rename the downloaded sdist to whatever they want.

The only supported template variables are: `version`. `version` is replaced by the version returned by the resolver.