### PR TITLE
add the build environment when calling build_sdist

### DIFF
--- a/e2e/test_build_steps.sh
+++ b/e2e/test_build_steps.sh
@@ -49,7 +49,13 @@ pypi-mirror create -d "$OUTDIR/wheels-repo/downloads/" -m "$OUTDIR/wheels-repo/s
 # because podman won't see the server via localhost.
 python3 -m http.server --directory "$OUTDIR/wheels-repo/" 9999 &
 HTTP_SERVER_PID=$!
-IP=$(ip route get 1.1.1.1 | grep 1.1.1.1 | awk '{print $7}')
+if which ip 2>&1 >/dev/null; then
+    # Linux
+    IP=$(ip route get 1.1.1.1 | grep 1.1.1.1 | awk '{print $7}')
+else
+    # macOS
+    IP=$(ipconfig getifaddr en0)
+fi
 export WHEEL_SERVER_URL="http://${IP}:9999/simple"
 
 # Define the function used in the build script

--- a/src/fromager/commands/build.py
+++ b/src/fromager/commands/build.py
@@ -107,12 +107,18 @@ def _build(
 
     # Build environment
     sdist.prepare_build_environment(wkctx, req, source_root_dir)
+    build_env = wheels.BuildEnvironment(wkctx, source_root_dir.parent, None)
 
     # Make a new source distribution, in case we patched the code.
-    sdist_filename = sources.build_sdist(wkctx, req, source_root_dir, dist_version)
+    sdist_filename = sources.build_sdist(
+        ctx=wkctx,
+        req=req,
+        version=dist_version,
+        sdist_root_dir=source_root_dir,
+        build_env=build_env,
+    )
 
     # Build
-    build_env = wheels.BuildEnvironment(wkctx, source_root_dir.parent, None)
     wheel_filename = wheels.build_wheel(
         ctx=wkctx,
         req=req,

--- a/src/fromager/commands/step.py
+++ b/src/fromager/commands/step.py
@@ -95,7 +95,14 @@ def build_sdist(
     """
     req = Requirement(f"{dist_name}=={dist_version}")
     source_root_dir = _find_source_root_dir(wkctx.work_dir, req, dist_version)
-    sdist_filename = sources.build_sdist(wkctx, req, source_root_dir, dist_version)
+    build_env = wheels.BuildEnvironment(wkctx, source_root_dir.parent, None)
+    sdist_filename = sources.build_sdist(
+        ctx=wkctx,
+        req=req,
+        version=dist_version,
+        sdist_root_dir=source_root_dir,
+        build_env=build_env,
+    )
     print(sdist_filename)
 
 

--- a/src/fromager/sdist.py
+++ b/src/fromager/sdist.py
@@ -206,8 +206,9 @@ def handle_requirement(
                 sources.build_sdist(
                     ctx=ctx,
                     req=req,
-                    sdist_root_dir=sdist_root_dir,
                     version=resolved_version,
+                    sdist_root_dir=sdist_root_dir,
+                    build_env=build_env,
                 )
             except Exception as err:
                 logger.warning(

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -16,7 +16,7 @@ import resolvelib
 from packaging.requirements import Requirement
 from packaging.version import Version
 
-from . import context, dependencies, overrides, resolver, tarballs, vendor_rust
+from . import context, dependencies, overrides, resolver, tarballs, vendor_rust, wheels
 
 logger = logging.getLogger(__name__)
 
@@ -327,8 +327,9 @@ def _default_prepare_source(
 def build_sdist(
     ctx: context.WorkContext,
     req: Requirement,
-    sdist_root_dir: pathlib.Path,
     version: Version,
+    sdist_root_dir: pathlib.Path,
+    build_env: wheels.BuildEnvironment,
 ) -> pathlib.Path:
     logger.info(f"{req.name}: building source distribution in {sdist_root_dir}")
     builder = overrides.find_override_method(req.name, "build_sdist")
@@ -339,8 +340,9 @@ def build_sdist(
         ctx=ctx,
         extra_environ=extra_environ,
         req=req,
-        sdist_root_dir=sdist_root_dir,
         version=version,
+        sdist_root_dir=sdist_root_dir,
+        build_env=build_env,
     )
     logger.info(f"{req.name}: built source distribution {sdist_filename}")
     return sdist_filename
@@ -350,8 +352,9 @@ def default_build_sdist(
     ctx: context.WorkContext,
     extra_environ: dict,
     req: Requirement,
-    sdist_root_dir: pathlib.Path,
     version: Version,
+    sdist_root_dir: pathlib.Path,
+    build_env: wheels.BuildEnvironment,
 ) -> pathlib.Path:
     # It seems like the "correct" way to do this would be to run the
     # PEP 517 API in the source tree we have modified. However, quite


### PR DESCRIPTION
Also reorder the function arguments a bit more
logically (the version is related to the
requirement).