### PR TITLE
cleanup: fix typings in commands: canonicalize.py, download_sequence.py, list_overrides.py, server.py

### DIFF
--- a/src/fromager/commands/canonicalize.py
+++ b/src/fromager/commands/canonicalize.py
@@ -5,7 +5,7 @@ from .. import overrides
 
 @click.command()
 @click.argument("dist_name", nargs=-1)
-def canonicalize(dist_name: list[str]):
+def canonicalize(dist_name: list[str]) -> None:
     """convert a package name to its canonical form for use in override paths"""
     for name in dist_name:
         print(overrides.pkgname_to_override_module(name))

--- a/src/fromager/commands/download_sequence.py
+++ b/src/fromager/commands/download_sequence.py
@@ -24,7 +24,7 @@ def download_sequence(
     build_order_file: str,
     sdist_server_url: str,
     include_wheels: str,
-):
+) -> None:
     """Download a sequence of source distributions in order.
 
     BUILD_ORDER_FILE is the build-order.json files to build

--- a/src/fromager/commands/list_overrides.py
+++ b/src/fromager/commands/list_overrides.py
@@ -7,7 +7,7 @@ from fromager import context, overrides
 @click.pass_obj
 def list_overrides(
     wkctx: context.WorkContext,
-):
+) -> None:
     """List all of the packages with overrides in the current configuration."""
     for name in overrides.list_all(
         wkctx.patches_dir, wkctx.envs_dir, wkctx.settings.download_source()

--- a/src/fromager/commands/server.py
+++ b/src/fromager/commands/server.py
@@ -24,7 +24,7 @@ def wheel_server(
     wkctx: context.WorkContext,
     port: int,
     address: str,
-):
+) -> None:
     "Start a web server to server the local wheels-repo"
     server.update_wheel_mirror(wkctx)
     t = server.run_wheel_server(


### PR DESCRIPTION
part of #226 

fixes the following error in each file:
```
error: Function is missing a return type annotation  [no-untyped-def]
```