### PR TITLE
bug: fix installation of dependency by using the resolved_version instead of actual_version

### DIFF
--- a/src/fromager/sdist.py
+++ b/src/fromager/sdist.py
@@ -507,6 +507,8 @@ def _maybe_install(
             logger.info(
                 f"{req.name}: found {req.name} {actual_version} installed, updating to {resolved_version}"
             )
+            safe_install(ctx, Requirement(f"{req.name}=={resolved_version}"), req_type)
+            return
         except importlib.metadata.PackageNotFoundError as err:
             logger.debug(
                 f"{req.name}: could not determine version of {req.name}, will install: {err}"
@@ -537,5 +539,4 @@ def safe_install(
             f"{req}",
         ]
     )
-    version = importlib.metadata.version(req.name)
-    logger.info("installed %s %s using %s", req_type, req, version)
+    logger.info("installed %s %s using %s", req_type, req, req.specifier)


### PR DESCRIPTION
We noticed that dependencies that were resolving to some different version were not actually being installed using that version. Here is my analysis of the bug:

[_maybe_install](https://github.com/python-wheel-build/fromager/blob/main/src/fromager/sdist.py#L492) is called after handling each requirement. If the resolved version is not none, then it checks whether the actual version matches the resolved version and if it doesn't then it installs it using [safe_install](https://github.com/python-wheel-build/fromager/blob/main/src/fromager/sdist.py#L517) but in`_maybe_install` it seems like we are passing the old requirement to `safe_install` instead of the resolved one: https://github.com/python-wheel-build/fromager/blob/main/src/fromager/sdist.py#L514