### PR TITLE
Drop support for Python 3.10

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.10"
           - "3.11"
           - "3.12"
         rust-version:
@@ -54,7 +53,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.10"
           - "3.11"
           - "3.12"
         rust-version:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -30,63 +30,48 @@ pull_request_rules:
           - check-success=pkglint
           - check-success=markdownlint
 
-          - check-success=unit (3.10, 1.75)
           - check-success=unit (3.11, 1.75)
           - check-success=unit (3.12, 1.75)
 
-          - check-success=e2e (3.10, 1.75, bootstrap)
           - check-success=e2e (3.11, 1.75, bootstrap)
           - check-success=e2e (3.12, 1.75, bootstrap)
 
-          - check-success=e2e (3.10, 1.75, bootstrap_extras)
           - check-success=e2e (3.11, 1.75, bootstrap_extras)
           - check-success=e2e (3.12, 1.75, bootstrap_extras)
 
-          - check-success=e2e (3.10, 1.75, build)
           - check-success=e2e (3.11, 1.75, build)
           - check-success=e2e (3.12, 1.75, build)
 
-          - check-success=e2e (3.10, 1.75, build_settings)
           - check-success=e2e (3.11, 1.75, build_settings)
           - check-success=e2e (3.12, 1.75, build_settings)
 
-          - check-success=e2e (3.10, 1.75, build_order)
           - check-success=e2e (3.11, 1.75, build_order)
           - check-success=e2e (3.12, 1.75, build_order)
 
-          - check-success=e2e (3.10, 1.75, build_steps)
           - check-success=e2e (3.11, 1.75, build_steps)
           - check-success=e2e (3.12, 1.75, build_steps)
 
-          - check-success=e2e (3.10, 1.75, override)
           - check-success=e2e (3.11, 1.75, override)
           - check-success=e2e (3.12, 1.75, override)
 
-          - check-success=e2e (3.10, 1.75, meson)
           - check-success=e2e (3.11, 1.75, meson)
           - check-success=e2e (3.12, 1.75, meson)
 
-          - check-success=e2e (3.10, 1.75, pep517_build_sdist)
           - check-success=e2e (3.11, 1.75, pep517_build_sdist)
           - check-success=e2e (3.12, 1.75, pep517_build_sdist)
 
-          - check-success=e2e (3.10, 1.75, prebuilt_wheels_alt_server)
           - check-success=e2e (3.11, 1.75, prebuilt_wheels_alt_server)
           - check-success=e2e (3.12, 1.75, prebuilt_wheels_alt_server)
 
-          - check-success=e2e (3.10, 1.75, report_missing_dependency)
           - check-success=e2e (3.11, 1.75, report_missing_dependency)
           - check-success=e2e (3.12, 1.75, report_missing_dependency)
 
-          - check-success=e2e (3.10, 1.75, rust_vendor)
           - check-success=e2e (3.11, 1.75, rust_vendor)
           - check-success=e2e (3.12, 1.75, rust_vendor)
 
-          - check-success=e2e (3.10, 1.75, download_sequence)
           - check-success=e2e (3.11, 1.75, download_sequence)
           - check-success=e2e (3.12, 1.75, download_sequence)
 
-          - check-success=e2e (3.10, 1.75, optimize_build)
           - check-success=e2e (3.11, 1.75, optimize_build)
           - check-success=e2e (3.12, 1.75, optimize_build)
 

--- a/e2e/flit_core_override/pyproject.toml
+++ b/e2e/flit_core_override/pyproject.toml
@@ -16,14 +16,13 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Utilities",
 ]
 
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 dependencies = []
 

--- a/e2e/post_build_hook/pyproject.toml
+++ b/e2e/post_build_hook/pyproject.toml
@@ -18,14 +18,13 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Utilities",
 ]
 
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 dependencies = []
 

--- a/e2e/stevedore_override/pyproject.toml
+++ b/e2e/stevedore_override/pyproject.toml
@@ -16,14 +16,13 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Utilities",
 ]
 
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 dependencies = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,14 +21,13 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Utilities",
 ]
 
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 [tool.setuptools.dynamic]
 optional-dependencies.build = { file = ["requirements-build.txt"] }
@@ -61,7 +60,7 @@ build_wheel = "fromager.wheels:default_build_wheel"
 version_file = "src/fromager/version.py"
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 # same as black's default line length
 line-length = 88
 exclude = [


### PR DESCRIPTION
There is no need to support Python 3.10 any more. Intel Gaudi software 1.17.0 now uses Python 3.11. The rest of the AI stack prefers 3.11, too.