### PR TITLE
cleanup: change warn to warning in settings.py

### DIFF
--- a/src/fromager/settings.py
+++ b/src/fromager/settings.py
@@ -180,7 +180,7 @@ def load(settings_file: pathlib.Path, settings_dir: pathlib.Path) -> Settings:
             )
             pkg_data = yaml.safe_load(f.read())
             if package_name in settings_data["packages"]:
-                logger.warn(
+                logger.warning(
                     "%s: discarding settings from %s",
                     package_name,
                     package_settings_from[package_name],


### PR DESCRIPTION
I am getting this warning when running the unit tests:

```
================================================================== warnings summary ===================================================================
tests/test_settings.py::test_load_package_files_precedence
tests/test_settings.py::test_load_package_files_precedence
  /home/sbapna/projects/fromager/.tox/py/lib/python3.12/site-packages/fromager/settings.py:183: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    logger.warn(

```