### PR TITLE
fix: include hidden files when uploading coverage artifacts

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,6 +53,7 @@ jobs:
         with:
           name: coverage-unit-py${{ matrix.python-version }}-rs${{ matrix.rust-version }}-${{ matrix.os }}
           path: .coverage.*
+          include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 1
 
@@ -131,6 +132,7 @@ jobs:
         with:
           name: coverage-e2e-${{ matrix.test-script }}-py${{ matrix.python-version }}-rs${{ matrix.rust-version }}-${{ matrix.os }}
           path: .coverage.*
+          include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 1
 


### PR DESCRIPTION
Fixes our broken github actions for coverage. It was because there was a breaking change release for the upload-artifacts github action which now ignores hidden files by default https://github.com/actions/upload-artifact/releases/tag/v4.4.0