### PR TITLE
Do not vendor Rust test code for meson

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,6 +67,7 @@ jobs:
           - build
           - build_order
           - build_steps
+          - meson
           - override
           - pep517_build_sdist
           - prebuilt_wheels_alt_server

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -62,6 +62,10 @@ pull_request_rules:
           - check-success=e2e (3.11, 1.75, override)
           - check-success=e2e (3.12, 1.75, override)
 
+          - check-success=e2e (3.10, 1.75, meson)
+          - check-success=e2e (3.11, 1.75, meson)
+          - check-success=e2e (3.12, 1.75, meson)
+
           - check-success=e2e (3.10, 1.75, pep517_build_sdist)
           - check-success=e2e (3.11, 1.75, pep517_build_sdist)
           - check-success=e2e (3.12, 1.75, pep517_build_sdist)

--- a/e2e/test_meson.sh
+++ b/e2e/test_meson.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# -*- indent-tabs-mode: nil; tab-width: 2; sh-indentation: 2; -*-
+
+# Test meson build, verify that vendor_rust workaround is effective
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+set -x
+set -e
+set -o pipefail
+
+# Bootstrap to create the build order file.
+OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
+
+# What are we building?
+DIST="meson"
+VERSION="1.5.0"
+
+# Recreate output directory
+rm -rf "$OUTDIR"
+mkdir -p "$OUTDIR/build-logs"
+
+# Set up virtualenv with the CLI and dependencies.
+tox -e e2e -n -r
+source ".tox/e2e/bin/activate"
+
+# Bootstrap the test project
+fromager \
+    --sdists-repo="$OUTDIR/sdists-repo" \
+    --wheels-repo="$OUTDIR/wheels-repo" \
+    --work-dir="$OUTDIR/work-dir" \
+    bootstrap "${DIST}==${VERSION}"
+
+EXPECTED_FILES="
+wheels-repo/downloads/${DIST}-${VERSION}-py3-none-any.whl
+sdists-repo/downloads/${DIST}-${VERSION}.tar.gz
+"
+
+pass=true
+for f in $EXPECTED_FILES; do
+  if [ ! -f "$OUTDIR/$f" ]; then
+    echo "FAIL: Did not find $OUTDIR/$f" 1>&2
+    pass=false
+  fi
+done
+$pass

--- a/src/fromager/vendor_rust.py
+++ b/src/fromager/vendor_rust.py
@@ -93,7 +93,15 @@ def vendor_rust(
     ``False``.
     """
     # check for Cargo.toml
-    manifests = list(project_dir.glob("**/Cargo.toml"))
+    manifests = []
+    for manifest in project_dir.glob("**/Cargo.toml"):
+        if any((d in manifest.parts) for d in ["22 cargo subproject", "25 cargo lock"]):
+            # HACK: meson 1.5.0 tests have broken Cargo.toml. Don't vendor
+            # test cases of meson and vendored copies of meson NumPy 2.0.1
+            # vendors meson.
+            logger.debug(f"{req.name}: ignore {manifest}")
+            continue
+        manifests.append(manifest)
     if not manifests:
         logger.debug(f"{req.name}: has no Cargo.toml files")
         return False


### PR DESCRIPTION
The directories `22 cargo subproject` and `25 cargo lock` contain broken `Cargo.toml`. Don't vendor Rust crates for test code. We ignore the code here because meson is both shipped stand-alone and vendored in NumPy 2.0.