### PR TITLE
fix artifact naming conflicts

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -104,4 +104,5 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
+          name: ${{ matrix.test-script }}-py${{ matrix.python-version }}-rs${{ matrix.rust-version }}-${{ matrix.os }}
           path: e2e-output


### PR DESCRIPTION
artifact upload fails due to naming conflicts: https://github.com/python-wheel-build/fromager/actions/runs/10458484064/job/28960435191#step:7:18