### PR TITLE
fix filenames in tarballs for sdists

### DIFF
--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -437,7 +437,11 @@ def default_build_sdist(
     # The format argument is specified based on
     # https://peps.python.org/pep-0517/#build-sdist.
     with tarfile.open(sdist_filename, "x:gz", format=tarfile.PAX_FORMAT) as sdist:
-        tarballs.tar_reproducible(sdist, sdist_root_dir)
+        tarballs.tar_reproducible(
+            tar=sdist,
+            basedir=sdist_root_dir,
+            prefix=sdist_root_dir.parent,
+        )
     return sdist_filename
 
 

--- a/src/fromager/tarballs.py
+++ b/src/fromager/tarballs.py
@@ -22,8 +22,17 @@ def _tar_reset(tarinfo: tarfile.TarInfo) -> tarfile.TarInfo:
     return tarinfo
 
 
-def tar_reproducible(tar: tarfile.TarFile, basedir: pathlib.Path) -> None:
-    """Create reproducible tar file"""
+def tar_reproducible(
+    tar: tarfile.TarFile,
+    basedir: pathlib.Path,
+    prefix: pathlib.Path | None = None,
+) -> None:
+    """Create reproducible tar file
+
+    Add content from basedir to already opened tar. If prefix is provided, use
+    it to set relative paths for the content being added.
+
+    """
 
     content = [str(basedir)]  # convert from pathlib.Path, if that's what we have
     for root, dirs, files in os.walk(basedir):
@@ -34,4 +43,7 @@ def tar_reproducible(tar: tarfile.TarFile, basedir: pathlib.Path) -> None:
     content.sort()
 
     for fn in content:
-        tar.add(fn, filter=_tar_reset, recursive=False, arcname=fn)
+        # Ensure that the paths in the tarfile are rooted at the prefix
+        # directory, if we have one.
+        arcname = fn if prefix is None else os.path.relpath(fn, prefix)
+        tar.add(fn, filter=_tar_reset, recursive=False, arcname=arcname)

--- a/tests/test_tarballs.py
+++ b/tests/test_tarballs.py
@@ -1,3 +1,4 @@
+import os
 import tarfile
 
 from fromager import tarballs
@@ -23,3 +24,35 @@ def test_modes_change(tmp_path):
     t1_contents = t1.read_bytes()
     t2_contents = t2.read_bytes()
     assert t1_contents == t2_contents, "file contents differ"
+
+
+def test_prefix_strip(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    subdir = root / "subdir"
+    subdir.mkdir()
+    a = subdir / "a"
+    a.write_text("this is file a")
+
+    t1 = tmp_path / "out1.tar"
+    with tarfile.open(t1, "w") as tf:
+        tarballs.tar_reproducible(tar=tf, basedir=root, prefix=subdir.parent)
+    with tarfile.open(t1, "r") as tf:
+        names = tf.getnames()
+    assert names == [".", "subdir", "subdir/a"]
+
+
+def test_no_prefix_strip(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    subdir = root / "subdir"
+    subdir.mkdir()
+    a = subdir / "a"
+    a.write_text("this is file a")
+
+    t1 = tmp_path / "out1.tar"
+    with tarfile.open(t1, "w") as tf:
+        tarballs.tar_reproducible(tar=tf, basedir=root)
+    with tarfile.open(t1, "r") as tf:
+        names = tf.getnames()
+    assert names == [str(p).lstrip(os.sep) for p in [root, subdir, a]]


### PR DESCRIPTION
Remove the prefix from the members of the tarballs
created by default for sdists.

Fixes #287