### PR TITLE
cleanup: fix typing in command/build.py

### DIFF
--- a/src/fromager/commands/build.py
+++ b/src/fromager/commands/build.py
@@ -21,7 +21,7 @@ def build(
     dist_name: str,
     dist_version: Version,
     sdist_server_url: str,
-):
+) -> None:
     """Build a single version of a single wheel
 
     DIST_NAME is the name of a distribution
@@ -55,7 +55,7 @@ def build_sequence(
     wkctx: context.WorkContext,
     build_order_file: str,
     sdist_server_url: str,
-):
+) -> None:
     """Build a sequence of wheels in order
 
     BUILD_ORDER_FILE is the build-order.json files to build
@@ -131,7 +131,7 @@ def _build(
         ctx=wkctx,
         req=req,
         dist_name=dist_name,
-        dist_version=dist_version,
+        dist_version=str(dist_version),
         sdist_filename=sdist_filename,
         wheel_filename=wheel_filename,
     )


### PR DESCRIPTION
part of #226 

fixes
```
src/fromager/commands/build.py:19: error: Function is missing a return type annotation  [no-untyped-def]
src/fromager/commands/build.py:54: error: Function is missing a return type annotation  [no-untyped-def]
src/fromager/commands/build.py:110: error: Argument 3 to "BuildEnvironment" has incompatible type "None"; expected "Iterable[Requirement]"  [arg-type]
src/fromager/commands/build.py:134: error: Argument "dist_version" to "run_post_build_hooks" has incompatible type "Version"; expected "str"  [arg-type]
src/fromager/commands/build.py:136: error: Argument "wheel_filename" to "run_post_build_hooks" has incompatible type "Path | None"; expected "Path"  [arg-type]
src/fromager/commands/build.py:139: error: Incompatible return value type (got "Path | None", expected "Path")  [return-value]
```