### PR TITLE
pass constraints file when installing build dependencies

### DIFF
--- a/e2e/test_build.sh
+++ b/e2e/test_build.sh
@@ -14,9 +14,16 @@ VERSION="5.2.0"
 # Install hook for test
 pip install e2e/post_build_hook
 
+OS=$(uname)
+if [ "$OS" = "Darwin" ]; then
+    NETWORK_ISOLATION=""
+else
+    NETWORK_ISOLATION="--network-isolation"
+fi
+
 # Bootstrap the test project
 fromager \
-    --network-isolation \
+    $NETWORK_ISOLATION \
     --sdists-repo="$OUTDIR/sdists-repo" \
     --wheels-repo="$OUTDIR/wheels-repo" \
     --work-dir="$OUTDIR/work-dir" \

--- a/e2e/test_report_missing_dependency.sh
+++ b/e2e/test_report_missing_dependency.sh
@@ -54,8 +54,9 @@ fromager \
   step prepare-source "$DIST" "$VERSION"
 
 # Prepare the build environment
+build_log="$OUTDIR/build-logs/prepare-build.log"
 fromager \
-  --log-file "$OUTDIR/build-logs/prepare-build.log" \
+  --log-file "$build_log" \
   --work-dir "$OUTDIR/work-dir" \
   --sdists-repo "$OUTDIR/sdists-repo" \
   --wheels-repo "$OUTDIR/wheels-repo" \
@@ -63,10 +64,11 @@ fromager \
   step prepare-build "$DIST" "$VERSION" \
   || echo "Got expected build error"
 
-if grep -q "MissingDependency" "$OUTDIR/build-logs/prepare-build.log"; then
+if grep -q "MissingDependency" "$build_log"; then
   echo "PASS: Found expected error"
 else
-  echo "FAIL: Did not find expected error in $OUTDIR/build-logs/prepare-build.log"
+  echo "FAIL: Did not find expected error in $build_log"
+  cat "$build_log"
   exit 1
 fi
 

--- a/e2e/test_rust_vendor.sh
+++ b/e2e/test_rust_vendor.sh
@@ -11,9 +11,16 @@ source "$SCRIPTDIR/common.sh"
 DIST="maturin"
 VERSION="1.6.0"
 
+OS=$(uname)
+if [ "$OS" = "Darwin" ]; then
+    NETWORK_ISOLATION=""
+else
+    NETWORK_ISOLATION="--network-isolation"
+fi
+
 # Bootstrap the test project
 fromager \
-    --network-isolation \
+    $NETWORK_ISOLATION \
     --sdists-repo="$OUTDIR/sdists-repo" \
     --wheels-repo="$OUTDIR/wheels-repo" \
     --work-dir="$OUTDIR/work-dir" \

