### PR TITLE
cleanup: fix typings in commands/bootstrap.py

### DIFF
--- a/src/fromager/commands/bootstrap.py
+++ b/src/fromager/commands/bootstrap.py
@@ -14,7 +14,7 @@ def _get_requirements_from_args(
     toplevel: typing.Iterable[str],
     req_files: typing.Iterable[pathlib.Path],
 ) -> typing.Iterable[tuple[str, str]]:
-    to_build = []
+    to_build: list[tuple[str, str]] = []
     to_build.extend(("toplevel", t) for t in toplevel)
     for filename in req_files:
         to_build.extend(
@@ -39,7 +39,7 @@ def bootstrap(
     wkctx: context.WorkContext,
     requirements_files: list[pathlib.Path],
     toplevel: list[str],
-):
+) -> None:
     """Compute and build the dependencies of a set of requirements recursively
 
     TOPLEVEL is a requirements specification, including a package name
@@ -59,8 +59,8 @@ def bootstrap(
 
     server.start_wheel_server(wkctx)
 
-    for origin, toplevel in progress.progress(to_build):
-        sdist.handle_requirement(wkctx, Requirement(toplevel), req_type=origin)
+    for origin, dep in progress.progress(to_build):
+        sdist.handle_requirement(wkctx, Requirement(dep), req_type=origin)
 
     # If we put pre-built wheels in the downloads directory, we should
     # remove them so we can treat that directory as a source of wheels


### PR DESCRIPTION
part of #226 

fixes:
```
src/fromager/commands/bootstrap.py:17: error: Need type annotation for "to_build" (hint: "to_build: list[<type>] = ...")  [var-annotated]
src/fromager/commands/bootstrap.py:38: error: Function is missing a return type annotation  [no-untyped-def]
src/fromager/commands/bootstrap.py:63: error: Argument 1 to "Requirement" has incompatible type "list[str]"; expected "str"  [arg-type]
```