### PR TITLE
improve network isolation error handling

### DIFF
--- a/tests/test_external_commands.py
+++ b/tests/test_external_commands.py
@@ -73,7 +73,7 @@ else:
     not SUPPORTS_NETWORK_ISOLATION, reason="network isolation is not supported"
 )
 def test_external_commands_network_isolation_real():
-    with pytest.raises(subprocess.CalledProcessError) as e:
+    with pytest.raises(external_commands.NetworkIsolationError) as e:
         external_commands.run(
             ["host", "github.com"],
             network_isolation=True,
@@ -81,4 +81,3 @@ def test_external_commands_network_isolation_real():
         )
     exc = typing.cast(subprocess.CalledProcessError, e.value)
     assert exc.returncode == 1
-    assert "network unreachable" in exc.stdout


### PR DESCRIPTION
Add an exception type for network isolation errors
and raise that type instead of a simple
CalledProcessError when we are running with
network isolation and see a message that looks
like that is the problem. This fixes a problem
with running the tests on different versions of
Linux, where the actual error message from the
program run by the test might be different.