### PR TITLE
add package-specific settings files

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -455,3 +455,25 @@ packages:
             include_sdists: false
         build_dir: directory name relative to sdist directory, defaults to an empty string, which means to use the sdist directory
 ```
+
+### Customizations using package-specific settings files
+
+In addition to the unified settings file, package settings can be saved in their
+own file in the directory specified with `--settings-dir`. Files should be named
+using the canonicalized form of the package name with the suffix `.yaml`. The
+data from the file is treated as though it appears in the
+`packages.package_name` section of the main settings file.  Files are read in
+lexicographical order. Settings in package-specific files override all settings
+in the global file.
+
+```yaml
+# settings/torch.yaml
+download_source:
+    url: "https://github.com/pytorch/pytorch/releases/download/v${version}/pytorch-v${version}.tar.gz"
+    destination_filename: "${canonicalized_name}-${version}.tar.gz"
+resolver_dist:
+    sdist_server_url: "https://pypi.org/simple"
+    include_wheels: true
+    include_sdists: false
+build_dir: directory name relative to sdist directory, defaults to an empty string, which means to use the sdist directory
+```

--- a/src/fromager/__main__.py
+++ b/src/fromager/__main__.py
@@ -91,6 +91,12 @@ else:
     help="location of the application settings file",
 )
 @click.option(
+    "--settings-dir",
+    default=pathlib.Path("overrides/settings"),
+    type=clickext.ClickPath(),
+    help="location of per-package settings files",
+)
+@click.option(
     "-c",
     "--constraints-file",
     type=clickext.ClickPath(),
@@ -132,6 +138,7 @@ def main(
     patches_dir: pathlib.Path,
     envs_dir: pathlib.Path,
     settings_file: pathlib.Path,
+    settings_dir: pathlib.Path,
     constraints_file: pathlib.Path,
     wheel_server_url: str,
     cleanup: bool,
@@ -178,7 +185,7 @@ def main(
         ctx.fail(f"network isolation is not available: {NETWORK_ISOLATION_ERROR}")
 
     wkctx = context.WorkContext(
-        active_settings=settings.load(settings_file),
+        active_settings=settings.load(settings_file, settings_dir),
         pkg_constraints=constraints.load(constraints_file),
         patches_dir=patches_dir,
         envs_dir=envs_dir,

--- a/src/fromager/settings.py
+++ b/src/fromager/settings.py
@@ -23,10 +23,7 @@ class Settings:
         return set(overrides.pkgname_to_override_module(n) for n in names)
 
     def packages(self) -> dict[str, dict[str, str]]:
-        p = self._return_value_or_default(self._data.get("packages"), {})
-        return {
-            overrides.pkgname_to_override_module(key): value for key, value in p.items()
-        }
+        return self._return_value_or_default(self._data.get("packages"), {})
 
     def download_source_url(
         self,

--- a/src/fromager/settings.py
+++ b/src/fromager/settings.py
@@ -148,16 +148,47 @@ def _resolve_template(
         raise
 
 
-def _parse(content: str) -> Settings:
-    data = yaml.safe_load(content)
-    return Settings(data)
+def load(settings_file: pathlib.Path, settings_dir: pathlib.Path) -> Settings:
+    settings_data = {}
 
-
-def load(filename: pathlib.Path) -> Settings:
-    filepath = pathlib.Path(filename)
+    filepath = pathlib.Path(settings_file)
     if not filepath.exists():
         logger.debug("settings file %s does not exist, ignoring", filepath.absolute())
-        return Settings({})
-    with open(filepath, "r") as f:
-        logger.info("loading settings from %s", filepath.absolute())
-        return _parse(f.read())
+    else:
+        with open(filepath, "r") as f:
+            logger.info("loading settings from %s", filepath.absolute())
+            settings_data = yaml.safe_load(f.read())
+
+    # Per-package files are inserted in the `packages` key using the name that
+    # will be used to look the value up. Transform any existing keys to that
+    # format so we can warn if there are overriding values.
+    package_settings_from = {}
+    if "packages" not in settings_data:
+        settings_data["packages"] = {}
+    else:
+        new_packages = {}
+        for name, value in settings_data["packages"].items():
+            package_name = overrides.pkgname_to_override_module(name)
+            new_packages[package_name] = value
+            package_settings_from[package_name] = settings_file
+        settings_data["packages"] = new_packages
+
+    for package_file in sorted(settings_dir.glob("*.yaml")):
+        package_name = overrides.pkgname_to_override_module(package_file.stem)
+        with open(package_file, "r") as f:
+            logger.info(
+                "%s: loading settings from %s",
+                package_name,
+                package_file.absolute(),
+            )
+            pkg_data = yaml.safe_load(f.read())
+            if package_name in settings_data["packages"]:
+                logger.warn(
+                    "%s: discarding settings from %s",
+                    package_name,
+                    package_settings_from[package_name],
+                )
+            settings_data["packages"][package_name] = pkg_data
+            package_settings_from[package_name] = package_file
+
+    return Settings(settings_data)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -149,7 +149,7 @@ def test_escape_sdist_root_build_dir():
 
 
 def test_changelog():
-    s = settings._parse(
+    s = _parse(
         textwrap.dedent("""
     packages:
       foo:


### PR DESCRIPTION
Support settings for individual packages in separate files for easier
sharing and management. This also makes it easier to set up jobs to test
builds of specific packages when their settings change, without building
packages that have no changes.