### PR TITLE
cleanup: remove unused function from vendor_rust

### DIFF
--- a/src/fromager/vendor_rust.py
+++ b/src/fromager/vendor_rust.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 """Vendor Rust crates into an sdist"""
 
 import json
@@ -144,40 +143,3 @@ def vendor_rust(
     _cargo_config(project_dir)
 
     return True
-
-
-def test():
-    import argparse
-    import tarfile
-    import tempfile
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("sdists", type=pathlib.Path, nargs="+")
-    parser.add_argument("--outdir", type=pathlib.Path, default="outdir")
-
-    args = parser.parse_args()
-    args.outdir.mkdir(exist_ok=True)
-
-    logging.basicConfig(level=logging.INFO)
-
-    for sdist in args.sdists:
-        out_sdist = args.outdir / sdist.name
-        if out_sdist.is_file():
-            out_sdist.unlink()
-        logger.info("Vendoring '%s'", sdist)
-        with tempfile.TemporaryDirectory() as tmp:
-            tmpdir = pathlib.Path(tmp)
-            with tarfile.open(sdist) as tar:
-                # filter argument was added in 3.10.12, 3.11.4, 3.12.0
-                tar.extractall(path=tmpdir, filter="data")
-
-            project_name = sdist.name[: -len(".tar.gz")]
-            project_dir = tmpdir / project_name
-            vendor_rust(project_dir)
-
-            with tarfile.open(out_sdist, "x:gz") as tar:
-                tar.add(project_dir, arcname=project_name)
-
-
-if __name__ == "__main__":
-    test()


### PR DESCRIPTION
part of #226 

fixes the following error:

```
src/fromager/vendor_rust.py:149: error: Function is missing a return type annotation  [no-untyped-def]
src/fromager/vendor_rust.py:149: note: Use "-> None" if function does not return a value
src/fromager/vendor_rust.py:176: error: Missing positional argument "project_dir" in call to "vendor_rust"  [call-arg]
src/fromager/vendor_rust.py:183: error: Call to untyped function "test" in typed context  [no-untyped-call]
```

I don't think we were using the `test` function anywhere and it was just put to quickly test this module manually
