### PR TITLE
clean up install message for build environment

### DIFF
--- a/src/fromager/sdist.py
+++ b/src/fromager/sdist.py
@@ -584,4 +584,4 @@ def safe_install(
         ],
         network_isolation=False,
     )
-    logger.info("installed %s %s using %s", req_type, req, req.specifier)
+    logger.info("installed %s requirement %s", req_type, req)


### PR DESCRIPTION
The old message produced confusing output like

  installed build_system wheel using

The new message will look like

  installed build_system requirement wheel

or

  installed build_system requirement wheel>1.0