### PR TITLE
fix return value for pep517_build_sdist

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,6 +68,7 @@ jobs:
           - build_order
           - build_steps
           - override
+          - pep517_build_sdist
           - prebuilt_wheels_alt_server
           - report_missing_dependency
           - rust_vendor

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,9 +2,9 @@ pull_request_rules:
   - name: Add CI label
     conditions:
       - or:
-          - 'title~=^tox:'
-          - 'title~=^ci:'
-          - 'title~=^e2e:'
+          - "title~=^tox:"
+          - "title~=^ci:"
+          - "title~=^e2e:"
           - files~=tox.ini
           - files~=.github/
           - files~=.markdownlint-config.yaml
@@ -17,7 +17,7 @@ pull_request_rules:
   - name: Add Mergify label
     conditions:
       - or:
-          - 'title~=^mergify:'
+          - "title~=^mergify:"
           - files~=.mergify.yml$
     actions:
       label:
@@ -62,6 +62,10 @@ pull_request_rules:
           - check-success=e2e (3.11, 1.75, override)
           - check-success=e2e (3.12, 1.75, override)
 
+          - check-success=e2e (3.10, 1.75, pep517_build_sdist)
+          - check-success=e2e (3.11, 1.75, pep517_build_sdist)
+          - check-success=e2e (3.12, 1.75, pep517_build_sdist)
+
           - check-success=e2e (3.10, 1.75, prebuilt_wheels_alt_server)
           - check-success=e2e (3.11, 1.75, prebuilt_wheels_alt_server)
           - check-success=e2e (3.12, 1.75, prebuilt_wheels_alt_server)
@@ -82,7 +86,7 @@ pull_request_rules:
           - check-success=e2e (3.11, 1.75, optimize_build)
           - check-success=e2e (3.12, 1.75, optimize_build)
 
-          - '-draft'
+          - "-draft"
 
           # At least 1 reviewer
           - "#approved-reviews-by>=1"

--- a/e2e/stevedore_override/build/lib/package_plugins/stevedore.py
+++ b/e2e/stevedore_override/build/lib/package_plugins/stevedore.py
@@ -1,0 +1,26 @@
+import logging
+import pathlib
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+from fromager import context, sources, wheels
+
+logger = logging.getLogger(__name__)
+
+
+def build_sdist(
+    ctx: context.WorkContext,
+    extra_environ: dict,
+    req: Requirement,
+    sdist_root_dir: pathlib.Path,
+    version: Version,
+    build_env: wheels.BuildEnvironment,
+) -> pathlib.Path:
+    return sources.pep517_build_sdist(
+        ctx=ctx,
+        extra_environ=extra_environ,
+        req=req,
+        sdist_root_dir=sdist_root_dir,
+        version=version,
+    )

--- a/e2e/stevedore_override/pyproject.toml
+++ b/e2e/stevedore_override/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "stevedore-overrides"
+authors = [{ name = "Doug Hellmann", email = "dhellmann@redhat.com" }]
+description = "test package"
+dynamic = ["version"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Utilities",
+]
+
+requires-python = ">=3.10"
+
+dependencies = []
+
+[project.entry-points."fromager.project_overrides"]
+stevedore = "package_plugins.stevedore"

--- a/e2e/stevedore_override/src/package_plugins/stevedore.py
+++ b/e2e/stevedore_override/src/package_plugins/stevedore.py
@@ -1,0 +1,26 @@
+import logging
+import pathlib
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+from fromager import context, sources, wheels
+
+logger = logging.getLogger(__name__)
+
+
+def build_sdist(
+    ctx: context.WorkContext,
+    extra_environ: dict,
+    req: Requirement,
+    sdist_root_dir: pathlib.Path,
+    version: Version,
+    build_env: wheels.BuildEnvironment,
+) -> pathlib.Path:
+    return sources.pep517_build_sdist(
+        ctx=ctx,
+        extra_environ=extra_environ,
+        req=req,
+        sdist_root_dir=sdist_root_dir,
+        version=version,
+    )

