### PR TITLE
enable CI on macos

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,7 +47,7 @@ jobs:
 
   e2e:
     name: e2e
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
@@ -74,6 +74,9 @@ jobs:
           - download_sequence
           - optimize_build
           - extra_metadata
+        os:
+          - ubuntu-latest
+          - macos-latest
 
     steps:
       - name: Get source

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -26,58 +26,66 @@ pull_request_rules:
   - name: Automatic merge on approval
     conditions:
       - and:
-          - check-success=linter
-          - check-success=pkglint
-          - check-success=markdownlint
-
-          - check-success=unit (3.11, 1.75)
-          - check-success=unit (3.12, 1.75)
-
-          - check-success=e2e (3.11, 1.75, bootstrap)
-          - check-success=e2e (3.12, 1.75, bootstrap)
-
-          - check-success=e2e (3.11, 1.75, bootstrap_extras)
-          - check-success=e2e (3.12, 1.75, bootstrap_extras)
-
-          - check-success=e2e (3.11, 1.75, build)
-          - check-success=e2e (3.12, 1.75, build)
-
-          - check-success=e2e (3.11, 1.75, build_settings)
-          - check-success=e2e (3.12, 1.75, build_settings)
-
-          - check-success=e2e (3.11, 1.75, build_order)
-          - check-success=e2e (3.12, 1.75, build_order)
-
-          - check-success=e2e (3.11, 1.75, build_steps)
-          - check-success=e2e (3.12, 1.75, build_steps)
-
-          - check-success=e2e (3.11, 1.75, override)
-          - check-success=e2e (3.12, 1.75, override)
-
-          - check-success=e2e (3.11, 1.75, meson)
-          - check-success=e2e (3.12, 1.75, meson)
-
-          - check-success=e2e (3.11, 1.75, pep517_build_sdist)
-          - check-success=e2e (3.12, 1.75, pep517_build_sdist)
-
-          - check-success=e2e (3.11, 1.75, prebuilt_wheels_alt_server)
-          - check-success=e2e (3.12, 1.75, prebuilt_wheels_alt_server)
-
-          - check-success=e2e (3.11, 1.75, report_missing_dependency)
-          - check-success=e2e (3.12, 1.75, report_missing_dependency)
-
-          - check-success=e2e (3.11, 1.75, rust_vendor)
-          - check-success=e2e (3.12, 1.75, rust_vendor)
-
-          - check-success=e2e (3.11, 1.75, download_sequence)
-          - check-success=e2e (3.12, 1.75, download_sequence)
-
-          - check-success=e2e (3.11, 1.75, optimize_build)
-          - check-success=e2e (3.12, 1.75, optimize_build)
-
-          - check-success=e2e (3.11, 1.75, extra_metadata)
-          - check-success=e2e (3.12, 1.75, extra_metadata)
-
+          - check-success=e2e (3.11, 1.75, bootstrap, macos-latest)
+          - check-success=e2e (3.11, 1.75, bootstrap, ubuntu-latest)
+          - check-success=e2e (3.11, 1.75, bootstrap_extras, macos-latest)
+          - check-success=e2e (3.11, 1.75, bootstrap_extras, ubuntu-latest)
+          - check-success=e2e (3.11, 1.75, build, macos-latest)
+          - check-success=e2e (3.11, 1.75, build, ubuntu-latest)
+          - check-success=e2e (3.11, 1.75, build_order, macos-latest)
+          - check-success=e2e (3.11, 1.75, build_order, ubuntu-latest)
+          - check-success=e2e (3.11, 1.75, build_settings, macos-latest)
+          - check-success=e2e (3.11, 1.75, build_settings, ubuntu-latest)
+          - check-success=e2e (3.11, 1.75, build_steps, macos-latest)
+          - check-success=e2e (3.11, 1.75, build_steps, ubuntu-latest)
+          - check-success=e2e (3.11, 1.75, download_sequence, macos-latest)
+          - check-success=e2e (3.11, 1.75, download_sequence, ubuntu-latest)
+          - check-success=e2e (3.11, 1.75, extra_metadata, macos-latest)
+          - check-success=e2e (3.11, 1.75, extra_metadata, ubuntu-latest)
+          - check-success=e2e (3.11, 1.75, meson, macos-latest)
+          - check-success=e2e (3.11, 1.75, meson, ubuntu-latest)
+          - check-success=e2e (3.11, 1.75, optimize_build, macos-latest)
+          - check-success=e2e (3.11, 1.75, optimize_build, ubuntu-latest)
+          - check-success=e2e (3.11, 1.75, override, macos-latest)
+          - check-success=e2e (3.11, 1.75, override, ubuntu-latest)
+          - check-success=e2e (3.11, 1.75, pep517_build_sdist, macos-latest)
+          - check-success=e2e (3.11, 1.75, pep517_build_sdist, ubuntu-latest)
+          - check-success=e2e (3.11, 1.75, prebuilt_wheels_alt_server, macos-latest)
+          - check-success=e2e (3.11, 1.75, prebuilt_wheels_alt_server, ubuntu-latest)
+          - check-success=e2e (3.11, 1.75, report_missing_dependency, macos-latest)
+          - check-success=e2e (3.11, 1.75, report_missing_dependency, ubuntu-latest)
+          - check-success=e2e (3.11, 1.75, rust_vendor, macos-latest)
+          - check-success=e2e (3.11, 1.75, rust_vendor, ubuntu-latest)
+          - check-success=e2e (3.12, 1.75, bootstrap, macos-latest)
+          - check-success=e2e (3.12, 1.75, bootstrap, ubuntu-latest)
+          - check-success=e2e (3.12, 1.75, bootstrap_extras, macos-latest)
+          - check-success=e2e (3.12, 1.75, bootstrap_extras, ubuntu-latest)
+          - check-success=e2e (3.12, 1.75, build, macos-latest)
+          - check-success=e2e (3.12, 1.75, build, ubuntu-latest)
+          - check-success=e2e (3.12, 1.75, build_order, macos-latest)
+          - check-success=e2e (3.12, 1.75, build_order, ubuntu-latest)
+          - check-success=e2e (3.12, 1.75, build_settings, macos-latest)
+          - check-success=e2e (3.12, 1.75, build_settings, ubuntu-latest)
+          - check-success=e2e (3.12, 1.75, build_steps, macos-latest)
+          - check-success=e2e (3.12, 1.75, build_steps, ubuntu-latest)
+          - check-success=e2e (3.12, 1.75, download_sequence, macos-latest)
+          - check-success=e2e (3.12, 1.75, download_sequence, ubuntu-latest)
+          - check-success=e2e (3.12, 1.75, extra_metadata, macos-latest)
+          - check-success=e2e (3.12, 1.75, extra_metadata, ubuntu-latest)
+          - check-success=e2e (3.12, 1.75, meson, macos-latest)
+          - check-success=e2e (3.12, 1.75, meson, ubuntu-latest)
+          - check-success=e2e (3.12, 1.75, optimize_build, macos-latest)
+          - check-success=e2e (3.12, 1.75, optimize_build, ubuntu-latest)
+          - check-success=e2e (3.12, 1.75, override, macos-latest)
+          - check-success=e2e (3.12, 1.75, override, ubuntu-latest)
+          - check-success=e2e (3.12, 1.75, pep517_build_sdist, macos-latest)
+          - check-success=e2e (3.12, 1.75, pep517_build_sdist, ubuntu-latest)
+          - check-success=e2e (3.12, 1.75, prebuilt_wheels_alt_server, macos-latest)
+          - check-success=e2e (3.12, 1.75, prebuilt_wheels_alt_server, ubuntu-latest)
+          - check-success=e2e (3.12, 1.75, report_missing_dependency, macos-latest)
+          - check-success=e2e (3.12, 1.75, report_missing_dependency, ubuntu-latest)
+          - check-success=e2e (3.12, 1.75, rust_vendor, macos-latest)
+          - check-success=e2e (3.12, 1.75, rust_vendor, ubuntu-latest)
           - "-draft"
 
           # At least 1 reviewer

