### PR TITLE
cleanup: fix typings for hooks.py

### DIFF
--- a/src/fromager/hooks.py
+++ b/src/fromager/hooks.py
@@ -1,12 +1,13 @@
 import logging
 import pathlib
+import typing
 
 from packaging.requirements import Requirement
 from stevedore import extension, hook
 
 from fromager import context
 
-_mgrs = {}
+_mgrs: dict[str, hook.HookManager] = {}
 logger = logging.getLogger(__name__)
 
 
@@ -29,7 +30,7 @@ def _die_on_plugin_load_failure(
     mgr: hook.HookManager,
     ep: extension.Extension,
     err: Exception,
-):
+) -> typing.NoReturn:
     raise RuntimeError(f"failed to load overrides for {ep.name}") from err
 
 
@@ -40,7 +41,7 @@ def run_post_build_hooks(
     dist_version: str,
     sdist_filename: pathlib.Path,
     wheel_filename: pathlib.Path,
-):
+) -> None:
     hook_mgr = _get_hooks("post_build")
     if hook_mgr.names():
         logger.info(f"{req.name}: starting post-build hooks")


### PR DESCRIPTION
part of #226 

fixes the following errors:

```
src/fromager/hooks.py:9: error: Need type annotation for "_mgrs" (hint: "_mgrs: dict[<type>, <type>] = ...")  [var-annotated]
src/fromager/hooks.py:28: error: Function is missing a return type annotation  [no-untyped-def]
src/fromager/hooks.py:36: error: Function is missing a return type annotation  [no-untyped-def]
```