### PR TITLE
Only vendor Rust when project uses setuptools-rust / maturin

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,6 +67,7 @@ jobs:
           - build
           - build_order
           - build_steps
+          - meson
           - override
           - pep517_build_sdist
           - prebuilt_wheels_alt_server

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -62,6 +62,10 @@ pull_request_rules:
           - check-success=e2e (3.11, 1.75, override)
           - check-success=e2e (3.12, 1.75, override)
 
+          - check-success=e2e (3.10, 1.75, meson)
+          - check-success=e2e (3.11, 1.75, meson)
+          - check-success=e2e (3.12, 1.75, meson)
+
           - check-success=e2e (3.10, 1.75, pep517_build_sdist)
           - check-success=e2e (3.11, 1.75, pep517_build_sdist)
           - check-success=e2e (3.12, 1.75, pep517_build_sdist)

--- a/e2e/test_meson.sh
+++ b/e2e/test_meson.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# -*- indent-tabs-mode: nil; tab-width: 2; sh-indentation: 2; -*-
+
+# Test meson build, verify that vendor_rust workaround is effective
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+set -x
+set -e
+set -o pipefail
+
+# Bootstrap to create the build order file.
+OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
+
+# What are we building?
+DIST="meson"
+VERSION="1.5.0"
+
+# Recreate output directory
+rm -rf "$OUTDIR"
+mkdir -p "$OUTDIR/build-logs"
+
+# Set up virtualenv with the CLI and dependencies.
+tox -e e2e -n -r
+source ".tox/e2e/bin/activate"
+
+# Bootstrap the test project
+fromager \
+    --sdists-repo="$OUTDIR/sdists-repo" \
+    --wheels-repo="$OUTDIR/wheels-repo" \
+    --work-dir="$OUTDIR/work-dir" \
+    bootstrap "${DIST}==${VERSION}"
+
+EXPECTED_FILES="
+wheels-repo/downloads/${DIST}-${VERSION}-py3-none-any.whl
+sdists-repo/downloads/${DIST}-${VERSION}.tar.gz
+"
+
+pass=true
+for f in $EXPECTED_FILES; do
+  if [ ! -f "$OUTDIR/$f" ]; then
+    echo "FAIL: Did not find $OUTDIR/$f" 1>&2
+    pass=false
+  fi
+done
+$pass


### PR DESCRIPTION
`vendor_rust` now inspects `pyproject.toml` and looks for `setuptools-rust` and `maturin` in `[build-system]requires`. When `pyproject.toml` does not exist or does not list a Rust build plugin as requirement, then Rust crates are not vendored.

The change indirectly addresses the issue with Meson's broken Rust crates in `test cases/rust`.