--- a/e2e/mergify_lint.py
+++ b/e2e/mergify_lint.py
@@ -7,39 +7,39 @@ import sys
 import yaml
 
 # Parse the mergify settings to find the rules that are in place.
-mergify_settings_file = pathlib.Path('.mergify.yml')
-mergify_settings = yaml.safe_load(mergify_settings_file.read_text(encoding='utf8'))
-required_jobs = set()
-for item in mergify_settings['pull_request_rules']:
-    if item['name'] == 'Automatic merge on approval':
-        conditions = item['conditions'][0]['and']
-        # Look for 'check-success=e2e (something, something, something)'
+mergify_settings_file = pathlib.Path(".mergify.yml")
+mergify_settings = yaml.safe_load(mergify_settings_file.read_text(encoding="utf8"))
+existing_jobs = set()
+for item in mergify_settings["pull_request_rules"]:
+    if item["name"] == "Automatic merge on approval":
+        conditions = item["conditions"][0]["and"]
+        # Look for 'check-success=e2e (something, something, something, something)'
         for rule in conditions:
             if not isinstance(rule, str):
                 continue
-            if not rule.startswith('check-success=e2e'):
+            if not rule.startswith("check-success=e2e"):
                 continue
-            parameters = rule.partition(' ')[-1]
-            required_jobs.add(parameters)
-        if not required_jobs:
-            raise ValueError(f'Could not find e2e jobs in {mergify_settings_file}')
-print('found mergify required jobs:', required_jobs)
+            parameters = rule.partition(" ")[-1]
+            existing_jobs.add(parameters)
+        if not existing_jobs:
+            raise ValueError(f"Could not find e2e jobs in {mergify_settings_file}")
+print("existing jobs:\n  ", "\n  ".join(str(j) for j in sorted(existing_jobs)), sep="")
 
 # Parse the github actions file to find the test jobs that are defined.
