### PR TITLE
deal with setuptools 72.0.0

### DIFF
--- a/e2e/common.sh
+++ b/e2e/common.sh
@@ -22,3 +22,5 @@ on_exit() {
     fi
 }
 trap on_exit EXIT SIGINT SIGTERM
+
+export FROMAGER_CONSTRAINTS_FILE="${SCRIPTDIR}/constraints.txt"

--- a/e2e/common.sh
+++ b/e2e/common.sh
@@ -8,22 +8,32 @@ set -o pipefail
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
 
+# Recreate output directory
 rm -rf "$OUTDIR"
 mkdir "$OUTDIR"
+
+# Recompute path to output directory so it is a full path
 OUTDIR=$(cd "$OUTDIR" && pwd)
 
+# Make sure the build-logs directory exists
+mkdir -p "$OUTDIR/build-logs"
+
+# Recreate the virtualenv with fromager installed
 tox -e e2e -n -r
 source .tox/e2e/bin/activate
 
+# Set a variable to constrain packages used in the tests
+export FROMAGER_CONSTRAINTS_FILE="${SCRIPTDIR}/constraints.txt"
+
+# Local web server management
 HTTP_SERVER_PID=""
 on_exit() {
     if [ -n "$HTTP_SERVER_PID" ]; then
+        echo "Stopping wheel server"
         kill "$HTTP_SERVER_PID"
     fi
 }
 trap on_exit EXIT SIGINT SIGTERM
