### PR TITLE
Fix progress bar recursion in bootstrap command

### DIFF
--- a/src/fromager/progress.py
+++ b/src/fromager/progress.py
@@ -6,9 +6,40 @@ import tqdm as _tqdm
 __all__ = ("progress",)
 
 
+class Progressbar:
+    def __init__(self, tqdm: _tqdm.tqdm | None) -> None:
+        self._tqdm = tqdm
+
+    def update_total(self, n: int) -> None:
+        if self._tqdm is not None and self._tqdm.total is not None:
+            self._tqdm.total += n
+
+    def update(self, n: int = 1) -> bool | None:
+        if self._tqdm is not None:
+            return self._tqdm.update(n)
+        return None
+
+    def __enter__(self) -> "Progressbar":
+        if self._tqdm is not None:
+            self._tqdm.__enter__()
+        return self
+
+    def __exit__(self, typ, value, traceback) -> None:
+        if self._tqdm is not None:
+            self._tqdm.__exit__(typ, value, traceback)
+
+
 def progress(it: typing.Iterable, *, unit="pkg", **kwargs: typing.Any) -> typing.Any:
     """tqdm progress bar"""
     if not sys.stdout.isatty():
         # wider progress bar in CI
         kwargs.setdefault("ncols", 78)
     yield from _tqdm.tqdm(it, unit=unit, **kwargs)
+
+
+def progress_context(total: int, *, unit="pkg", **kwargs: typing.Any) -> Progressbar:
+    """Context manager for progress bar with dynamic updates"""
+    if not sys.stdout.isatty():
+        # wider progress bar in CI
+        kwargs.setdefault("ncols", 78)
+    return Progressbar(_tqdm.tqdm(None, total=total, unit=unit, **kwargs))


### PR DESCRIPTION
The bootstrap command uses a recursive algorithm to fetch sources and to build sdists + wheels. The complete set of dependencies is unknown until all packages have been downloaded and built.

The bootstrap command now passes an optional `progressbar` object around. Each handler updates the total amount of items in the beginning of a loop, and notifies the progress bar when an item has finished.