### PR TITLE
fix: rename `resolver_dist` to `resolve_source` and pass output dir to `download_source`

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -61,7 +61,7 @@ $ fromager --settings-dir=overrides/settings ...
 download_source:
     url: "https://github.com/pytorch/pytorch/releases/download/v${version}/pytorch-v${version}.tar.gz"
     destination_filename: "${canonicalized_name}-${version}.tar.gz"
-resolver_dist:
+resolve_source:
     sdist_server_url: "https://pypi.org/simple"
     include_wheels: true
     include_sdists: false
@@ -79,7 +79,7 @@ variants:
         pre_built: true
 ```
 
-### Download sources
+### Download source
 
 To use predefined urls to download sources from, instead of overriding
 the entire `download_source` function, a mapping of package to download
@@ -87,11 +87,11 @@ source url can be provided directly in settings.yaml. Optionally the
 downloaded sdist can be renamed. Both the url and the destination filename
 support templating. The only supported template variable are:
 
-- `version` - it is replaced by the version returned by the resolver
+- `version` - it is replaced by the version returned by the `resolve_source`
 - `canonicalized_name` - it is replaced by the canonicalized name of the
   package specified in the requirement, specifically it applies `canonicalize_name(req.nam)`
 
-### Resolver dist
+### Resolve source
 
 The source distribution index server used by the package resolver can
 be overriden for a particular package. The resolver can also be told
@@ -221,8 +221,9 @@ The `download_source()` function is responsible for downloading the
 source from a URL.
 
 The arguments are the `WorkContext`, the `Requirement` being
-evaluated, version of the package being downloaded and the URL
-from which the source can be downloaded as returned by `resolve_source`.
+evaluated, version of the package being downloaded, the URL
+from which the source can be downloaded as returned by `resolve_source`,
+and the output directory in which the source should be downloaded.  
 
 The return value should be a `pathlib.Path` file path to the downloaded source.
 
@@ -272,7 +273,7 @@ included, and the URL for the sdist server.
 The return value must be an instance of a class that implements the
 `resolvelib.providers.AbstractProvider` API.
 
-The expectation is that it acts an engine for any sort of package resolution
+The expectation is that it acts as an engine for any sort of package resolution
 whether it is for wheels or sources. The provider can
 therefore use any value as the "URL" that will help it decide what to
 download. For example, the `GitHubTagProvider` returns the actual tag

--- a/e2e/build_settings/stevedore.yaml
+++ b/e2e/build_settings/stevedore.yaml
@@ -1,7 +1,7 @@
 download_source:
   url: https://files.pythonhosted.org/packages/e7/c1/b210bf1071c96ecfcd24c2eeb4c828a2a24bf74b38af13896d02203b1eec/stevedore-${version}.tar.gz
   destination_filename: stevedore-custom-${version}.tar.gz
-resolver_dist:
+resolve_source:
   sdist_server_url: "https://pypi.org/simple"
   include_sdists: false
   include_wheels: true

--- a/src/fromager/packagesettings.py
+++ b/src/fromager/packagesettings.py
@@ -105,7 +105,7 @@ MODEL_CONFIG = pydantic.ConfigDict(
 )
 
 
-class ResolverDist(pydantic.BaseModel):
+class ResolveSource(pydantic.BaseModel):
     """Packages resolver dist"""
 
     model_config = MODEL_CONFIG
@@ -173,7 +173,7 @@ class PackageSettings(pydantic.BaseModel):
         download_source:
             url: https://egg.test
             destination_filename: new_filename
-        resolver_dist:
+        resolve_source:
             sdist_server_url: https://sdist.test/egg
             include_sdists: true
             include_wheels: false
@@ -206,14 +206,14 @@ class PackageSettings(pydantic.BaseModel):
     download_source: DownloadSource = Field(default_factory=DownloadSource)
     """Alternative source download settings"""
 
-    resolver_dist: ResolverDist = Field(default_factory=ResolverDist)
+    resolve_source: ResolveSource = Field(default_factory=ResolveSource)
     """Resolve distribution version"""
 
     variants: Mapping[Variant, VariantInfo] = Field(default_factory=dict)
     """Variant configuration"""
 
     @pydantic.field_validator(
-        "download_source", "resolver_dist", "variants", mode="before"
+        "download_source", "resolve_source", "variants", mode="before"
     )
     @classmethod
     def before_none_dict(
@@ -434,22 +434,22 @@ class PackageBuildInfo:
         else:
             return None
 
-    def resolver_sdist_server_url(self, default: str) -> str:
+    def resolve_source_sdist_server_url(self, default: str) -> str:
         """Package index server URL for resolving package versions"""
-        url = self._ps.resolver_dist.sdist_server_url
+        url = self._ps.resolve_source.sdist_server_url
         if url is None:
             url = default
         return url
 
     @property
-    def resolver_include_wheels(self) -> bool:
+    def resolve_source_include_wheels(self) -> bool:
         """Include wheels when resolving package versions?"""
-        return self._ps.resolver_dist.include_wheels
+        return self._ps.resolve_source.include_wheels
 
     @property
-    def resolver_include_sdists(self) -> bool:
+    def resolve_source_include_sdists(self) -> bool:
         """Include sdists when resolving package versions?"""
-        return self._ps.resolver_dist.include_sdists
+        return self._ps.resolve_source.include_sdists
 
     def build_dir(self, sdist_root_dir: pathlib.Path) -> pathlib.Path:
         """Build directory for package (e.g. subdirectory)"""

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -51,6 +51,7 @@ def download_source(
         req=req,
         version=version,
         download_url=download_url,
+        sdists_downloads_dir=ctx.sdists_downloads,
     )
 
     if not isinstance(source_path, pathlib.Path):
@@ -107,27 +108,31 @@ def default_resolve_source(
     "Return URL to source and its version."
 
     pbi = ctx.package_build_info(req)
-    override_sdist_server_url = pbi.resolver_sdist_server_url(sdist_server_url)
+    override_sdist_server_url = pbi.resolve_source_sdist_server_url(sdist_server_url)
 
     url, version = resolver.resolve(
         ctx=ctx,
         req=req,
         sdist_server_url=override_sdist_server_url,
-        include_sdists=pbi.resolver_include_sdists,
-        include_wheels=pbi.resolver_include_wheels,
+        include_sdists=pbi.resolve_source_include_sdists,
+        include_wheels=pbi.resolve_source_include_wheels,
     )
     return url, version
 
 
 def default_download_source(
-    ctx: context.WorkContext, req: Requirement, version: Version, download_url: str
+    ctx: context.WorkContext,
+    req: Requirement,
+    version: Version,
+    download_url: str,
+    sdists_downloads_dir: pathlib.Path,
 ) -> pathlib.Path:
     "Download the requirement and return the name of the output path."
     pbi = ctx.package_build_info(req)
     destination_filename = pbi.download_source_destination_filename(version=version)
     url = pbi.download_source_url(version=version, default=download_url)
     source_filename = _download_source_check(
-        ctx.sdists_downloads, url, destination_filename
+        sdists_downloads_dir, url, destination_filename
     )
 
     logger.debug(

--- a/tests/test_packagesettings.py
+++ b/tests/test_packagesettings.py
@@ -37,7 +37,7 @@ FULL_EXPECTED = {
     },
     "name": "test-pkg",
     "has_config": True,
-    "resolver_dist": {
+    "resolve_source": {
         "include_sdists": True,
         "include_wheels": False,
         "sdist_server_url": "https://sdist.test/egg",
@@ -71,7 +71,7 @@ EMPTY_EXPECTED = {
         "destination_filename": None,
     },
     "has_config": True,
-    "resolver_dist": {
+    "resolve_source": {
         "sdist_server_url": None,
         "include_sdists": True,
         "include_wheels": False,
@@ -165,10 +165,10 @@ def test_pbi_test_pkg(testdata_context: context.WorkContext) -> None:
         pbi.download_source_destination_filename(Version("1.0.2"))
         == "test-pkg-1.0.2.tar.gz"
     )
-    assert pbi.resolver_include_sdists is True
-    assert pbi.resolver_include_wheels is False
+    assert pbi.resolve_source_include_sdists is True
+    assert pbi.resolve_source_include_wheels is False
     assert (
-        pbi.resolver_sdist_server_url("https://pypi.org/simple")
+        pbi.resolve_source_sdist_server_url("https://pypi.org/simple")
         == "https://sdist.test/egg"
     )
     assert pbi.build_tag(Version("1.0.2")) == (2, "")
@@ -198,10 +198,10 @@ def test_pbi_other(testdata_context: context.WorkContext) -> None:
     assert pbi.download_source_url(Version("1.0.0")) is None
     assert pbi.download_source_destination_filename(Version("1.0.0")) is None
     assert pbi.download_source_destination_filename(Version("1.0.0")) is None
-    assert pbi.resolver_include_sdists is True
-    assert pbi.resolver_include_wheels is False
+    assert pbi.resolve_source_include_sdists is True
+    assert pbi.resolve_source_include_wheels is False
     assert (
-        pbi.resolver_sdist_server_url("https://pypi.org/simple")
+        pbi.resolve_source_sdist_server_url("https://pypi.org/simple")
         == "https://pypi.org/simple"
     )
     assert pbi.build_tag(Version("1.0.0")) == ()

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -42,7 +42,13 @@ def test_default_download_source_from_settings(
         include_wheels=False,
     )
 
-    sources.default_download_source(testdata_context, req, Version("42.1.2"), "url")
+    sources.default_download_source(
+        testdata_context,
+        req,
+        Version("42.1.2"),
+        "url",
+        testdata_context.sdists_downloads,
+    )
 
     download_source_check.assert_called_with(
         testdata_context.sdists_downloads,
@@ -55,9 +61,9 @@ def test_default_download_source_from_settings(
 @patch("fromager.sources._download_source_check")
 @patch.multiple(
     packagesettings.PackageBuildInfo,
-    resolver_include_sdists=False,
-    resolver_include_wheels=True,
-    resolver_sdist_server_url=Mock(return_value="url"),
+    resolve_source_include_sdists=False,
+    resolve_source_include_wheels=True,
+    resolve_source_sdist_server_url=Mock(return_value="url"),
 )
 def test_default_download_source_with_predefined_resolve_dist(
     download_source_check: Mock,

--- a/tests/testdata/config-0.27/expected/torch.yaml
+++ b/tests/testdata/config-0.27/expected/torch.yaml
@@ -4,7 +4,7 @@ download_source:
 env:
   USE_FFMPEG: '0'
   USE_OPENCV: '0'
-resolver_dist:
+resolve_source:
   include_sdists: false
   include_wheels: true
   sdist_server_url: https://pypi.org/simple

--- a/tests/testdata/config-0.27/settings.yaml
+++ b/tests/testdata/config-0.27/settings.yaml
@@ -7,7 +7,7 @@ packages:
     download_source:
       url: "https://github.com/pytorch/pytorch/releases/download/v${version}/pytorch-v${version}.tar.gz"
       destination_filename: "torch-${version}.tar.gz"
-    resolver_dist:
+    resolve_source:
       sdist_server_url: "https://pypi.org/simple"
       include_sdists: false
       include_wheels: true

--- a/tests/testdata/context/overrides/settings/test_pkg.yaml
+++ b/tests/testdata/context/overrides/settings/test_pkg.yaml
@@ -13,7 +13,7 @@ env:
 download_source:
     url: https://egg.test/${canonicalized_name}/v${version}.tar.gz
     destination_filename: ${canonicalized_name}-${version}.tar.gz
-resolver_dist:
+resolve_source:
     sdist_server_url: https://sdist.test/egg
     include_sdists: true
     include_wheels: false


### PR DESCRIPTION
fixes #385 and also adds the nit picks from #384 

I know we discussed renaming fields in settings such that they are decoupled from their corresponding override but i think in this case `resolve_source` is a good name :)