### PR TITLE
feat: add an option to skip building of wheel if it is exists on the wheel server

### DIFF
--- a/src/fromager/sdist.py
+++ b/src/fromager/sdist.py
@@ -278,7 +278,7 @@ def download_wheel(
     output_directory: pathlib.Path,
     wheel_server_urls: list[str],
 ) -> tuple[pathlib.Path, str, str]:
-    wheel_url, resolved_version = _resolve_prebuilt_wheel(ctx, req, wheel_server_urls)
+    wheel_url, resolved_version = resolve_prebuilt_wheel(ctx, req, wheel_server_urls)
     wheel_filename = output_directory / os.path.basename(urlparse(wheel_url).path)
     if not wheel_filename.exists():
         logger.info(f"{req.name}: downloading pre-built wheel {wheel_url}")
@@ -301,7 +301,7 @@ def _download_wheel_check(destination_dir, wheel_url):
     return wheel_filename
 
 
-def _resolve_prebuilt_wheel(
+def resolve_prebuilt_wheel(
     ctx: context.WorkContext,
     req: Requirement,
     wheel_server_urls: list[str],


### PR DESCRIPTION
fixes #235 

It should be easy to toggle this option even via env variable by setting `FROMAGER_BUILD_SEQUENCE_SKIP_EXISTING=true` (see https://click.palletsprojects.com/en/8.1.x/options/#values-from-environment-variables:~:text=When%20using%20auto_envvar_prefix,is%20WEB_RUN_SERVER_HOST.)

I also moved `start_wheel_server` outside of the loop to avoid applying the `update_wheel_mirror` method twice per package