### PR TITLE
Show ELF provides and requires in logs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 click>=8.1.7
+elfdeps>=0.1.2
 html5lib
 packaging
 pkginfo


### PR DESCRIPTION
Fromager uses `elfdeps` to analyse the content of a wheel file and logs the library dependencies and provides.

Example output for `lxml-5.2.2-cp311-cp311-linux_x86_64.whl`

```
INFO: lxml: Requires libraries: libc.so.6, libexslt.so.0, libxml2.so.2, libxslt.so.1
DEBUG: lxml: Requires libc.so.6(GLIBC_2.3.4, GLIBC_2.4, GLIBC_2.2.5, GLIBC_2.14)
DEBUG: lxml: Requires libexslt.so.0()
DEBUG: lxml: Requires libxml2.so.2(LIBXML2_2.6.17, LIBXML2_2.5.2, LIBXML2_2.4.30, LIBXML2_2.9.0, LIBXML2_2.5.9, LIBXML2_2.6.0, LIBXML2_2.7.4, LIBXML2_2.6.15, LIBXML2_2.6.20, LIBXML2_2.6.5, LIBXML2_2.6.18, LIBXML2_2.6.10, LIBXML2_2.7.0, LIBXML2_2.6.24, LIBXML2_2.6.2, LIBXML2_2.6.16, LIBXML2_2.6.21, LIBXML2_2.6.32, LIBXML2_2.5.7, LIBXML2_2.6.1, LIBXML2_2.6.14, LIBXML2_2.6.23, LIBXML2_2.5.8)
DEBUG: lxml: Requires libxslt.so.1(LIBXML2_1.1.2, LIBXML2_1.0.22, LIBXML2_1.0.11, LIBXML2_1.0.24, LIBXML2_1.1.26, LIBXML2_1.1.9, LIBXML2_1.0.18)
DEBUG: lxml: Requires rtld(GNU_HASH)
```