### PR TITLE
fix: remove quotes if it surrounds the value of an environment variable

### DIFF
--- a/src/fromager/overrides.py
+++ b/src/fromager/overrides.py
@@ -108,6 +108,9 @@ def extra_environ_for_pkg(
                 key, _, value = line.strip().partition("=")
                 key = key.strip()
                 value = value.strip()
+                # remove quotes if they surround the value
+                if value[0] == value[-1] and (value[0] == '"' or value[0] == "'"):
+                    value = value[1:-1]
                 if "$(" in value:
                     raise ValueError(f"'{value}': subshell '$()' is not supported.")
                 value = string.Template(value).substitute(template_env)

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -68,13 +68,23 @@ def test_extra_environ_for_pkg_expansion(tmp_path: pathlib.Path):
         f.write("EGG = Python\n")
         f.write("SPAM=Monty ${EGG}!\n")
         f.write("KNIGHT=$NAME\n")
+        f.write("FOO='Bar'\n")
+        f.write("XYZ=A\"BC'\n")
+        f.write('HELLO="World"\n')
 
     with mock.patch.dict(os.environ) as environ:
         environ.clear()
         environ["NAME"] = "Ni"
         extra_environ = overrides.extra_environ_for_pkg(tmp_path, pkg_name, variant)
 
-    assert extra_environ == {"EGG": "Python", "SPAM": "Monty Python!", "KNIGHT": "Ni"}
+    assert extra_environ == {
+        "EGG": "Python",
+        "SPAM": "Monty Python!",
+        "KNIGHT": "Ni",
+        "FOO": "Bar",
+        "XYZ": "A\"BC'",
+        "HELLO": "World",
+    }
 
     # unknown key
     with env_file.open("w", encoding="utf=8") as f:


### PR DESCRIPTION
fixes #203 