### PR TITLE
Redesign parallel build configuration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ click>=8.1.7
 html5lib
 packaging
 pkginfo
+psutil
 PyGithub
 pyproject_hooks>=1.0.0,!=1.1.0
 python-pypi-mirror

--- a/src/fromager/__main__.py
+++ b/src/fromager/__main__.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import logging
-import os
 import pathlib
 
 import click
@@ -94,8 +93,21 @@ VERBOSE_LOG_FMT = "%(levelname)s:%(name)s:%(lineno)d: %(message)s"
 @click.option(
     "-j",
     "--jobs",
+    "max_jobs",
     type=int,
-    help="number of jobs available to run in parallel",
+    help="maximum number of jobs to run in parallel",
+)
+@click.option(
+    "--jobs-cpu-scaling",
+    type=int,
+    default=1,
+    help="CPU core scaling for parallel jobs (allocate N CPU cores per job)",
+)
+@click.option(
+    "--jobs-memory-scaling",
+    type=int,
+    default=2,
+    help="Memory scaling for parallel jobs (allocate N GB per job)",
 )
 @click.pass_context
 def main(
@@ -113,7 +125,9 @@ def main(
     wheel_server_url: str,
     cleanup: bool,
     variant: str,
-    jobs: int,
+    max_jobs: int | None,
+    jobs_cpu_scaling: int,
+    jobs_memory_scaling: int,
 ):
     # Set the overall logger level to debug and allow the handlers to filter
     # messages at their own level.
@@ -161,7 +175,9 @@ def main(
         wheel_server_url=wheel_server_url,
         cleanup=cleanup,
         variant=variant,
-        jobs=jobs if jobs is None or jobs > 0 else os.cpu_count(),
+        max_jobs=max_jobs,
+        jobs_cpu_scaling=jobs_cpu_scaling,
+        jobs_memory_scaling=jobs_memory_scaling,
     )
     wkctx.setup()
     ctx.obj = wkctx

--- a/src/fromager/settings.py
+++ b/src/fromager/settings.py
@@ -1,34 +1,92 @@
 import logging
 import pathlib
+import typing
 
 import yaml
+from packaging.utils import NormalizedName, canonicalize_name
 
 from . import overrides
 
 logger = logging.getLogger(__name__)
 
 
+class DownloadSource(typing.NamedTuple):
+    url: str | None = None
+    rename_to: str | None = None
+
+
+class BuildOption(typing.NamedTuple):
+    # scale parallel jobs by available CPU cores
+    # 1: as many parallel jobs as CPU cores
+    # 2: os.cpu_count() // 2
+    cpu_scaling: int | None = None
+    # scale parallel jobs by memory
+    # 2: assume that each parallel job requires 2 GB max memory
+    memory_scaling: int | None = None
+
+
+class _Data(typing.TypedDict):
+    pre_built: dict[str, set[NormalizedName]]
+    download_source: dict[str, DownloadSource]
+    build_option: dict[str, BuildOption]
+
+
 class Settings:
     def __init__(self, data: dict):
-        self._data = data
+        self._data: _Data = {
+            "pre_built": {},
+            "download_source": {},
+            "build_option": {},
+        }
+
+        # variant -> set of canonicalized package names
+        pre_built: dict[str, typing.Sequence[str]] = data.get("pre_built") or {}
+        self._data["pre_built"] = {
+            variant: set(canonicalize_name(p) for p in packages)
+            for variant, packages in pre_built.items()
+        }
+
+        # canon package -> DownloadSource
+        download_source: dict[str, dict[str, str]] = data.get("download_source") or {}
+        self._data["download_source"] = {
+            canonicalize_name(package): DownloadSource(**info)
+            for package, info in download_source.items()
+        }
+
+        # canon package -> BuildOption
+        build_option: dict[str, dict[str, typing.Any]] = data.get("build_option") or {}
+        self._data["build_option"] = {
+            canonicalize_name(package): BuildOption(**info)
+            for package, info in build_option.items()
+        }
 
     def pre_built(self, variant: str) -> set[str]:
-        p = self._data.get("pre_built") or {}
-        names = p.get(variant) or []
+        names = self._data["pre_built"].get(variant, set())
         return set(overrides.pkgname_to_override_module(n) for n in names)
 
-    def download_source(self) -> dict[str, dict[str, str]]:
-        return self._data.get("download_source") or {}
+    def download_source(self) -> dict[str, DownloadSource]:
+        return self._data["download_source"]
+
+    def _get_pkg_ds(self, pkg: str) -> DownloadSource | None:
+        pkg = canonicalize_name(pkg)
+        return self.download_source().get(pkg, None)
 
     def sdist_download_url(self, pkg: str) -> str | None:
-        p = self.download_source()
-        download_source = p.get(pkg) or {}
-        return download_source.get("url")
+        ds = self._get_pkg_ds(pkg)
+        if ds:
+            return ds.url
+        return None
 
     def sdist_local_filename(self, pkg: str) -> str | None:
-        p = self.download_source()
-        download_source = p.get(pkg) or {}
-        return download_source.get("rename_to")
+        ds = self._get_pkg_ds(pkg)
+        if ds:
+            return ds.rename_to
+        return None
+
+    def build_option(self, pkg: str) -> BuildOption | None:
+        pkg = canonicalize_name(pkg)
+        build_option = self._data["build_option"]
+        return build_option.get(pkg)
 
 
 def _parse(content: str) -> Settings:
@@ -41,6 +99,6 @@ def load(filename: pathlib.Path) -> Settings:
     if not filepath.exists():
         logger.debug("settings file %s does not exist, ignoring", filepath.absolute())
         return Settings({})
-    with open(filepath, "r") as f:
+    with filepath.open(encoding="utf-8") as f:
         logger.info("loading settings from %s", filepath.absolute())
-        return _parse(f)
+        return _parse(f.read())

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -84,13 +84,13 @@ def build_wheel(
     # TODO: refactor?
     # Build Rust without network access
     extra_environ["CARGO_NET_OFFLINE"] = "true"
-    # configure max jobs settings. should cover most of the cases, if not then the user can use ctx.jobs in their plugin
-    if ctx.jobs:
-        extra_environ["MAKEFLAGS"] = (
-            f"{extra_environ.get('MAKEFLAGS', '')} -j{ctx.jobs}"
-        )
-        extra_environ["CMAKE_BUILD_PARALLEL_LEVEL"] = f"{ctx.jobs}"
-        extra_environ["MAX_JOBS"] = f"{ctx.jobs}"
+
+    # configure max jobs settings, settings depend on package, available
+    # CPU cores, and available virtual memory.
+    jobs = ctx.parallel_jobs(req)
+    extra_environ["MAKEFLAGS"] = f"{extra_environ.get('MAKEFLAGS', '')} -j{jobs}"
+    extra_environ["CMAKE_BUILD_PARALLEL_LEVEL"] = str(jobs)
+    extra_environ["MAX_JOBS"] = str(jobs)
 
     # Start the timer
     start = datetime.now().replace(microsecond=0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from fromager import constraints, context, settings
@@ -15,5 +17,9 @@ def tmp_context(tmp_path):
         work_dir=tmp_path / "work-dir",
         wheel_server_url="",
     )
-    ctx.setup()
-    return ctx
+    with (
+        patch.object(ctx, "cpu_count", return_value=8),
+        patch.object(ctx, "available_memory_gib", return_value=15.1),
+    ):
+        ctx.setup()
+        yield ctx

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -24,9 +24,11 @@ def test_with_pre_built():
       cuda:
         - a
         - b
+        - X
+        - egg_SPAM
     """)
     )
-    assert s.pre_built("cuda") == set(["a", "b"])
+    assert s.pre_built("cuda") == set(["a", "b", "x", "egg_spam"])
 
 
 def test_with_download_source():
@@ -36,12 +38,18 @@ def test_with_download_source():
       foo:
         url: url
         rename_to: rename
+      egg_SPAM:
+        url: egg-url
+        rename_to: rename-spam
     """)
     )
     assert s.sdist_local_filename("foo") == "rename"
     assert s.sdist_local_filename("bar") is None
