### PR TITLE
cleanup: fix misc types in context, external_commands and finders

### DIFF
--- a/src/fromager/context.py
+++ b/src/fromager/context.py
@@ -141,7 +141,7 @@ class WorkContext:
         req_type: str,
         req: Requirement,
         version: Version,
-    ):
+    ) -> None:
         logger.debug(
             "recording %s dependency %s -> %s %s",
             req_type,

--- a/src/fromager/external_commands.py
+++ b/src/fromager/external_commands.py
@@ -29,7 +29,7 @@ def network_isolation_cmd() -> typing.Sequence[str]:
     raise ValueError(f"unsupported platform {sys.platform}")
 
 
-def detect_network_isolation():
+def detect_network_isolation() -> None:
     """Detect if network isolation is available and working
 
     unshare needs 'unshare' and 'clone' syscall. Docker's seccomp policy

--- a/src/fromager/finders.py
+++ b/src/fromager/finders.py
@@ -25,7 +25,7 @@ def _check_archive_name_in_settings(
     ctx: context.WorkContext,
     req: Requirement,
     dist_version: str,
-):
+) -> str | None:
     destination_filename_from_settings = (
         ctx.settings.download_source_destination_filename(
             req.name, req=req, version=dist_version


### PR DESCRIPTION
part of #226 

fixes
```
src/fromager/external_commands.py:32: error: Function is missing a return type annotation  [no-untyped-def]
src/fromager/external_commands.py:32: note: Use "-> None" if function does not return a value
src/fromager/context.py:138: error: Function is missing a return type annotation  [no-untyped-def]
src/fromager/finders.py:24: error: Function is missing a return type annotation  [no-untyped-def]
src/fromager/__main__.py:25: error: Call to untyped function "detect_network_isolation" in typed context  [no-untyped-call]
```