### PR TITLE
cleanup: fix typings in wheels.py

### DIFF
--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -33,13 +33,13 @@ class BuildEnvironment:
     def python(self) -> pathlib.Path:
         return (self.path / "bin/python3").absolute()
 
-    def _createenv(self):
+    def _createenv(self) -> None:
         if self.path.exists():
             logger.info("reusing build environment in %s", self.path)
             return
 
         logger.debug("creating build environment in %s", self.path)
-        external_commands.run([sys.executable, "-m", "virtualenv", self.path])
+        external_commands.run([sys.executable, "-m", "virtualenv", str(self.path)])
         logger.info("created build environment in %s", self.path)
 
         req_filename = self.path / "requirements.txt"
@@ -52,7 +52,7 @@ class BuildEnvironment:
             return
         external_commands.run(
             [
-                self.python,
+                str(self.python),
                 "-m",
                 "pip",
                 "install",
@@ -63,9 +63,9 @@ class BuildEnvironment:
             + self._ctx.pip_wheel_server_args
             + [
                 "-r",
-                req_filename.absolute(),
+                str(req_filename.absolute()),
             ],
-            cwd=self.path.parent,
+            cwd=str(self.path.parent),
         )
         logger.info("installed dependencies into build environment in %s", self.path)
 
@@ -117,7 +117,7 @@ def build_wheel(
 def default_build_wheel(
     ctx: context.WorkContext,
     build_env: BuildEnvironment,
-    extra_environ: dict,
+    extra_environ: dict[str, typing.Any],
     req: Requirement,
     sdist_root_dir: pathlib.Path,
     version: Version,


### PR DESCRIPTION
part of #226 

fixes the following errors:

```
src/fromager/wheels.py:30: error: Call to untyped function "_createenv" in typed context  [no-untyped-call]
src/fromager/wheels.py:36: error: Function is missing a return type annotation  [no-untyped-def]
src/fromager/wheels.py:36: note: Use "-> None" if function does not return a value
src/fromager/wheels.py:42: error: List item 3 has incompatible type "Path"; expected "str"  [list-item]
src/fromager/wheels.py:54: error: Argument 1 to "run" has incompatible type "list[object]"; expected "list[str]"  [arg-type]
src/fromager/wheels.py:68: error: Argument "cwd" to "run" has incompatible type "Path"; expected "str | None"  [arg-type]
src/fromager/wheels.py:120: error: Missing type parameters for generic type "dict"  [type-arg]
```