### PR TITLE
Add mypy optional dependency and types-tqdm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,11 +31,9 @@ classifiers = [
 requires-python = ">=3.10"
 
 [tool.setuptools.dynamic]
-optional-dependencies = { test = { file = [
-    "requirements-test.txt",
-] }, build = { file = [
-    "requirements-build.txt",
-] } }
+optional-dependencies.build = { file = ["requirements-build.txt"] }
+optional-dependencies.mypy = { file = ["requirements-mypy.txt"] }
+optional-dependencies.test = { file = ["requirements-test.txt"] }
 dependencies = { file = ["requirements.txt"] }
 
 [project.urls]

--- a/requirements-mypy.txt
+++ b/requirements-mypy.txt
@@ -1,0 +1,7 @@
+  mypy
+  pytest
+  types-html5lib
+  types-PyYAML
+  types-requests
+  types-toml
+  types-tqdm

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,7 @@ minversion = 3.2.0
 envlist=py,linter
 
 [testenv]
-deps =
-    .[test]
+extras = test
 commands =
     python -m pytest \
       --cov=fromager \
@@ -46,13 +45,7 @@ deps = .
 
 [testenv:mypy]
 description = Python type checking with mypy
-deps =
-  mypy
-  pytest
-  types-html5lib
-  types-PyYAML
-  types-requests
-  types-toml
+extras = mypy
 commands =
   mypy -p fromager
   mypy tests/


### PR DESCRIPTION
- move `mypy` extras into a requirements file
- install `types-tqdm` to fix mypy error in progress.py
- use a different TOML style for optional-dependencies
- tox: install extra dependencies with `extras`

See: #226