### PR TITLE
Feat: entry points with override methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,17 @@ fromager = "fromager.__main__:invoke_main"
 # This test plugin should stay in the package.
 fromager_test = "fromager.example_override"
 
+[project.entry-points."fromager.override_methods"]
+# override methods and their default implementations
+get_build_system_dependencies = "fromager.dependencies:default_get_build_system_dependencies"
+get_build_backend_dependencies = "fromager.dependencies:default_get_build_backend_dependencies"
+get_build_sdist_dependencies = "fromager.dependencies:default_get_build_sdist_dependencies"
+get_install_dependencies = "fromager.dependencies:default_get_install_dependencies"
+resolver_provider = "fromager.sources:default_resolver_provider"
+download_source = "fromager.sources:default_download_source"
+build_sdist = "fromager.sources:default_build_sdist"
+build_wheel = "fromager.wheels:default_build_wheel"
+
 [tool.setuptools_scm]
 version_file = "src/fromager/version.py"
 

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -228,7 +228,7 @@ def _takes_arg(f: typing.Callable, arg_name: str) -> bool:
 def unpack_source(
     ctx: context.WorkContext,
     source_filename: pathlib.Path,
-) -> pathlib.Path:
+) -> tuple[pathlib.Path, bool]:
     unpack_dir = ctx.work_dir / _sdist_root_name(source_filename)
     if unpack_dir.exists():
         if ctx.cleanup:
@@ -257,7 +257,7 @@ def unpack_source(
     return (next(iter(unpack_dir.glob("*"))), True)
 
 
-def patch_source(ctx: context.WorkContext, source_root_dir: pathlib.Path):
+def patch_source(ctx: context.WorkContext, source_root_dir: pathlib.Path) -> None:
     for p in overrides.patches_for_source_dir(ctx.patches_dir, source_root_dir.name):
         logger.info("applying patch file %s to %s", p, source_root_dir)
         with open(p, "r") as f:
@@ -273,7 +273,7 @@ def write_build_meta(
     req: Requirement,
     source_filename: pathlib.Path,
     version: Version,
-):
+) -> pathlib.Path:
     meta_file = unpack_dir / "build-meta.json"
     with open(meta_file, "w") as f:
         json.dump(

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -115,7 +115,7 @@ def default_build_wheel(
     req: Requirement,
     sdist_root_dir: pathlib.Path,
     version: Version,
-):
+) -> None:
     logger.debug(f"{req.name}: building wheel in {sdist_root_dir} with {extra_environ}")
 
     # Activate the virtualenv for the subprocess:

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -1,0 +1,10 @@
+import inspect
+from importlib.metadata import entry_points
+
+
+def test_ep_override_methods():
+    epg = entry_points(group="fromager.override_methods")
+    assert epg
+    for name in epg.names:
+        func = epg[name].load()
+        assert inspect.isfunction(func)


### PR DESCRIPTION
The new entry point `fromager.override_methods` lists all fromager override methods by name and their default implementation. This allows consumers to get a list of known override methods and compare function signatures.

Also address some typing issues in override methods and helpers.