### PR TITLE
optimize sdist production during bootstrapping

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,6 +70,7 @@ jobs:
           - report_missing_dependency
           - rust_vendor
           - download_sequence
+          - optimize_build
 
     steps:
       - name: Get source

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -70,6 +70,10 @@ pull_request_rules:
           - check-success=e2e (3.11, 1.75, download_sequence)
           - check-success=e2e (3.12, 1.75, download_sequence)
 
+          - check-success=e2e (3.10, 1.75, optimize_build)
+          - check-success=e2e (3.11, 1.75, optimize_build)
+          - check-success=e2e (3.12, 1.75, optimize_build)
+
           - '-draft'
 
           # At least 1 reviewer

--- a/e2e/test_optimize_build.sh
+++ b/e2e/test_optimize_build.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# -*- indent-tabs-mode: nil; tab-width: 2; sh-indentation: 2; -*-
+
+set -x
+set -e
+set -o pipefail
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
+
+rm -rf "$OUTDIR"
+mkdir "$OUTDIR"
+
+tox -e e2e -n -r
+source .tox/e2e/bin/activate
+
+fromager \
+  --sdists-repo="$OUTDIR/sdists-repo" \
+  --wheels-repo="$OUTDIR/wheels-repo" \
+  --work-dir="$OUTDIR/work-dir" \
+  --log-file="$OUTDIR/logfile.txt" \
+  bootstrap 'stevedore==5.2.0'
+
+pass=true
+
+if  grep -q "have sdist version" "$OUTDIR/logfile.txt"; then
+    echo "Failed to build source distribution"
+    pass=false
+fi
+
+rm -rf "$OUTDIR/wheels-repo/downloads"
+rm -rf "$OUTDIR/logfile.txt"
+
+fromager \
+  --sdists-repo="$OUTDIR/sdists-repo" \
+  --wheels-repo="$OUTDIR/wheels-repo" \
+  --work-dir="$OUTDIR/work-dir" \
+  --log-file="$OUTDIR/logfile.txt" \
+  bootstrap 'stevedore==5.2.0'
+
+if ! grep -q "have sdist version" "$OUTDIR/logfile.txt"; then
+    echo "Building source distribution from scratch even after sdist exists"
+    pass=false
+fi
+
+rm -rf "$OUTDIR/sdists-repo/builds"
+rm -rf "$OUTDIR/wheels-repo/downloads"
+rm -rf "$OUTDIR/logfile.txt"
+
+fromager \
+  --sdists-repo="$OUTDIR/sdists-repo" \
+  --wheels-repo="$OUTDIR/wheels-repo" \
+  --work-dir="$OUTDIR/work-dir" \
+  --log-file="$OUTDIR/logfile.txt" \
+  bootstrap 'stevedore==5.2.0'
+
+if  grep -q "have sdist version" "$OUTDIR/logfile.txt"; then
+    echo "Failed to build source distribution"
+    pass=false
+fi
+
+rm -rf "$OUTDIR/logfile.txt"
+$pass

--- a/src/fromager/sdist.py
+++ b/src/fromager/sdist.py
@@ -195,7 +195,15 @@ def handle_requirement(
                 | build_sdist_dependencies,
             )
             try:
-                sources.build_sdist(ctx, req, sdist_root_dir)
+                find_sdist_result = finders.find_sdist(
+                    ctx.sdists_builds, req, resolved_version
+                )
+                if not find_sdist_result:
+                    sources.build_sdist(ctx, req, sdist_root_dir)
+                else:
+                    logger.info(
+                        f"{req.name} have sdist version {resolved_version}: {find_sdist_result}"
+                    )
             except Exception as err:
                 logger.warning(
                     f"{req.name}: failed to build source distribution: {err}"


### PR DESCRIPTION
I added to check whether sdist is already built before. If I get a `None`, call to `build_sdist()` 

1. Should there be anything in the `else` case? (Reference to my latest comment on issue)
2. Should I include a unit test for this?