+    assert s.sdist_local_filename("egg-spam") == "rename-spam"
+    assert s.sdist_local_filename("egg.spam") == "rename-spam"
     assert s.sdist_download_url("foo") == "url"
     assert s.sdist_download_url("bar") is None
+    assert s.sdist_download_url("egg_spam") == "egg-url"
 
 
 def test_no_download_source():
@@ -52,3 +60,28 @@ def test_no_download_source():
     )
     assert s.sdist_local_filename("foo") is None
     assert s.sdist_download_url("foo") is None
+
+
+def test_with_build_option():
+    s = settings._parse(
+        textwrap.dedent("""
+    build_option:
+      foo:
+        cpu_scaling: 2
+        memory_scaling: 5
+    """)
+    )
+    bo = s.build_option("foo")
+    assert bo is not None
+    assert bo.cpu_scaling == 2
+    assert bo.memory_scaling == 5
+    assert s.build_option("bar") is None
+
+
+def test_no_build_option():
+    s = settings._parse(
+        textwrap.dedent("""
+    build_option:
+    """)
+    )
+    assert s.build_option("foo") is None

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands =
       --cov-report term-missing \
       --log-level DEBUG \
       -vv \
-      tests
+      {posargs:tests}
 
 [testenv:linter]
 base_python=python3.11
@@ -50,6 +50,7 @@ deps =
   mypy
   pytest
   types-html5lib
+  types-psutil
   types-PyYAML
   types-requests
   types-toml


### PR DESCRIPTION
The configuration for parallel build jobs can take available memory into account. Scaling factors for memory and CPU cores can be set globally and per package.

- `--jobs` now sets the maximum number of cores to use (default: all cores)
- `--jobs-cpu-scaling` sets how many cores are allocated per job (default: 1 CPU core per job)
- `--jobs-memory-scaling` sets how much memory is allocated per job (default: 2 GiB per job)

Per package override is configured in `overrides/settings.yaml`

```yaml
build_option:
  mypackage:
    cpu_scaling: 2
    memory_scaling: 5
```