### PR TITLE
upload logs on e2e failures to help debug

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,3 +99,9 @@ jobs:
 
       - name: Run tests
         run: ./e2e/test_${{ matrix.test-script }}.sh
+      
+      - name: Upload logs for debugging
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          path: e2e-output


### PR DESCRIPTION
I am having trouble debugging macos failures and the only way I can do that is via github actions since I don't have access to a mac machine