--- a/e2e/test_pep517_build_sdist.sh
+++ b/e2e/test_pep517_build_sdist.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# -*- indent-tabs-mode: nil; tab-width: 2; sh-indentation: 2; -*-
+
+# Test to show that we get a detailed error message if a dependency is
+# not available when setting up to build a package.
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+set -x
+set -e
+set -o pipefail
+
+# Bootstrap to create the build order file.
+OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
+
+# What are we building?
+DIST="stevedore"
+VERSION="5.2.0"
+
+# Recreate output directory
+rm -rf "$OUTDIR"
+mkdir -p "$OUTDIR/build-logs"
+
+# Set up virtualenv with the CLI and dependencies.
+tox -e e2e -n -r
+source ".tox/e2e/bin/activate"
+pip install e2e/stevedore_override
+
+# # Bootstrap the test project to get local copies of all of the dependencies.
+# fromager \
+#     --sdists-repo="$OUTDIR/sdists-repo" \
+#     --wheels-repo="$OUTDIR/wheels-repo" \
+#     --work-dir="$OUTDIR/work-dir" \
+#     bootstrap "${DIST}==${VERSION}"
+
+# Download the source archive
+fromager \
+    --log-file "$OUTDIR/build-logs/${DIST}-download-source-archive.log" \
+    --work-dir "$OUTDIR/work-dir" \
+    --sdists-repo "$OUTDIR/sdists-repo" \
+    --wheels-repo "$OUTDIR/wheels-repo" \
+    step download-source-archive "$DIST" "$VERSION" "https://pypi.org/simple"
+
+# Prepare the source dir for building
+rm -rf "$OUTDIR/work-dir/${DIST}*"
+fromager \
+    --log-file "$OUTDIR/build-logs/${DIST}-prepare-source.log" \
+    --work-dir "$OUTDIR/work-dir" \
+    --sdists-repo "$OUTDIR/sdists-repo" \
+    --wheels-repo "$OUTDIR/wheels-repo" \
+    step prepare-source "$DIST" "$VERSION"
+
+# Prepare the build environment
+fromager \
+    --log-file "$OUTDIR/build-logs/${DIST}-prepare-build.log" \
+    --work-dir "$OUTDIR/work-dir" \
+    --sdists-repo "$OUTDIR/sdists-repo" \
+    --wheels-repo "$OUTDIR/wheels-repo" \
+    --wheel-server-url "https://pypi.org/simple/" \
+    step prepare-build "$DIST" "$VERSION"
+
+# Build an updated sdist
+rm -rf "$OUTDIR/sdists-repo/builds"
+fromager \
+    --log-file "$OUTDIR/build-logs/${DIST}-build-sdist.log" \
+    --work-dir "$OUTDIR/work-dir" \
+    --sdists-repo "$OUTDIR/sdists-repo" \
+    --wheels-repo "$OUTDIR/wheels-repo" \
+    step build-sdist "$DIST" "$VERSION"
+
+EXPECTED_FILES="
+$OUTDIR/sdists-repo/builds/stevedore-*.tar.gz
+"
+
+pass=true
+for pattern in $EXPECTED_FILES; do
+  if [ ! -f "${pattern}" ]; then
+    echo "Did not find $pattern" 1>&2
+    pass=false
+  fi
+done
+
+$pass

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -404,7 +404,9 @@ def pep517_build_sdist(
     """Use the PEP 517 API to build a source distribution from a modified source tree."""
     pyproject_toml = dependencies.get_pyproject_contents(sdist_root_dir)
     hook_caller = dependencies.get_build_backend_hook_caller(
-        sdist_root_dir, pyproject_toml, extra_environ
+        sdist_root_dir,
+        pyproject_toml,
+        extra_environ,
     )
     sdist_filename = hook_caller.build_sdist(ctx.sdists_builds)
-    return sdist_filename
+    return ctx.sdists_builds / sdist_filename


### PR DESCRIPTION
Return the full path to the built file instead of
just the base name that is returned by the build
backend. Add an end-to-end test for building
sdists using pep517_build_sdist().