-github_actions_file = pathlib.Path('.github/workflows/test.yaml')
-github_actions = yaml.safe_load(github_actions_file.read_text(encoding='utf8'))
-matrix = github_actions['jobs']['e2e']['strategy']['matrix']
-python_versions = list(sorted(matrix['python-version']))
-rust_versions = list(sorted(matrix['rust-version']))
-test_scripts = set(matrix['test-script'])
-print('found test scripts:', test_scripts)
+github_actions_file = pathlib.Path(".github/workflows/test.yaml")
+github_actions = yaml.safe_load(github_actions_file.read_text(encoding="utf8"))
+matrix = github_actions["jobs"]["e2e"]["strategy"]["matrix"]
+python_versions = list(sorted(matrix["python-version"]))
+rust_versions = list(sorted(matrix["rust-version"]))
+test_scripts = set(matrix["test-script"])
+print("found test scripts:\n  ", "\n  ".join(sorted(test_scripts)), sep="")
+os_versions = list(sorted(matrix["os"]))
 
-e2e_dir = pathlib.Path('e2e')
+e2e_dir = pathlib.Path("e2e")
 e2e_jobs = set(
-    script.name[len('test_'):-len('.sh')]
-    for script in e2e_dir.glob('test_*.sh')
+    script.name[len("test_") : -len(".sh")] for script in e2e_dir.glob("test_*.sh")
 )
-print('found job scripts:', e2e_jobs)
+print("found job scripts:\n  ", "\n  ".join(sorted(e2e_jobs)), sep="")
 
 # Remember if we should fail so we can apply all of the rules and then
 # exit with an error.
@@ -47,17 +47,32 @@ RC = 0
 
 # Require test jobs for every script.
 for script_name in sorted(e2e_jobs.difference(test_scripts)):
-    print(f'ERROR: {script_name} not in the matrix in {github_actions_file}')
-    RC =1
+    print(f"ERROR: {script_name} not in the matrix in {github_actions_file}")
+    RC = 1
 
 # We expect a job for every combination of python version, rust
 # version, and test script.
 expected_jobs = set(
-    str(combo).replace("'", '')
-    for combo in itertools.product(python_versions, rust_versions, test_scripts)
+    str(combo).replace("'", "")
+    for combo in itertools.product(
+        python_versions,
+        rust_versions,
+        test_scripts,
+        os_versions,
+    )
 )
-for job_name in sorted(expected_jobs.difference(required_jobs)):
-    print(f'ERROR: there is no rule requiring "check-success=e2e {job_name}" in {mergify_settings_file}')
+if not expected_jobs.difference(existing_jobs):
+    print("found rules for all expected jobs!")
+for job_name in sorted(expected_jobs.difference(existing_jobs)):
+    print(
+        f'ERROR: there is no rule requiring "check-success=e2e {job_name}" in {mergify_settings_file}'
+    )
     RC = 1
+
+if RC:
+    print(f"\njobs list to paste into {mergify_settings_file}:\n")
+    for job_name in sorted(expected_jobs):
+        print(f"          - check-success=e2e {job_name}")
+    print()
 
 sys.exit(RC)

--- a/e2e/test_rust_vendor.sh
+++ b/e2e/test_rust_vendor.sh
@@ -5,6 +5,7 @@
 # available.
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck disable=SC1091
 source "$SCRIPTDIR/common.sh"
 
 # What are we building?
@@ -14,8 +15,10 @@ VERSION="1.6.0"
 OS=$(uname)
 if [ "$OS" = "Darwin" ]; then
     NETWORK_ISOLATION=""
+    WHEEL_PLATFORM_TAG="macosx_10_9_universal2"
 else
     NETWORK_ISOLATION="--network-isolation"
+    WHEEL_PLATFORM_TAG="linux_x86_64"
 fi
 
 # Bootstrap the test project
@@ -29,7 +32,7 @@ fromager \
 PYVER=$(python3 -c 'import sys; print("%s%s" % sys.version_info[:2])')
 
 EXPECTED_FILES="
-wheels-repo/downloads/${DIST}-${VERSION}-cp${PYVER}-cp${PYVER}-linux_x86_64.whl
+wheels-repo/downloads/${DIST}-${VERSION}-cp${PYVER}-cp${PYVER}-${WHEEL_PLATFORM_TAG}.whl
 sdists-repo/downloads/${DIST}-${VERSION}.tar.gz
 "
 


### PR DESCRIPTION
In addition to updating the actual GitHub action settings, this PR adds output to the linter so it prints a full list of rules that are expected for mergify, to make it easy to update that configuration file.

Fixes #332 