### PR TITLE
fix filtering based on markers during bootstrapping

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,6 +63,7 @@ jobs:
         test-script:
           - bootstrap
           - bootstrap_constraint
+          - bootstrap_extras
           - build
           - build_order
           - build_steps

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -42,6 +42,10 @@ pull_request_rules:
           - check-success=e2e (3.11, 1.75, bootstrap_constraint)
           - check-success=e2e (3.12, 1.75, bootstrap_constraint)
 
+          - check-success=e2e (3.10, 1.75, bootstrap_extras)
+          - check-success=e2e (3.11, 1.75, bootstrap_extras)
+          - check-success=e2e (3.12, 1.75, bootstrap_extras)
+
           - check-success=e2e (3.10, 1.75, build)
           - check-success=e2e (3.11, 1.75, build)
           - check-success=e2e (3.12, 1.75, build)

--- a/e2e/bootstrap_extras.txt
+++ b/e2e/bootstrap_extras.txt
@@ -1,0 +1,2 @@
+requests[socks]==2.32.3
+stevedore ; python_version < "3.7"  # should not be included in output of test

--- a/e2e/test_bootstrap_extras.sh
+++ b/e2e/test_bootstrap_extras.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# -*- indent-tabs-mode: nil; tab-width: 2; sh-indentation: 2; -*-
+
+# Tests full bootstrap with packages that have extras.
+
+set -x
+set -e
+set -o pipefail
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
+
+rm -rf "$OUTDIR"
+mkdir "$OUTDIR"
+
+tox -e e2e -n -r
+source .tox/e2e/bin/activate
+
+fromager \
+  --log-file="$OUTDIR/test.log" \
+  --sdists-repo="$OUTDIR/sdists-repo" \
+  --wheels-repo="$OUTDIR/wheels-repo" \
+  --work-dir="$OUTDIR/work-dir" \
+  bootstrap -r "${SCRIPTDIR}/bootstrap_extras.txt"
+
+find "$OUTDIR/wheels-repo/" -name '*.whl'
+find "$OUTDIR/sdists-repo/" -name '*.tar.gz'
+ls "$OUTDIR"/work-dir/*/build.log || true
+
+UNEXPECTED_FILES="
+$OUTDIR/wheels-repo/downloads/stevedore-*.whl
+$OUTDIR/sdists-repo/downloads/stevedore-*.tar.gz
+$OUTDIR/sdists-repo/builds/stevedore-*.tar.gz
+$OUTDIR/work-dir/stevedore-*/build.log
+"
+
+pass=true
+
+for pattern in $UNEXPECTED_FILES; do
+  if [ -f "${pattern}" ]; then
+    echo "Found unexpected file $pattern" 1>&2
+    pass=false
+  fi
+done
+
+EXPECTED_FILES="
+$OUTDIR/wheels-repo/downloads/setuptools-*.whl
+$OUTDIR/sdists-repo/downloads/setuptools-*.tar.gz
+$OUTDIR/sdists-repo/builds/setuptools-*.tar.gz
+$OUTDIR/work-dir/setuptools-*/build.log
+
+$OUTDIR/wheels-repo/downloads/PySocks-*.whl
+$OUTDIR/sdists-repo/downloads/PySocks-*.tar.gz
+$OUTDIR/sdists-repo/builds/PySocks-*.tar.gz
+$OUTDIR/work-dir/PySocks-*/build.log
+"
+
+for pattern in $EXPECTED_FILES; do
+  if [ ! -f "${pattern}" ]; then
+    echo "Did not find file $pattern" 1>&2
+    pass=false
+  fi
+done
+
+# Verify that the constraints file matches the build order file.
+jq -r '.[] | .dist + "==" + .version' "$OUTDIR/work-dir/build-order.json" > "$OUTDIR/build-order-constraints.txt"
+cat "$OUTDIR/work-dir/constraints.txt" | sed 's/  #.*//g' > "$OUTDIR/constraints-without-comments.txt"
+sort -o "$OUTDIR/constraints-without-comments.txt" "$OUTDIR/constraints-without-comments.txt"
+sort -o "$OUTDIR/build-order-constraints.txt" "$OUTDIR/build-order-constraints.txt"
+if ! diff "$OUTDIR/constraints-without-comments.txt" "$OUTDIR/build-order-constraints.txt";
+then
+  echo "FAIL: constraints do not match build order"
+  pass=false
+fi
+
+$pass

--- a/src/fromager/sdist.py
+++ b/src/fromager/sdist.py
@@ -68,9 +68,16 @@ def handle_requirement(
 ) -> str:
     if why is None:
         why = []
-    if not requirements_file.evaluate_marker(req, req):
+    # If we're given a requirements file as input, we might be iterating over a
+    # list of requirements with marker expressions that limit their use to
+    # specific platforms or python versions. Evaluate the markers to filter out
+    # anything we shouldn't build. Only apply the filter to toplevel
+    # requirements (items without a why list leading up to them) because other
+    # dependencies are already filtered based on their markers in the context of
+    # their parent, so they include values like the parent's extras settings.
+    if (not why) and (not requirements_file.evaluate_marker(req, req)):
         logger.info(
-            f"{req.name}: ignoring {req_type} dependency because of its marker expression"
+            f"{req.name}: ignoring {req_type} dependency {req} because of its marker expression"
         )
         return ""
     logger.info(


### PR DESCRIPTION
If we're given a requirements file as input, we
might be iterating over a list of requirements
with marker expressions that limit their use to
specific platforms or python versions. Evaluate
the markers to filter out anything we shouldn't
build. Only apply the filter to toplevel
requirements (items without a why list leading up
to them) because other dependencies are already
filtered based on their markers in the context of
their parent, so they include values like the
parent's extras settings.

Fixes #182