### PR TITLE
download multiple packages in parallel in download-sequence

### DIFF
--- a/e2e/test_download_sequence.sh
+++ b/e2e/test_download_sequence.sh
@@ -9,6 +9,7 @@ source "$SCRIPTDIR/common.sh"
 
 # Bootstrap the test project
 fromager \
+  -v \
   --sdists-repo="$OUTDIR/sdists-repo" \
   --wheels-repo="$OUTDIR/wheels-repo" \
   --work-dir="$OUTDIR/work-dir" \


### PR DESCRIPTION
We use a build-order file to know what to
download, but we don't have to wait for one
download to complete to start the next one. Use
threads to download several packages in parallel.
Set a limit, but let the user control the limit
with a command line option.