### PR TITLE
Run sdist and wheel building with network isolation

### DIFF
--- a/e2e/test_build.sh
+++ b/e2e/test_build.sh
@@ -16,6 +16,7 @@ pip install e2e/post_build_hook
 
 # Bootstrap the test project
 fromager \
+    --network-isolation \
     --sdists-repo="$OUTDIR/sdists-repo" \
     --wheels-repo="$OUTDIR/wheels-repo" \
     --work-dir="$OUTDIR/work-dir" \

--- a/e2e/test_rust_vendor.sh
+++ b/e2e/test_rust_vendor.sh
@@ -13,6 +13,7 @@ VERSION="1.6.0"
 
 # Bootstrap the test project
 fromager \
+    --network-isolation \
     --sdists-repo="$OUTDIR/sdists-repo" \
     --wheels-repo="$OUTDIR/wheels-repo" \
     --work-dir="$OUTDIR/work-dir" \

--- a/src/fromager/context.py
+++ b/src/fromager/context.py
@@ -27,6 +27,7 @@ class WorkContext:
         cleanup: bool = True,
         variant: str = "cpu",
         jobs: int | None = None,
+        network_isolation: bool = False,
     ):
         self.settings = active_settings
         self.constraints = pkg_constraints
@@ -45,6 +46,7 @@ class WorkContext:
         self.cleanup = cleanup
         self.variant = variant
         self.jobs = jobs
+        self.network_isolation = network_isolation
 
         self._build_order_filename = self.work_dir / "build-order.json"
         self._constraints_filename = self.work_dir / "constraints.txt"

--- a/src/fromager/dependencies.py
+++ b/src/fromager/dependencies.py
@@ -239,6 +239,8 @@ def get_build_backend_hook_caller(
     sdist_root_dir: pathlib.Path,
     pyproject_toml: dict[str, typing.Any],
     override_environ: dict[str, typing.Any],
+    *,
+    network_isolation: bool = False,
 ) -> pyproject_hooks.BuildBackendHookCaller:
     backend = get_build_backend(pyproject_toml)
 
