### PR TITLE
fix reading requirements files for bootstrapping

### DIFF
--- a/src/fromager/commands/bootstrap.py
+++ b/src/fromager/commands/bootstrap.py
@@ -17,8 +17,10 @@ def _get_requirements_from_args(
     to_build = []
     to_build.extend(("toplevel", t) for t in toplevel)
     for filename in req_files:
-        parsed_req = requirements_file.parse_requirements_file(req_files)
-        to_build.extend((filename, req) for req in parsed_req)
+        to_build.extend(
+            (str(filename), req)
+            for req in requirements_file.parse_requirements_file(filename)
+        )
     return to_build
 
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,5 +1,4 @@
-import typing
-from unittest.mock import patch
+import pathlib
 
 from fromager.commands import bootstrap
 
@@ -14,10 +13,9 @@ def test_get_requirements_multiple_args():
     assert [("toplevel", "a"), ("toplevel", "b")] == requirements
 
 
-@patch("fromager.requirements_file.parse_requirements_file")
-def test_get_requirements_args_and_file(parse_requirements_file: typing.Callable):
-    requirements_file = "requirements.txt"
-    parse_requirements_file.return_value = ["c"]
+def test_get_requirements_args_and_file(tmp_path: pathlib.Path):
+    requirements_file = tmp_path / "requirements.txt"
+    requirements_file.write_text("c\n")
     requirements = bootstrap._get_requirements_from_args(
         ["a", "b"], [requirements_file]
     )


### PR DESCRIPTION
The requirements files are always passed from click as a sequence, even
if there is only one value. We need to iterate over them and convert
the filename to a string and parse each file individually. This change
fixes the parsing function and updates the unit test to ensure that it
works correctly by actually trying to parse files instead of mocking the
return value.