--- a/src/fromager/__main__.py
+++ b/src/fromager/__main__.py
@@ -9,7 +9,6 @@ import click
 from . import (
     clickext,
     commands,
-    constraints,
     context,
     external_commands,
     overrides,
@@ -186,7 +185,7 @@ def main(
 
     wkctx = context.WorkContext(
         active_settings=settings.load(settings_file, settings_dir),
-        pkg_constraints=constraints.load(constraints_file),
+        constraints_file=constraints_file,
         patches_dir=patches_dir,
         envs_dir=envs_dir,
         sdists_repo=sdists_repo,

--- a/src/fromager/sdist.py
+++ b/src/fromager/sdist.py
@@ -596,6 +596,7 @@ def safe_install(
             ":all:",
         ]
         + ctx.pip_wheel_server_args
+        + ctx.pip_constraint_args
         + [
             f"{req}",
         ],

--- a/src/fromager/sdist.py
+++ b/src/fromager/sdist.py
@@ -539,9 +539,12 @@ def prepare_build_environment(
         match = _pip_missing_dependency_pattern.search(err.output)
         if match:
             raise MissingDependency(
-                ctx=ctx,
-                req_type="build",
-                all_reqs=build_system_dependencies | build_backend_dependencies,
+                ctx,
+                "build",
+                match.groups()[0],
+                build_system_dependencies
+                | build_backend_dependencies
+                | build_sdist_dependencies,
             ) from err
         raise
     return build_env.path

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -68,6 +68,7 @@ class BuildEnvironment:
                 ":all:",
             ]
             + self._ctx.pip_wheel_server_args
+            + self._ctx.pip_constraint_args
             + [
                 "-r",
                 str(req_filename.absolute()),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,13 @@
 import pytest
 
-from fromager import constraints, context, settings
+from fromager import context, settings
 
 
 @pytest.fixture
 def tmp_context(tmp_path):
     ctx = context.WorkContext(
         active_settings=settings.Settings({}),
-        pkg_constraints=constraints.Constraints({}),
+        constraints_file=None,
         patches_dir="overrides/patches",
         envs_dir="overrides/envs",
         sdists_repo=tmp_path / "sdists-repo",

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,6 +1,9 @@
 import json
+import os
 
 from packaging.requirements import Requirement
+
+from fromager import context, settings
 
 
 def test_seen(tmp_context):
@@ -143,3 +146,33 @@ def test_build_order_name_canonicalization(tmp_context):
         },
     ]
     assert expected == contents
+
+
+def test_pip_constraints_args(tmp_path):
+    constraints_file = tmp_path / "constraints.txt"
+    constraints_file.write_text("\n")  # the file has to exist
+    ctx = context.WorkContext(
+        active_settings=settings.Settings({}),
+        constraints_file=constraints_file,
+        patches_dir="overrides/patches",
+        envs_dir="overrides/envs",
+        sdists_repo=tmp_path / "sdists-repo",
+        wheels_repo=tmp_path / "wheels-repo",
+        work_dir=tmp_path / "work-dir",
+        wheel_server_url="",
+    )
+    ctx.setup()
+    assert ["--constraint", os.fspath(constraints_file)] == ctx.pip_constraint_args
+
+    ctx = context.WorkContext(
+        active_settings=settings.Settings({}),
+        constraints_file=None,
+        patches_dir="overrides/patches",
+        envs_dir="overrides/envs",
+        sdists_repo=tmp_path / "sdists-repo",
+        wheels_repo=tmp_path / "wheels-repo",
+        work_dir=tmp_path / "work-dir",
+        wheel_server_url="",
+    )
+    ctx.setup()
+    assert [] == ctx.pip_constraint_args

--- a/tests/test_sdist.py
+++ b/tests/test_sdist.py
@@ -1,4 +1,5 @@
 import pathlib
+import textwrap
 import zipfile
 from unittest.mock import Mock, patch
 
@@ -59,3 +60,34 @@ def test_invalid_wheel_file_exception(mock_download_url, tmp_path: pathlib.Path)
     text_file.write_text("This is a test file")
     with pytest.raises(zipfile.BadZipFile):
         sdist._download_wheel_check(fake_dir, fake_url)
+
+
+def test_missing_dependency_pattern():
+    msg = textwrap.dedent("""
+        Looking in indexes: http://192.168.0.201:9999/simple
+        Looking in links: /Users/dhellmann/.pip/wheelhouse
+        Processing /Users/dhellmann/.pip/wheelhouse/pbr-6.0.0-py2.py3-none-any.whl (from -r /Users/dhellmann/Devel/fromager/fromager/e2e-output/work-dir/stevedore-5.2.0/build-3.12.0/requirements.txt (line 1))
+        ERROR: Could not find a version that satisfies the requirement setuptools>=40.8.0 (from versions: 11.3.1, 14.0)
+        ERROR: No matching distribution found for setuptools>=40.8.0
+        """)
+    match = sdist._pip_missing_dependency_pattern.search(msg)
+    assert match is not None
+
+
+def test_missing_dependency_pattern_resolution_impossible():
+    msg = textwrap.dedent("""
+    Looking in indexes: http://10.1.0.116:9999/simple
+    ERROR: Cannot install setuptools>=40.8.0 because these package versions have conflicting dependencies.
+
+    The conflict is caused by:
+        The user requested setuptools>=40.8.0
+        The user requested (constraint) setuptools<72.0.0
+
+    To fix this you could try to:
+    1. loosen the range of package versions you've specified
+    2. remove package versions to allow pip to attempt to solve the dependency conflict
+
+    ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
+    """)
+    match = sdist._pip_missing_dependency_pattern.search(msg)
+    assert match is not None


### PR DESCRIPTION
If we're given a constraints file to decide which build dependencies to
use, apply those same constraints during installation. This ensures that if
the private wheel server has multiple versions of a package, we use the
right one to do the build.