### PR TITLE
cleanup: fix typings for resolver.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,6 @@ mypy_path = ["src"]
 # TODO: remove excludes and silent follow
 follow_imports = "silent"
 exclude = [
-  "^src/fromager/resolver\\.py$",
   "^src/fromager/sources\\.py$",
   "^src/fromager/sdist\\.py$",
   "^src/fromager/commands/build\\.py$",

--- a/src/fromager/extras_provider.py
+++ b/src/fromager/extras_provider.py
@@ -18,7 +18,7 @@ candidate with an extra - X[foo] version v depends on X version v. By doing
 this, we constrain the solution to require a unique version of X.
 """
 
-from typing import TYPE_CHECKING
+import typing
 
 from packaging.requirements import Requirement
 from resolvelib.providers import AbstractProvider
@@ -27,7 +27,7 @@ from .candidate import Candidate
 
 # fix for runtime errors caused by inheriting classes that are generic in stubs but not runtime
 # https://mypy.readthedocs.io/en/latest/runtime_troubles.html#using-classes-that-are-generic-in-stubs-but-not-at-runtime
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     BaseAbstractProvider = AbstractProvider[Requirement, Candidate, str]
 else:
     BaseAbstractProvider = AbstractProvider
@@ -38,7 +38,7 @@ class ExtrasProvider(BaseAbstractProvider):
 
     def get_extras_for(
         self, requirement_or_candidate: Requirement | Candidate
-    ) -> tuple[str]:
+    ) -> typing.Iterable[str]:
         """Given a requirement or candidate, return its extras.
 
         The extras should be a hashable value.


### PR DESCRIPTION
part of #226 

fixes:
```
src/fromager/resolver.py:79: error: Need type annotation for "tags" (hint: "tags: set[<type>] = ...")  [var-annotated]
src/fromager/resolver.py:82: error: Incompatible types in assignment (expression has type "frozenset[Tag]", variable has type "set[Any]")  [assignment]
src/fromager/resolver.py:150: error: Incompatible return value type (got "tuple[str, ...]", expected "tuple[str]")  [return-value]
src/fromager/resolver.py:150: error: Argument 1 to "sorted" has incompatible type "Iterable[str] | None"; expected "Iterable[str]"  [arg-type]
src/fromager/resolver.py:155: error: Function is missing a type annotation  [no-untyped-def]
src/fromager/resolver.py:155: error: Signature of "get_preference" incompatible with supertype "AbstractProvider"  [override]
src/fromager/resolver.py:155: note:      Superclass:
src/fromager/resolver.py:155: note:          def get_preference(self, identifier: str, resolutions: Mapping[str, Candidate], candidates: Mapping[str, Iterator[Candidate]], information: Mapping[str, Iterator[RequirementInformation[Requirement, Candidate]]], backtrack_causes: Sequence[RequirementInformation[Requirement, Candidate]]) -> Preference
src/fromager/resolver.py:155: note:      Subclass:
src/fromager/resolver.py:155: note:          def get_preference(self, identifier: Any, resolutions: Any, candidates: Any, information: Any, **kwds: Any) -> Any
src/fromager/resolver.py:166: error: Missing type parameters for generic type "list"  [type-arg]
src/fromager/resolver.py:173: error: Argument 2 of "find_matches" is incompatible with supertype "AbstractProvider"; supertype defines the argument type as "Mapping[str, Iterator[Requirement]]"  [override]
src/fromager/resolver.py:173: note: This violates the Liskov substitution principle
src/fromager/resolver.py:173: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
src/fromager/resolver.py:174: error: Argument 3 of "find_matches" is incompatible with supertype "AbstractProvider"; supertype defines the argument type as "Mapping[str, Iterator[Candidate]]"  [override]
src/fromager/resolver.py:174: note: This violates the Liskov substitution principle
src/fromager/resolver.py:174: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
src/fromager/resolver.py:196: error: Argument 2 of "find_matches" is incompatible with supertype "AbstractProvider"; supertype defines the argument type as "Mapping[str, Iterator[Requirement]]"  [override]
src/fromager/resolver.py:196: note: This violates the Liskov substitution principle
src/fromager/resolver.py:196: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
src/fromager/resolver.py:197: error: Argument 3 of "find_matches" is incompatible with supertype "AbstractProvider"; supertype defines the argument type as "Mapping[str, Iterator[Candidate]]"  [override]
src/fromager/resolver.py:197: note: This violates the Liskov substitution principle
src/fromager/resolver.py:197: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
src/fromager/resolver.py:199: error: Incompatible types in assignment (expression has type "list[Requirement]", variable has type "dict[str, Iterable[Requirement]]")  [assignment]
src/fromager/resolver.py:207: error: Argument 2 to "get_project_from_pypi" has incompatible type "set[Never]"; expected "tuple[str]"  [arg-type]
src/fromager/resolver.py:217: error: "str" has no attribute "specifier"  [attr-defined]
src/fromager/resolver.py:246: error: Argument 1 to "sorted" has incompatible type "list[Candidate]"; expected "Iterable[Version]"  [arg-type]
src/fromager/resolver.py:262: error: Argument 2 of "find_matches" is incompatible with supertype "AbstractProvider"; supertype defines the argument type as "Mapping[str, Iterator[Requirement]]"  [override]
src/fromager/resolver.py:262: note: This violates the Liskov substitution principle
src/fromager/resolver.py:262: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
src/fromager/resolver.py:263: error: Argument 3 of "find_matches" is incompatible with supertype "AbstractProvider"; supertype defines the argument type as "Mapping[str, Iterator[Candidate]]"  [override]
src/fromager/resolver.py:263: note: This violates the Liskov substitution principle
src/fromager/resolver.py:263: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
src/fromager/resolver.py:265: error: Incompatible types in assignment (expression has type "list[Requirement]", variable has type "dict[str, Iterable[Requirement]]")  [assignment]
src/fromager/resolver.py:291: error: "str" has no attribute "specifier"  [attr-defined]
src/fromager/resolver.py:305: error: Argument "url" to "Candidate" has incompatible type "str | Version"; expected "str"  [arg-type]
src/fromager/resolver.py:306: error: Argument 1 to "sorted" has incompatible type "list[Candidate]"; expected "Iterable[Version]"  [arg-type]
```