### PR TITLE
show plugin package and version

### DIFF
--- a/e2e/flit_core_override/pyproject.toml
+++ b/e2e/flit_core_override/pyproject.toml
@@ -1,12 +1,10 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=64", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "flit-core-overrides"
-authors = [
-    {name = "Doug Hellmann", email="dhellmann@redhat.com"},
-]
+authors = [{ name = "Doug Hellmann", email = "dhellmann@redhat.com" }]
 description = "test package"
 dynamic = ["version"]
 classifiers = [

--- a/e2e/test_override.sh
+++ b/e2e/test_override.sh
@@ -13,6 +13,7 @@ source "$SCRIPTDIR/common.sh"
 pip install e2e/flit_core_override
 
 fromager \
+  --verbose \
   --log-file="$OUTDIR/bootstrap.log" \
   --sdists-repo="$OUTDIR/sdists-repo" \
   --wheels-repo="$OUTDIR/wheels-repo" \
@@ -25,7 +26,13 @@ find "$OUTDIR/wheels-repo/simple/" -name '*.whl'
 # Default to passing
 pass=true
 
-# Check for log message
+# Check for log message that the override is loaded
+if ! grep -q "from package_plugins.flit_core" "$OUTDIR/bootstrap.log"; then
+  echo "FAIL: Did not find log message from loading override in $OUTDIR/bootstrap.log" 1>&2
+  pass=false
+fi
+
+# Check for log message that the override is being used
 if ! grep -q "using override to build flit_core wheel" "$OUTDIR/bootstrap.log"; then
     echo "FAIL: Did not find log message from override in $OUTDIR/bootstrap.log" 1>&2
     pass=false

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+from importlib import metadata
 from unittest import mock
 from unittest.mock import patch
 
@@ -274,3 +275,10 @@ def test_regex_for_vllm(tmp_path: pathlib.Path):
     actual = overrides._filter_patches_based_on_req(lst, req_name)
     assert len(expected) == len(actual)
     assert expected == actual
+
+
+def test_get_dist_info():
+    fromager_version = metadata.version("fromager")
+    plugin_dist, plugin_version = overrides._get_dist_info("fromager.submodule")
+    assert plugin_dist == "fromager"
+    assert plugin_version == fromager_version


### PR DESCRIPTION
On startup, log the package and version from which
any override plugins are being loaded.