-
-export FROMAGER_CONSTRAINTS_FILE="${SCRIPTDIR}/constraints.txt"
 
 start_local_wheel_server() {
     # Start a web server for the wheels-repo. We remember the PID so we

--- a/e2e/common.sh
+++ b/e2e/common.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/bash
+
+set -x
+set -e
+set -u
+set -o pipefail
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
+
+rm -rf "$OUTDIR"
+mkdir "$OUTDIR"
+OUTDIR=$(cd "$OUTDIR" && pwd)
+
+tox -e e2e -n -r
+source .tox/e2e/bin/activate
+
+HTTP_SERVER_PID=""
+on_exit() {
+    if [ -n "$HTTP_SERVER_PID" ]; then
+        kill "$HTTP_SERVER_PID"
+    fi
+}
+trap on_exit EXIT SIGINT SIGTERM

--- a/e2e/common.sh
+++ b/e2e/common.sh
@@ -24,3 +24,19 @@ on_exit() {
 trap on_exit EXIT SIGINT SIGTERM
 
 export FROMAGER_CONSTRAINTS_FILE="${SCRIPTDIR}/constraints.txt"
+
+start_local_wheel_server() {
+    # Start a web server for the wheels-repo. We remember the PID so we
+    # can stop it later, and we determine the primary IP of the host
+    # because podman won't see the server via localhost.
+    python3 -m http.server --directory "$OUTDIR/wheels-repo/" 9999 &
+    HTTP_SERVER_PID=$!
+    if which ip 2>&1 >/dev/null; then
+        # Linux
+        IP=$(ip route get 1.1.1.1 | grep 1.1.1.1 | awk '{print $7}')
+    else
+        # macOS
+        IP=$(ipconfig getifaddr en0)
+    fi
+    export WHEEL_SERVER_URL="http://${IP}:9999/simple"
+}

--- a/e2e/common.sh
+++ b/e2e/common.sh
@@ -36,10 +36,11 @@ on_exit() {
 trap on_exit EXIT SIGINT SIGTERM
 
 start_local_wheel_server() {
+    local serve_dir="${1:-$OUTDIR/wheels-repo/}"
     # Start a web server for the wheels-repo. We remember the PID so we
     # can stop it later, and we determine the primary IP of the host
     # because podman won't see the server via localhost.
-    python3 -m http.server --directory "$OUTDIR/wheels-repo/" 9999 &
+    python3 -m http.server --directory "$serve_dir" 9999 &
     HTTP_SERVER_PID=$!
     if which ip 2>&1 >/dev/null; then
         # Linux

--- a/e2e/constraints.txt
+++ b/e2e/constraints.txt
@@ -1,0 +1,1 @@
+setuptools < 72.0.0  # https://github.com/pypa/setuptools/issues/4519

--- a/e2e/test_bootstrap.sh
+++ b/e2e/test_bootstrap.sh
@@ -7,18 +7,8 @@
 # the overall logic of the build tools separately from the isolated
 # build pipelines.
 
-set -x
-set -e
-set -o pipefail
-
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
-
-rm -rf "$OUTDIR"
-mkdir "$OUTDIR"
-
-tox -e e2e -n -r
-source .tox/e2e/bin/activate
+source "$SCRIPTDIR/common.sh"
 
 fromager \
   --log-file="$OUTDIR/bootstrap.log" \

--- a/e2e/test_bootstrap_constraint.sh
+++ b/e2e/test_bootstrap_constraint.sh
@@ -7,18 +7,8 @@
 # the overall logic of the build tools separately from the isolated
 # build pipelines.
 
-set -x
-set -e
-set -o pipefail
-
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
-
-rm -rf "$OUTDIR"
-mkdir "$OUTDIR"
-
-tox -e e2e -n -r
-source .tox/e2e/bin/activate
+source "$SCRIPTDIR/common.sh"
 
 fromager \
   --sdists-repo="$OUTDIR/sdists-repo" \

--- a/e2e/test_bootstrap_extras.sh
+++ b/e2e/test_bootstrap_extras.sh
@@ -3,18 +3,8 @@
 
 # Tests full bootstrap with packages that have extras.
 
-set -x
-set -e
-set -o pipefail
-
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
-
-rm -rf "$OUTDIR"
-mkdir "$OUTDIR"
-
-tox -e e2e -n -r
-source .tox/e2e/bin/activate
+source "$SCRIPTDIR/common.sh"
 
 fromager \
   --log-file="$OUTDIR/test.log" \

--- a/e2e/test_build.sh
+++ b/e2e/test_build.sh
@@ -5,25 +5,13 @@
 # available.
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-set -x
-set -e
-set -o pipefail
-
-# Bootstrap to create the build order file.
-OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
+source "$SCRIPTDIR/common.sh"
 
 # What are we building?
 DIST="stevedore"
 VERSION="5.2.0"
 
-# Recreate output directory
-rm -rf "$OUTDIR"
-mkdir -p "$OUTDIR/build-logs"
-
-# Set up virtualenv with the CLI and dependencies.
-tox -e e2e -n -r
-source ".tox/e2e/bin/activate"
+# Install hook for test
 pip install e2e/post_build_hook
 
 # Bootstrap the test project

--- a/e2e/test_build_order.sh
+++ b/e2e/test_build_order.sh
@@ -5,30 +5,11 @@
 # not available when setting up to build a package.
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-set -x
-set -e
-set -o pipefail
-
-on_exit() {
-  [ "$HTTP_SERVER_PID" ] && kill "$HTTP_SERVER_PID"
-}
-trap on_exit EXIT SIGINT SIGTERM
-
-# Bootstrap to create the build order file.
-OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
+source "$SCRIPTDIR/common.sh"
 
 # What are we building?
 DIST="stevedore"
 VERSION="5.2.0"
-
-# Recreate output directory
-rm -rf "$OUTDIR"
-mkdir -p "$OUTDIR/build-logs"
-
-# Set up virtualenv with the CLI and dependencies.
-tox -e e2e -n -r
-source ".tox/e2e/bin/activate"
 
 # Bootstrap the test project
 fromager \

--- a/e2e/test_build_order.sh
+++ b/e2e/test_build_order.sh
@@ -25,13 +25,7 @@ rm -r "$OUTDIR/work-dir" "$OUTDIR/sdists-repo" "$OUTDIR/wheels-repo"
 # Rebuild the wheel mirror to be empty
 pypi-mirror create -d "$OUTDIR/wheels-repo/downloads/" -m "$OUTDIR/wheels-repo/simple/"
 
-# Start a web server for the wheels-repo. We remember the PID so we
-# can stop it later, and we determine the primary IP of the host
-# because podman won't see the server via localhost.
-python3 -m http.server --directory "$OUTDIR/wheels-repo/" 9999 &
-HTTP_SERVER_PID=$!
-IP=$(ip route get 1.1.1.1 | grep 1.1.1.1 | awk '{print $7}')
-export WHEEL_SERVER_URL="http://${IP}:9999/simple"
+start_local_wheel_server
 
 # Rebuild everything
 fromager \

--- a/e2e/test_build_order.sh
+++ b/e2e/test_build_order.sh
@@ -29,7 +29,7 @@ start_local_wheel_server
 
 # Rebuild everything
 fromager \
-    --log-file "$OUTDIR/build-logs/${dist}-build.log" \
+    --log-file "$OUTDIR/build-logs/${DIST}-build.log" \
     --work-dir "$OUTDIR/work-dir" \
     --sdists-repo "$OUTDIR/sdists-repo" \
     --wheels-repo "$OUTDIR/wheels-repo" \

--- a/e2e/test_build_settings.sh
+++ b/e2e/test_build_settings.sh
@@ -5,25 +5,13 @@
 # available.
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-set -x
-set -e
-set -o pipefail
-
-# Bootstrap to create the build order file.
-OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
+source "$SCRIPTDIR/common.sh"
 
 # What are we building?
 DIST="stevedore"
 VERSION="5.2.0"
 
-# Recreate output directory
-rm -rf "$OUTDIR"
-mkdir -p "$OUTDIR/build-logs"
-
-# Set up virtualenv with the CLI and dependencies.
-tox -e e2e -n -r
-source ".tox/e2e/bin/activate"
+# Install hook for test
 pip install e2e/post_build_hook
 
 # Bootstrap the test project

--- a/e2e/test_build_steps.sh
+++ b/e2e/test_build_steps.sh
@@ -25,19 +25,7 @@ rm -r "$OUTDIR/work-dir" "$OUTDIR/sdists-repo" "$OUTDIR/wheels-repo"
 # Rebuild the wheel mirror to be empty
 pypi-mirror create -d "$OUTDIR/wheels-repo/downloads/" -m "$OUTDIR/wheels-repo/simple/"
 
-# Start a web server for the wheels-repo. We remember the PID so we
-# can stop it later, and we determine the primary IP of the host
-# because podman won't see the server via localhost.
-python3 -m http.server --directory "$OUTDIR/wheels-repo/" 9999 &
-HTTP_SERVER_PID=$!
-if which ip 2>&1 >/dev/null; then
-    # Linux
-    IP=$(ip route get 1.1.1.1 | grep 1.1.1.1 | awk '{print $7}')
-else
-    # macOS
-    IP=$(ipconfig getifaddr en0)
-fi
-export WHEEL_SERVER_URL="http://${IP}:9999/simple"
+start_local_wheel_server
 
 # Define the function used in the build script
 build_wheel() {

--- a/e2e/test_build_steps.sh
+++ b/e2e/test_build_steps.sh
@@ -5,30 +5,11 @@
 # not available when setting up to build a package.
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-set -x
-set -e
-set -o pipefail
-
-on_exit() {
-  [ "$HTTP_SERVER_PID" ] && kill "$HTTP_SERVER_PID"
-}
-trap on_exit EXIT SIGINT SIGTERM
-
-# Bootstrap to create the build order file.
-OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
+source "$SCRIPTDIR/common.sh"
 
 # What are we building?
 DIST="stevedore"
 VERSION="5.2.0"
-
-# Recreate output directory
-rm -rf "$OUTDIR"
-mkdir -p "$OUTDIR/build-logs"
-
-# Set up virtualenv with the CLI and dependencies.
-tox -e e2e -n -r
-source ".tox/e2e/bin/activate"
 
 # Bootstrap the test project
 fromager \

--- a/e2e/test_download_sequence.sh
+++ b/e2e/test_download_sequence.sh
@@ -5,21 +5,7 @@
 # sources.download_source.
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-set -x
-set -e
-set -o pipefail
-
-# Bootstrap to create the build order file.
-OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
-
-# Recreate output directory for idempotency
-rm -rf "$OUTDIR"
-mkdir -p "$OUTDIR/build-logs"
-
-# Set up virtualenv with the CLI and dependencies.
-tox -e e2e -n -r
-source ".tox/e2e/bin/activate"
+source "$SCRIPTDIR/common.sh"
 
 # Bootstrap the test project
 fromager \

--- a/e2e/test_meson.sh
+++ b/e2e/test_meson.sh
@@ -4,25 +4,11 @@
 # Test meson build, verify that vendor_rust workaround is effective
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-set -x
-set -e
-set -o pipefail
-
-# Bootstrap to create the build order file.
-OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
+source "$SCRIPTDIR/common.sh"
 
 # What are we building?
 DIST="meson"
 VERSION="1.5.0"
-
-# Recreate output directory
-rm -rf "$OUTDIR"
-mkdir -p "$OUTDIR/build-logs"
-
-# Set up virtualenv with the CLI and dependencies.
-tox -e e2e -n -r
-source ".tox/e2e/bin/activate"
 
 # Bootstrap the test project
 fromager \

--- a/e2e/test_optimize_build.sh
+++ b/e2e/test_optimize_build.sh
@@ -1,18 +1,8 @@
 #!/bin/bash
 # -*- indent-tabs-mode: nil; tab-width: 2; sh-indentation: 2; -*-
 
-set -x
-set -e
-set -o pipefail
-
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
-
-rm -rf "$OUTDIR"
-mkdir "$OUTDIR"
-
-tox -e e2e -n -r
-source .tox/e2e/bin/activate
+source "$SCRIPTDIR/common.sh"
 
 fromager \
   --sdists-repo="$OUTDIR/sdists-repo" \

--- a/e2e/test_override.sh
+++ b/e2e/test_override.sh
@@ -7,17 +7,9 @@
 # the overall logic of the build tools separately from the isolated
 # build pipelines.
 
-set -x
-set -e
-set -o pipefail
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$SCRIPTDIR/common.sh"
 
-OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
-
-rm -rf "$OUTDIR"
-mkdir "$OUTDIR"
-
-tox -e e2e -n -r
-source .tox/e2e/bin/activate
 pip install e2e/flit_core_override
 
 fromager \

--- a/e2e/test_pep517_build_sdist.sh
+++ b/e2e/test_pep517_build_sdist.sh
@@ -5,33 +5,13 @@
 # not available when setting up to build a package.
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-set -x
-set -e
-set -o pipefail
-
-# Bootstrap to create the build order file.
-OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
+source "$SCRIPTDIR/common.sh"
 
 # What are we building?
 DIST="stevedore"
 VERSION="5.2.0"
 
-# Recreate output directory
-rm -rf "$OUTDIR"
-mkdir -p "$OUTDIR/build-logs"
-
-# Set up virtualenv with the CLI and dependencies.
-tox -e e2e -n -r
-source ".tox/e2e/bin/activate"
 pip install e2e/stevedore_override
-
-# # Bootstrap the test project to get local copies of all of the dependencies.
-# fromager \
-#     --sdists-repo="$OUTDIR/sdists-repo" \
-#     --wheels-repo="$OUTDIR/wheels-repo" \
-#     --work-dir="$OUTDIR/work-dir" \
-#     bootstrap "${DIST}==${VERSION}"
 
 # Download the source archive
 fromager \

--- a/e2e/test_prebuilt_wheels_alt_server.sh
+++ b/e2e/test_prebuilt_wheels_alt_server.sh
@@ -4,23 +4,8 @@
 # Test that when resolving a pre-built wheel the --wheel-server-url is
 # given preference over PyPI.org.
 
-set -x
-set -e
-set -o pipefail
-
-on_exit() {
-  [ "$HTTP_SERVER_PID" ] && kill "$HTTP_SERVER_PID"
-}
-trap on_exit EXIT SIGINT SIGTERM
-
-OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
-
-rm -rf "$OUTDIR"
-mkdir "$OUTDIR"
-OUTDIR="$(cd "$OUTDIR" && pwd)"  # use full path so when we cd we can still find things
-
-tox -e e2e -n -r
-source .tox/e2e/bin/activate
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$SCRIPTDIR/common.sh"
 
 INIT="$OUTDIR/init"
 mkdir -p "$INIT"

--- a/e2e/test_prebuilt_wheels_alt_server.sh
+++ b/e2e/test_prebuilt_wheels_alt_server.sh
@@ -37,13 +37,7 @@ cp "$filename" "$INIT/wheels-repo/downloads"
 # Make sure the mirror is up to date
 pypi-mirror create -d "$INIT/wheels-repo/downloads/" -m "$INIT/wheels-repo/simple/"
 
-# Start a web server for the wheels-repo. We remember the PID so we
-# can stop it later, and we determine the primary IP of the host
-# because podman won't see the server via localhost.
-python3 -m http.server --directory "$INIT/wheels-repo/" 9999 &
-HTTP_SERVER_PID=$!
-IP=$(ip route get 1.1.1.1 | grep 1.1.1.1 | awk '{print $7}')
-export WHEEL_SERVER_URL="http://${IP}:9999/simple"
+start_local_wheel_server
 
 TESTDIR="$OUTDIR/test"
 mkdir -p "$TESTDIR"

--- a/e2e/test_prebuilt_wheels_alt_server.sh
+++ b/e2e/test_prebuilt_wheels_alt_server.sh
@@ -21,6 +21,8 @@ fromager \
   --work-dir="$INIT/work-dir" \
   bootstrap "${DIST}==${VERSION}"
 
+start_local_wheel_server "$INIT/wheels-repo"
+
 # Modify the wheel so we can identify it as coming from the right
 # server.
 cd "$OUTDIR"
@@ -36,8 +38,6 @@ cp "$filename" "$INIT/wheels-repo/downloads"
 
 # Make sure the mirror is up to date
 pypi-mirror create -d "$INIT/wheels-repo/downloads/" -m "$INIT/wheels-repo/simple/"
-
-start_local_wheel_server
 
 TESTDIR="$OUTDIR/test"
 mkdir -p "$TESTDIR"

--- a/e2e/test_report_missing_dependency.sh
+++ b/e2e/test_report_missing_dependency.sh
@@ -5,29 +5,11 @@
 # not available when setting up to build a package.
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-set -x
-set -e
-set -o pipefail
-
-on_exit() {
-  [ "$HTTP_SERVER_PID" ] && kill "$HTTP_SERVER_PID"
-}
-trap on_exit EXIT SIGINT SIGTERM
-
-# Bootstrap to create the build order file.
-OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
+source "$SCRIPTDIR/common.sh"
 
 # What are we building?
 DIST="stevedore"
 VERSION="5.2.0"
-
-# Recreate output directory
-rm -rf "$OUTDIR"
-mkdir -p "$OUTDIR/build-logs"
-
-tox -e e2e -n -r
-source .tox/e2e/bin/activate
 
 fromager \
   --sdists-repo="$OUTDIR/sdists-repo" \

--- a/e2e/test_report_missing_dependency.sh
+++ b/e2e/test_report_missing_dependency.sh
@@ -32,13 +32,7 @@ done
 rm -rf "$OUTDIR/wheels-repo/simple"
 pypi-mirror create -d "$OUTDIR/wheels-repo/downloads/" -m "$OUTDIR/wheels-repo/simple/"
 
-# Start a web server for the wheels-repo. We remember the PID so we
-# can stop it later, and we determine the primary IP of the host
-# because podman won't see the server via localhost.
-python3 -m http.server --directory "$OUTDIR/wheels-repo/" 9999 &
-HTTP_SERVER_PID=$!
-IP=$(ip route get 1.1.1.1 | grep 1.1.1.1 | awk '{print $7}')
-export WHEEL_SERVER_URL="http://${IP}:9999/simple"
+start_local_wheel_server
 
 # Rebuild the original toplevel wheel, expecting a failure.
 version=$(jq -r '.[] | select ( .dist == "'$DIST'" ) | .version' "$OUTDIR/work-dir/build-order.json")

--- a/e2e/test_rust_vendor.sh
+++ b/e2e/test_rust_vendor.sh
@@ -5,25 +5,11 @@
 # available.
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-set -x
-set -e
-set -o pipefail
-
-# Bootstrap to create the build order file.
-OUTDIR="$(dirname "$SCRIPTDIR")/e2e-output"
+source "$SCRIPTDIR/common.sh"
 
 # What are we building?
 DIST="maturin"
 VERSION="1.6.0"
-
-# Recreate output directory
-rm -rf "$OUTDIR"
-mkdir -p "$OUTDIR/build-logs"
-
-# Set up virtualenv with the CLI and dependencies.
-tox -e e2e -n -r
-source ".tox/e2e/bin/activate"
 
 # Bootstrap the test project
 fromager \

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,8 @@ python-pypi-mirror
 PyYAML
 requests
 resolvelib
+setuptools<72.0.0
 stevedore
 toml
 tqdm
 virtualenv
-


### PR DESCRIPTION
Update our dependency and constrain dependency in CI.

In order to do that, apply a common startup script to each test script so we have a place to set up the constraints using values that should be common to each test.