### PR TITLE
Enforce MyPy type checks, ignore files with known issues

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -44,9 +44,7 @@ jobs:
       - name: Install dependencies
         run: python -m pip install tox
 
-      # tox -e mypy is failing, ignore errors for now
       - name: Check MyPy
-        continue-on-error: true
         run: tox -e mypy
 
   pkglint:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,20 @@ known-first-party = ["fromager"]
 
 [tool.mypy]
 mypy_path = ["src"]
+# TODO: tighten type checks
+# check_untyped_defs = true
+# disallow_incomplete_defs = true
+# disallow_untyped_defs = true
+# warn_return_any = true
+
+# TODO: remove excludes and silent follow
+follow_imports = "silent"
+exclude = [
+  "^src/fromager/resolver\\.py$",
+  "^src/fromager/sources\\.py$",
+  "^src/fromager/sdist\\.py$",
+  "^src/fromager/commands/build\\.py$",
+]
 
 [[tool.mypy.overrides]]
 # packages without typing annotations and stubs

--- a/src/fromager/external_commands.py
+++ b/src/fromager/external_commands.py
@@ -15,7 +15,7 @@ else:
     NETWORK_ISOLATION = None
 
 
-def network_isolation_cmd() -> tuple[str, ...]:
+def network_isolation_cmd() -> typing.Sequence[str]:
     """Detect network isolation wrapper
 
     Raises ValueError when network isolation is not supported
@@ -37,7 +37,8 @@ def detect_network_isolation():
     """
     cmd = network_isolation_cmd()
     if os.name == "posix":
-        subprocess.check_call(cmd + ["true"], stderr=subprocess.STDOUT)
+        check = [*cmd, "true"]
+        subprocess.check_call(check, stderr=subprocess.STDOUT)
 
 
 # based on pyproject_hooks/_impl.py: quiet_subprocess_runner
@@ -58,7 +59,10 @@ def run(
     if network_isolation:
         # prevent network access by creating a new network namespace that
         # has no routing configured.
-        cmd = network_isolation_cmd() + cmd
+        cmd = [
+            *network_isolation_cmd(),
+            *cmd,
+        ]
 
     logger.debug(
         "running: %s %s in %s",

--- a/src/fromager/vendor_rust.py
+++ b/src/fromager/vendor_rust.py
@@ -78,7 +78,7 @@ def _cargo_config(project_dir: pathlib.Path) -> None:
     except FileNotFoundError:
         logger.debug("creating new '.cargo/config.toml'")
         dotcargo.mkdir(exist_ok=True)
-        cfg = {}
+        cfg = tomlkit.parse("")
 
     cfg.update(CARGO_CONFIG)
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,6 +1,5 @@
 import pathlib
-import typing
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from packaging.requirements import Requirement
@@ -40,9 +39,7 @@ def test_load_non_existant_constraints_file(tmp_path: pathlib.Path):
 
 
 @patch("fromager.requirements_file.parse_requirements_file")
-def test_load_constraints_file(
-    parse_requirements_file: typing.Callable, tmp_path: pathlib.Path
-):
+def test_load_constraints_file(parse_requirements_file: Mock, tmp_path: pathlib.Path):
     constraint_file = tmp_path / "constraint.txt"
     constraint_file.write_text("a\n")
     parse_requirements_file.return_value = ["torch==3.1.0"]

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -1,6 +1,5 @@
 import os
 import pathlib
-import typing
 from unittest import mock
 from unittest.mock import patch
 
@@ -189,7 +188,7 @@ def test_invoke_override_with_not_enough_args():
 
 @patch("fromager.overrides.find_override_method")
 def test_find_and_invoke(
-    find_override_method: typing.Callable,
+    find_override_method: mock.Mock,
 ):
     def default_foo(arg1):
         return arg1 is not None

--- a/tests/test_sdist.py
+++ b/tests/test_sdist.py
@@ -1,7 +1,6 @@
 import pathlib
-import typing
 import zipfile
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from packaging.requirements import Requirement
@@ -13,7 +12,7 @@ from fromager.context import WorkContext
 
 @patch("fromager.sources.resolve_dist")
 def test_missing_dependency_format(
-    resolve_dist: typing.Callable,
+    resolve_dist: Mock,
     tmp_context: WorkContext,
 ):
     resolutions = {

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,6 +1,5 @@
 import pathlib
-import typing
-from unittest.mock import call, patch
+from unittest.mock import Mock, call, patch
 
 import pytest
 from packaging.requirements import Requirement
@@ -41,10 +40,10 @@ def test_resolve_template_with_no_matching_template():
 @patch.object(settings.Settings, "download_source_url")
 @patch.object(settings.Settings, "download_source_destination_filename")
 def test_default_download_source_from_settings(
-    download_source_destination_filename: typing.Callable,
-    download_source_url: typing.Callable,
-    download_source_check: typing.Callable,
-    resolve_dist: typing.Callable,
+    download_source_destination_filename: Mock,
+    download_source_url: Mock,
+    download_source_check: Mock,
+    resolve_dist: Mock,
     tmp_context: context.WorkContext,
 ):
     resolve_dist.return_value = ("url", "1.0")
@@ -68,11 +67,11 @@ def test_default_download_source_from_settings(
 @patch.object(settings.Settings, "resolver_include_wheels")
 @patch.object(settings.Settings, "resolver_sdist_server_url")
 def test_default_download_source_with_predefined_resolve_dist(
-    resolver_sdist_server_url: typing.Callable,
-    resolver_include_wheels: typing.Callable,
-    resolver_include_sdists: typing.Callable,
-    download_source_check: typing.Callable,
-    resolve_dist: typing.Callable,
+    resolver_sdist_server_url: Mock,
+    resolver_include_wheels: Mock,
+    resolver_include_sdists: Mock,
+    download_source_check: Mock,
+    resolve_dist: Mock,
     tmp_context: context.WorkContext,
 ):
     resolve_dist.return_value = ("url", "1.0")
@@ -118,7 +117,7 @@ def test_warning_for_older_patch(mock, tmp_path: pathlib.Path):
 
 @patch("fromager.sources._apply_patch")
 def test_patch_sources_apply_unversioned_and_versioned(
-    apply_patch: typing.Callable,
+    apply_patch: Mock,
     tmp_path: pathlib.Path,
     tmp_context: context.WorkContext,
 ):
@@ -151,7 +150,7 @@ def test_patch_sources_apply_unversioned_and_versioned(
 
 @patch("fromager.sources._apply_patch")
 def test_patch_sources_apply_only_unversioned(
-    apply_patch: typing.Callable,
+    apply_patch: Mock,
     tmp_path: pathlib.Path,
     tmp_context: context.WorkContext,
 ):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.2.0
-envlist=py,linter
+envlist=py,linter,mypy
 
 [testenv]
 extras = test


### PR DESCRIPTION
Thanks to Shubh's relentless work, most files now pass MyPy type checker. It's time to ensure that new code does not introduce regressions.

- enforce successful MyPy runs in `tox.ini` and GitHub Actions
- ignore MyPy errors in files with known issues
- fix a bunch of low hanging fruits in tests

See: #226