### PR TITLE
Add caching to dependency resolution

### DIFF
--- a/src/fromager/dependencies.py
+++ b/src/fromager/dependencies.py
@@ -152,21 +152,6 @@ def default_get_build_sdist_dependencies(
     return hook_caller.get_requires_for_build_wheel()
 
 
-def get_install_dependencies(
-    ctx: context.WorkContext,
-    req: Requirement,
-    sdist_root_dir: pathlib.Path,
-) -> set[Requirement]:
-    logger.info(
-        f"{req.name}: getting installation dependencies for {req} in {sdist_root_dir}"
-    )
-    dep_func = overrides.find_override_method(req.name, "get_install_dependencies")
-    if not dep_func:
-        dep_func = default_get_install_dependencies
-    deps = _filter_requirements(req, dep_func(ctx, req, sdist_root_dir))
-    return deps
-
-
 def get_install_dependencies_of_wheel(
     req: Requirement, wheel_filename: pathlib.Path, requirements_file_dir: pathlib.Path
 ) -> set[Requirement]:

--- a/src/fromager/dependencies.py
+++ b/src/fromager/dependencies.py
@@ -24,10 +24,23 @@ def get_build_system_dependencies(
     logger.info(
         f"{req.name}: getting build system dependencies for {req} in {sdist_root_dir}"
     )
+
+    build_system_req_file = sdist_root_dir.parent / "build-system-requirements.txt"
+    if build_system_req_file.exists():
+        logger.info(
+            f"{req.name}: {build_system_req_file} already exists. Loading build system dependencies from {build_system_req_file.name}"
+        )
+        return _read_requirements_file(build_system_req_file)
+
     dep_func = overrides.find_override_method(req.name, "get_build_system_dependencies")
     if not dep_func:
         dep_func = default_get_build_system_dependencies
     deps = _filter_requirements(req, dep_func(ctx, req, sdist_root_dir))
+
+    _write_requirements_file(
+        deps,
+        build_system_req_file,
+    )
     return deps
 
 
@@ -63,12 +76,25 @@ def get_build_backend_dependencies(
     logger.info(
         f"{req.name}: getting build backend dependencies for {req} in {sdist_root_dir}"
     )
+
+    build_backend_req_file = sdist_root_dir.parent / "build-backend-requirements.txt"
+    if build_backend_req_file.exists():
+        logger.info(
+            f"{req.name}: {build_backend_req_file} already exists. Loading build backend dependencies from {build_backend_req_file.name}"
+        )
+        return _read_requirements_file(build_backend_req_file)
+
     dep_func = overrides.find_override_method(
         req.name, "get_build_backend_dependencies"
     )
     if not dep_func:
         dep_func = default_get_build_backend_dependencies
     deps = _filter_requirements(req, dep_func(ctx, req, sdist_root_dir))
+
+    _write_requirements_file(
+        deps,
+        build_backend_req_file,
+    )
     return deps
 
 
@@ -93,10 +119,23 @@ def get_build_sdist_dependencies(
     logger.info(
         f"{req.name}: getting build sdist dependencies for {req} in {sdist_root_dir}"
     )
+
+    build_sdist_req_file = sdist_root_dir.parent / "build-sdist-requirements.txt"
+    if build_sdist_req_file.exists():
+        logger.info(
+            f"{req.name}: {build_sdist_req_file} already exists. Loading build sdist dependencies from {build_sdist_req_file.name}"
+        )
+        return _read_requirements_file(build_sdist_req_file)
+
     dep_func = overrides.find_override_method(req.name, "get_build_sdist_dependencies")
     if not dep_func:
         dep_func = default_get_build_sdist_dependencies
     deps = _filter_requirements(req, dep_func(ctx, req, sdist_root_dir))
+
+    _write_requirements_file(
+        deps,
+        build_sdist_req_file,
+    )
     return deps
 
 
@@ -129,11 +168,16 @@ def get_install_dependencies(
 
 
 def get_install_dependencies_of_wheel(
-    req: Requirement, wheel_filename: pathlib.Path
+    req: Requirement, wheel_filename: pathlib.Path, requirements_file_dir: pathlib.Path
 ) -> set[Requirement]:
     logger.info(f"{req.name}: getting installation dependencies from {wheel_filename}")
     wheel = pkginfo.Wheel(wheel_filename)
-    return _filter_requirements(req, wheel.requires_dist)
+    deps = _filter_requirements(req, wheel.requires_dist)
+    _write_requirements_file(
+        deps,
+        requirements_file_dir / "requirements.txt",
+    )
+    return deps
 
 
 def default_get_install_dependencies(
@@ -215,3 +259,19 @@ def get_build_backend_hook_caller(
         backend_path=backend["backend-path"],
         runner=_run_hook_with_extra_environ,
     )
+
+
+def _write_requirements_file(
+    requirements: typing.Iterable[Requirement],
+    filename: pathlib.Path,
+):
+    with open(filename, "w") as f:
+        for r in requirements:
+            f.write(f"{r}\n")
+
+
+def _read_requirements_file(
+    filename: pathlib.Path,
+) -> set[Requirement] | None:
+    lines = requirements_file.parse_requirements_file(filename)
+    return set([Requirement(line) for line in lines])

--- a/src/fromager/dependencies.py
+++ b/src/fromager/dependencies.py
@@ -28,7 +28,7 @@ def get_build_system_dependencies(
     build_system_req_file = sdist_root_dir.parent / "build-system-requirements.txt"
     if build_system_req_file.exists():
         logger.info(
-            f"{req.name}: {build_system_req_file} already exists. Loading build system dependencies from {build_system_req_file.name}"
+            f"{req.name}: loading build system dependencies from {build_system_req_file.name}"
         )
         return _read_requirements_file(build_system_req_file)
 
@@ -80,7 +80,7 @@ def get_build_backend_dependencies(
     build_backend_req_file = sdist_root_dir.parent / "build-backend-requirements.txt"
     if build_backend_req_file.exists():
         logger.info(
-            f"{req.name}: {build_backend_req_file} already exists. Loading build backend dependencies from {build_backend_req_file.name}"
+            f"{req.name}: loading build backend dependencies from {build_backend_req_file.name}"
         )
         return _read_requirements_file(build_backend_req_file)
 
@@ -123,7 +123,7 @@ def get_build_sdist_dependencies(
     build_sdist_req_file = sdist_root_dir.parent / "build-sdist-requirements.txt"
     if build_sdist_req_file.exists():
         logger.info(
-            f"{req.name}: {build_sdist_req_file} already exists. Loading build sdist dependencies from {build_sdist_req_file.name}"
+            f"{req.name}: loading build sdist dependencies from {build_sdist_req_file.name}"
         )
         return _read_requirements_file(build_sdist_req_file)
 

--- a/src/fromager/sdist.py
+++ b/src/fromager/sdist.py
@@ -462,15 +462,6 @@ def prepare_build_environment(
     return build_env.path
 
 
-def _write_requirements_file(
-    requirements: typing.Iterable[Requirement],
-    filename: pathlib.Path,
-):
-    with open(filename, "w") as f:
-        for r in requirements:
-            f.write(f"{r}\n")
-
-
 def _maybe_install(
     ctx: context.WorkContext,
     req: Requirement,

--- a/src/fromager/sdist.py
+++ b/src/fromager/sdist.py
@@ -213,12 +213,9 @@ def handle_requirement(
     # Process installation dependencies for all wheels.
     next_req_type = "install"
     install_dependencies = dependencies.get_install_dependencies_of_wheel(
-        req, wheel_filename
+        req, wheel_filename, unpack_dir
     )
-    _write_requirements_file(
-        install_dependencies,
-        unpack_dir / "requirements.txt",
-    )
+
     for dep in _sort_requirements(install_dependencies):
         try:
             handle_requirement(ctx, dep, next_req_type, why)
@@ -310,10 +307,7 @@ def _handle_build_system_requirements(
     build_system_dependencies = dependencies.get_build_system_dependencies(
         ctx, req, sdist_root_dir
     )
-    _write_requirements_file(
-        build_system_dependencies,
-        sdist_root_dir.parent / "build-system-requirements.txt",
-    )
+
     for dep in _sort_requirements(build_system_dependencies):
         try:
             resolved = handle_requirement(ctx, dep, "build-system", why)
@@ -337,10 +331,7 @@ def _handle_build_backend_requirements(
     build_backend_dependencies = dependencies.get_build_backend_dependencies(
         ctx, req, sdist_root_dir
     )
-    _write_requirements_file(
-        build_backend_dependencies,
-        sdist_root_dir.parent / "build-backend-requirements.txt",
-    )
+
     for dep in _sort_requirements(build_backend_dependencies):
         try:
             resolved = handle_requirement(ctx, dep, "build-backend", why)
@@ -364,10 +355,7 @@ def _handle_build_sdist_requirements(
     build_sdist_dependencies = dependencies.get_build_sdist_dependencies(
         ctx, req, sdist_root_dir
     )
-    _write_requirements_file(
-        build_sdist_dependencies,
-        sdist_root_dir.parent / "build-sdist-requirements.txt",
-    )
+
     for dep in _sort_requirements(build_sdist_dependencies):
         try:
             resolved = handle_requirement(ctx, dep, "build-sdist", why)
@@ -390,10 +378,7 @@ def prepare_build_environment(
     build_system_dependencies = dependencies.get_build_system_dependencies(
         ctx, req, sdist_root_dir
     )
-    _write_requirements_file(
-        build_system_dependencies,
-        sdist_root_dir.parent / "build-system-requirements.txt",
-    )
+
     for dep in build_system_dependencies:
         # We may need these dependencies installed in order to run build hooks
         # Example: frozenlist build-system.requires includes expandvars because
@@ -415,10 +400,7 @@ def prepare_build_environment(
     build_backend_dependencies = dependencies.get_build_backend_dependencies(
         ctx, req, sdist_root_dir
     )
-    _write_requirements_file(
-        build_backend_dependencies,
-        sdist_root_dir.parent / "build-backend-requirements.txt",
-    )
+
     for dep in build_backend_dependencies:
         # Build backends are often used to package themselves, so in
         # order to determine their dependencies they may need to be
@@ -440,10 +422,7 @@ def prepare_build_environment(
     build_sdist_dependencies = dependencies.get_build_sdist_dependencies(
         ctx, req, sdist_root_dir
     )
-    _write_requirements_file(
-        build_sdist_dependencies,
-        sdist_root_dir.parent / "build-sdist-requirements.txt",
-    )
+
     for dep in build_sdist_dependencies:
         try:
             _maybe_install(ctx, dep, next_req_type, None)

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -94,17 +94,3 @@ def test_get_build_sdist_dependencies(tmp_context: context.WorkContext):
     )
     names = set(r.name for r in results)
     assert names == set()
-
-
-@_clean_build_artifacts
-def test_get_install_dependencies(tmp_context: context.WorkContext):
-    pyproject_contents = dependencies.get_pyproject_contents(_fromager_root)
-    expected = set(
-        Requirement(d) for d in pyproject_contents["project"]["dependencies"]
-    )
-    actual = dependencies.get_install_dependencies(
-        tmp_context,
-        Requirement("fromager"),
-        _fromager_root,
-    )
-    assert actual == expected

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -74,6 +74,20 @@ def test_get_build_system_dependencies(tmp_context: context.WorkContext):
     assert names == set(["setuptools", "setuptools_scm"])
 
 
+def test_get_build_system_dependencies_cached(
+    tmp_context: context.WorkContext, tmp_path: pathlib.Path
+):
+    sdist_root_dir = tmp_path / "sdist"
+    sdist_root_dir.mkdir()
+
+    req_file = tmp_path / "build-system-requirements.txt"
+    req_file.write_text("foo==1.0")
+    results = dependencies.get_build_system_dependencies(
+        tmp_context, Requirement("fromager"), sdist_root_dir
+    )
+    assert results == set([Requirement("foo==1.0")])
+
+
 @_clean_build_artifacts
 def test_get_build_backend_dependencies(tmp_context: context.WorkContext):
     results = dependencies.get_build_backend_dependencies(
@@ -85,6 +99,20 @@ def test_get_build_backend_dependencies(tmp_context: context.WorkContext):
     assert names == set()
 
 
+def test_get_build_backend_dependencies_cached(
+    tmp_context: context.WorkContext, tmp_path: pathlib.Path
+):
+    sdist_root_dir = tmp_path / "sdist"
+    sdist_root_dir.mkdir()
+
+    req_file = tmp_path / "build-backend-requirements.txt"
+    req_file.write_text("foo==1.0")
+    results = dependencies.get_build_backend_dependencies(
+        tmp_context, Requirement("fromager"), sdist_root_dir
+    )
+    assert results == set([Requirement("foo==1.0")])
+
+
 @_clean_build_artifacts
 def test_get_build_sdist_dependencies(tmp_context: context.WorkContext):
     results = dependencies.get_build_sdist_dependencies(
@@ -94,3 +122,17 @@ def test_get_build_sdist_dependencies(tmp_context: context.WorkContext):
     )
     names = set(r.name for r in results)
     assert names == set()
+
+
+def test_get_build_sdist_dependencies_cached(
+    tmp_context: context.WorkContext, tmp_path: pathlib.Path
+):
+    sdist_root_dir = tmp_path / "sdist"
+    sdist_root_dir.mkdir()
+
+    req_file = tmp_path / "build-sdist-requirements.txt"
+    req_file.write_text("foo==1.0")
+    results = dependencies.get_build_sdist_dependencies(
+        tmp_context, Requirement("fromager"), sdist_root_dir
+    )
+    assert results == set([Requirement("foo==1.0")])


### PR DESCRIPTION
fixes #167 

Before resolving and getting requirements for dependency resolution, it checks first to see if the requirements have been produced before and if they have then they are loaded in from the file they were written to instead of resolving them again.