### PR TITLE
This PR adds code to calculate time taken to build a wheel

### DIFF
--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -78,8 +78,6 @@ def build_wheel(
     logger.info(
         f"{req.name}: building wheel for {req} in {sdist_root_dir} writing to {ctx.wheels_build}"
     )
-    # Start the timer
-    start = datetime.now().replace(microsecond=0)
 
     builder = overrides.find_override_method(req.name, "build_wheel")
     if not builder:
@@ -96,12 +94,16 @@ def build_wheel(
         extra_environ["CMAKE_BUILD_PARALLEL_LEVEL"] = f"{ctx.jobs}"
         extra_environ["MAX_JOBS"] = f"{ctx.jobs}"
 
+    # Start the timer
+    start = datetime.now().replace(microsecond=0)
+
     builder(ctx, build_env, extra_environ, req, sdist_root_dir)
-    wheels = list(ctx.wheels_build.glob("*.whl"))
 
     # End the timer
     end = datetime.now().replace(microsecond=0)
-    logger.info(f"Time taken to build wheel for {req.name}: {end - start}")
+
+    wheels = list(ctx.wheels_build.glob("*.whl"))
+    logger.info(f"{req.name}: time taken to build wheel {end - start}")
 
     if wheels:
         return wheels[0]

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -5,6 +5,7 @@ import platform
 import sys
 import tempfile
 import typing
+from datetime import datetime
 
 from packaging.requirements import Requirement
 
@@ -77,6 +78,9 @@ def build_wheel(
     logger.info(
         f"{req.name}: building wheel for {req} in {sdist_root_dir} writing to {ctx.wheels_build}"
     )
+    # Start the timer
+    start = datetime.now().replace(microsecond=0)
+
     builder = overrides.find_override_method(req.name, "build_wheel")
     if not builder:
         builder = default_build_wheel
@@ -94,6 +98,11 @@ def build_wheel(
 
     builder(ctx, build_env, extra_environ, req, sdist_root_dir)
     wheels = list(ctx.wheels_build.glob("*.whl"))
+
+    # End the timer
+    end = datetime.now().replace(microsecond=0)
+    logger.info(f"Time taken to build wheel for {req.name}: {end - start}")
+
     if wheels:
         return wheels[0]
     return None


### PR DESCRIPTION
I have used the time format as `hh:mm:ss` and ignored the milliseconds. Let me know if we want milliseconds as well.
Also, I have used the log message in `build_wheel()` to log this time required as `build_wheel()` is the function called by bootstrap, build and build-sequence.

Let me know if any changes are required!