### PR TITLE
Include README.md in Sphinx docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#creat
 as documented in [this
 issue](https://gitlab.com/gitlab-org/gitlab/-/issues/350582):
 
-```plaintext
+```
 machine gitlab.com login oauth2 password $token
 ```  
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,3 +1,6 @@
+``fromager`` cli
+================
+
 .. click:: fromager.__main__:main
   :prog: fromager
   :nested: full

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,8 @@
 from importlib import metadata
 
+from sphinx.addnodes import pending_xref
+from sphinx.transforms import SphinxTransform
+
 # Configuration file for the Sphinx documentation builder.
 #
 # For the full list of built-in configuration values, see the documentation:
@@ -16,22 +19,37 @@ release = metadata.version("fromager")
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["sphinx_click", 
-              "myst_parser"
-        ]
+extensions = ["sphinx_click", "myst_parser"]
 
 # Recognized suffixes
 source_suffix = [
-    ".rst", ".md",
+    ".rst",
+    ".md",
 ]
 
-templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
-language = 'English'
+language = "English"
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'alabaster'
-html_static_path = ['_static']
+html_theme = "alabaster"
+html_static_path = ["_static"]
+
+
+class RootReadmeTransform(SphinxTransform):
+    default_priority = 1
+
+    def apply(self, **kwargs) -> None:
+        for node in self.document.traverse(pending_xref):
+            if node.source == "../README.md":
+                reftarget = node.get("reftarget")
+                if reftarget is not None and reftarget.startswith("docs/"):
+                    # remove `docs/` and `.md`
+                    node["reftarget"] = reftarget[5:-3]
+
+
+def setup(app):
+    app.add_transform(RootReadmeTransform)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,15 +1,5 @@
-.. Fromager documentation master file, created by
-   sphinx-quickstart on Fri Jul 26 11:06:15 2024.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 Fromager documentation
 ======================
-
-Add your content using ``reStructuredText`` syntax. See the
-`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_
-documentation for details.
-
 
 .. toctree::
    :maxdepth: 2
@@ -18,3 +8,7 @@ documentation for details.
    cli.rst
    customization.md
    develop.md
+
+
+.. include:: ../README.md
+   :parser: myst_parser.sphinx_

--- a/tox.ini
+++ b/tox.ini
@@ -18,8 +18,8 @@ deps=
     ruff
     PyYAML
 commands =
-    ruff check src tests
-    ruff format --check src tests
+    ruff check src tests docs
+    ruff format --check src tests docs
     python ./e2e/mergify_lint.py
 skip_install = true
 skip_sdist = true
@@ -29,8 +29,8 @@ base_python=python3.11
 deps=
     ruff
 commands =
-    ruff format src tests
-    ruff check --fix src tests
+    ruff format src tests docs
+    ruff check --fix src tests docs
 skip_install = true
 skip_sdist = true
 


### PR DESCRIPTION
- include `../README.md` in the index document
- add a Sphinx transformer to fix the xref to documents. The README contains HTML-like links, MyST wants document references
- ruff `conf.py`