@@ -255,7 +257,12 @@ def get_build_backend_hook_caller(
         if extra_environ is not None:
             full_environ.update(extra_environ)
         full_environ.update(override_environ)
-        external_commands.run(cmd, cwd=cwd, extra_environ=full_environ)
+        external_commands.run(
+            cmd,
+            cwd=cwd,
+            extra_environ=full_environ,
+            network_isolation=network_isolation,
+        )
 
     return pyproject_hooks.BuildBackendHookCaller(
         source_dir=str(sdist_root_dir),

--- a/src/fromager/external_commands.py
+++ b/src/fromager/external_commands.py
@@ -1,17 +1,52 @@
 import logging
 import os
 import shlex
+import shutil
 import subprocess
+import sys
 import typing
 
 logger = logging.getLogger(__name__)
+
+NETWORK_ISOLATION: list[str] | None
+if sys.platform == "linux":
+    NETWORK_ISOLATION = ["unshare", "--net", "--map-current-user"]
+else:
+    NETWORK_ISOLATION = None
+
+
+def network_isolation_cmd() -> tuple[str, ...]:
+    """Detect network isolation wrapper
+
+    Raises ValueError when network isolation is not supported
+    Returns: command list to run a process with network isolation
+    """
+    if sys.platform == "linux":
+        unshare = shutil.which("unshare")
+        if unshare is not None:
+            return [unshare, "--net", "--map-current-user"]
+        raise ValueError("Linux system without 'unshare' command")
+    raise ValueError(f"unsupported platform {sys.platform}")
+
+
+def detect_network_isolation():
+    """Detect if network isolation is available and working
+
+    unshare needs 'unshare' and 'clone' syscall. Docker's seccomp policy
+    blocks these syscalls. Podman's policy allows them.
+    """
+    cmd = network_isolation_cmd()
+    if os.name == "posix":
+        subprocess.check_call(cmd + ["true"], stderr=subprocess.STDOUT)
 
 
 # based on pyproject_hooks/_impl.py: quiet_subprocess_runner
 def run(
     cmd: typing.Sequence[str],
+    *,
     cwd: str | None = None,
     extra_environ: dict[str, typing.Any] | None = None,
+    network_isolation: bool = False,
     log_filename: str | None = None,
 ) -> str:
     """Call the subprocess while logging output"""
@@ -19,6 +54,11 @@ def run(
         extra_environ = {}
     env = os.environ.copy()
     env.update(extra_environ)
+
+    if network_isolation:
+        # prevent network access by creating a new network namespace that
+        # has no routing configured.
+        cmd = network_isolation_cmd() + cmd
 
     logger.debug(
         "running: %s %s in %s",

--- a/src/fromager/sdist.py
+++ b/src/fromager/sdist.py
@@ -537,6 +537,7 @@ def safe_install(
         + ctx.pip_wheel_server_args
         + [
             f"{req}",
-        ]
+        ],
+        network_isolation=False,
     )
     logger.info("installed %s %s using %s", req_type, req, req.specifier)

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -452,6 +452,7 @@ def pep517_build_sdist(
         sdist_root_dir,
         pyproject_toml,
         extra_environ,
+        network_isolation=ctx.network_isolation,
     )
     sdist_filename = hook_caller.build_sdist(ctx.sdists_builds)
     return ctx.sdists_builds / sdist_filename

--- a/src/fromager/vendor_rust.py
+++ b/src/fromager/vendor_rust.py
@@ -37,7 +37,7 @@ def _cargo_vendor(
     for manifest in manifests[1:]:
         args.append(f"--sync={manifest}")
     args.append(os.fspath(project_dir / VENDOR_DIR))
-    external_commands.run(args)
+    external_commands.run(args, network_isolation=False)
     return sorted(project_dir.joinpath(VENDOR_DIR).iterdir())
 
 

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -39,7 +39,10 @@ class BuildEnvironment:
             return
 
         logger.debug("creating build environment in %s", self.path)
-        external_commands.run([sys.executable, "-m", "virtualenv", str(self.path)])
+        external_commands.run(
+            [sys.executable, "-m", "virtualenv", str(self.path)],
+            network_isolation=False,
+        )
         logger.info("created build environment in %s", self.path)
 
         req_filename = self.path / "requirements.txt"
@@ -66,6 +69,7 @@ class BuildEnvironment:
                 str(req_filename.absolute()),
             ],
             cwd=str(self.path.parent),
+            network_isolation=False,
         )
         logger.info("installed dependencies into build environment in %s", self.path)
 
@@ -160,4 +164,9 @@ def default_build_wheel(
             os.fspath(sdist_root_dir.parent / "build.log"),
             os.fspath(sdist_root_dir),
         ]
-        external_commands.run(cmd, cwd=dir_name, extra_environ=override_env)
+        external_commands.run(
+            cmd,
+            cwd=dir_name,
+            extra_environ=override_env,
+            network_isolation=ctx.network_isolation,
+        )

--- a/tests/test_external_commands.py
+++ b/tests/test_external_commands.py
@@ -1,4 +1,10 @@
+import os
 import pathlib
+import subprocess
+import typing
+from unittest import mock
+
+import pytest
 
 from fromager import external_commands
 
@@ -21,3 +27,58 @@ def test_external_commands_log_file(tmp_path):
     assert log_filename.exists()
     file_contents = log_filename.read_text()
     assert "test\n" == file_contents
+
+
+@mock.patch("subprocess.run", return_value=mock.Mock(returncode=0))
+@mock.patch(
+    "fromager.external_commands.network_isolation_cmd",
+    return_value=["/bin/unshare", "--net", "--map-current-user"],
+)
+@mock.patch.dict(os.environ)
+def test_external_commands_network_isolation(
+    m_network_isolation_cmd: mock.Mock,
+    m_run: mock.Mock,
+):
+    os.environ.clear()
+    external_commands.run(
+        ["host", "github.com"],
+        extra_environ={},
+        network_isolation=True,
+    )
+    m_network_isolation_cmd.assert_called()
+    m_run.assert_called_with(
+        [
+            "/bin/unshare",
+            "--net",
+            "--map-current-user",
+            "host",
+            "github.com",
+        ],
+        cwd=None,
+        env={},
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+
+try:
+    external_commands.detect_network_isolation()
+except Exception:
+    SUPPORTS_NETWORK_ISOLATION: bool = False
+else:
+    SUPPORTS_NETWORK_ISOLATION = True
+
+
+@pytest.mark.skipif(
+    not SUPPORTS_NETWORK_ISOLATION, reason="network isolation is not supported"
+)
+def test_external_commands_network_isolation_real():
+    with pytest.raises(subprocess.CalledProcessError) as e:
+        external_commands.run(
+            ["host", "github.com"],
+            network_isolation=True,
+            extra_environ={"LC_ALL": "C"},
+        )
+    exc = typing.cast(subprocess.CalledProcessError, e.value)
+    assert exc.returncode == 1
+    assert "network unreachable" in exc.stdout

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ commands =
       --cov-report term-missing \
       --log-level DEBUG \
       -vv \
-      tests
+      {posargs:tests}
 
 [testenv:linter]
 base_python=python3.11


### PR DESCRIPTION
Prevent sdist and wheel build steps from accessing the internet. `externalcommand.run()` can use now run commands with unshare. `unshare --net --map-current-user` creates a new network namespace without access network.

Fixes: #263