### PR TITLE
catch errors when trying to download wheels from cli

### DIFF
--- a/src/fromager/commands/download_sequence.py
+++ b/src/fromager/commands/download_sequence.py
@@ -55,9 +55,12 @@ def download_sequence(
                 )
 
             if include_wheels:
-                sdist.download_wheel(
-                    wkctx,
-                    req,
-                    wkctx.wheels_downloads,
-                    wheel_servers,
-                )
+                try:
+                    sdist.download_wheel(
+                        wkctx,
+                        req,
+                        wkctx.wheels_downloads,
+                        wheel_servers,
+                    )
+                except Exception as err:
+                    logger.error(f"Failed to download wheel for {req}: {err}")

--- a/src/fromager/sdist.py
+++ b/src/fromager/sdist.py
@@ -256,7 +256,7 @@ def download_wheel(
     wheel_filename = output_directory / os.path.basename(urlparse(wheel_url).path)
     if not wheel_filename.exists():
         logger.info(f"{req.name}: downloading pre-built wheel {wheel_url}")
-        wheel_filename = sources.download_url(ctx.wheels_prebuilt, wheel_url)
+        wheel_filename = sources.download_url(output_directory, wheel_url)
         logger.info(f"{req.name}: saved wheel to {wheel_filename}")
     else:
         logger.info(f"{req.name}: have existing wheel {wheel_filename}")


### PR DESCRIPTION
When download-sequence tries to download pre-built
wheels, sometimes it finds packages that are only
available as source distributions. We can ignore
those errors because we will build the wheels
ourselves.