### PR TITLE
cleanup: fix typings for requirements_file.py

### DIFF
--- a/src/fromager/requirements_file.py
+++ b/src/fromager/requirements_file.py
@@ -26,12 +26,13 @@ def parse_requirements_file(
 def evaluate_marker(
     parent_req: Requirement,
     req: Requirement,
-    extras: dict | None = None,
+    extras: set[str] | None = None,
 ) -> bool:
     if not req.marker:
         return True
 
-    default_env = markers.default_environment()
+    # fixes mypy complaining about types: https://github.com/pypa/packaging/blob/main/src/packaging/markers.py#L310
+    default_env = typing.cast(dict[str, str], markers.default_environment())
     if not extras:
         marker_envs = [default_env]
     else:


### PR DESCRIPTION
part of #226 

Fixes the following errors:

```
src/fromager/requirements_file.py:29: error: Missing type parameters for generic type "dict"  [type-arg]
src/fromager/requirements_file.py:38: error: List comprehension has incompatible type List[dict[str, object]]; expected List[Environment]  [misc]
src/fromager/requirements_file.py:41: error: Argument 1 to "evaluate" of "Marker" has incompatible type "Environment"; expected "dict[str, str] | None"  [arg-type]
```

Need this to fix errors in dependencies.py but I am not combining the two together in one PR because dependencies.py has a lot of typing fixes