### PR TITLE
Allow empty lines and comment in env files

### DIFF
--- a/src/fromager/overrides.py
+++ b/src/fromager/overrides.py
@@ -113,7 +113,10 @@ def extra_environ_for_pkg(
         )
         with open(env_file, "r") as f:
             for line in f:
-                key, _, value = line.strip().partition("=")
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                key, _, value = line.partition("=")
                 key = key.strip()
                 value = value.strip()
                 # remove quotes if they surround the value

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -53,6 +53,10 @@ def test_extra_environ_for_pkg(tmp_path: pathlib.Path):
     result = overrides.extra_environ_for_pkg(env_dir, "project", "variant")
     assert result == {"VAR1": "VALUE1", "VAR2": "VALUE2"}
 
+    project_env.write_text("VAR1=VALUE3\n# some comment\n\nVAR2=VALUE4\n\n")
+    result = overrides.extra_environ_for_pkg(env_dir, "project", "variant")
+    assert result == {"VAR1": "VALUE3", "VAR2": "VALUE4"}
+
     result = overrides.extra_environ_for_pkg(env_dir, "non_existant_project", "variant")
     assert result == {}
 


### PR DESCRIPTION
`.env` files can now contain comments to explain the meaning of an env var or to mark a todo. `extra_environ_for_pkg()` no longer fails when an `.env` file contains empty lines.