### PR TITLE
rendering .md using myst-parser

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,14 @@ release = metadata.version("fromager")
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["sphinx_click"]
+extensions = ["sphinx_click", 
+              "myst_parser"
+        ]
+
+# Recognized suffixes
+source_suffix = [
+    ".rst", ".md",
+]
 
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -33,6 +33,7 @@ to support different build variants, such as to enable different
 hardware accelerators. Therefore, the environment file directory is
 organized with a subdirectory per variant.
 
+(canonical-distribution-names)=
 Environment files are named using the [canonical distribution
 name](#canonical-distribution-names) and the suffix `.env`.
 
@@ -154,6 +155,7 @@ def download_source(ctx, req, sdist_server_url):
 
 ### get_resolver_provider
 
+(pypi.org)=
 The `get_resolver_provider()` function allows an override to change
 the way requirement specifications are converted to fixed
 versions. The default implementation looks for published versions on a

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,3 +16,5 @@ documentation for details.
    :caption: Contents:
 
    cli.rst
+   customization.md
+   develop.md

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,4 @@
 sphinx
 sphinx-click
+myst-parser
+


### PR DESCRIPTION
We can now see `customization.md` and `develop.md` rendered in our docs