### PR TITLE
fix: use download links from build order file in download sequence and build sequence instead of resolving again

### DIFF
--- a/docs/using.md
+++ b/docs/using.md
@@ -56,8 +56,7 @@ source distributions. The server URL is usually a simple index URL for
 an internal package index. The outputs are one patched source
 distribution and one built wheel.
 
-The `build-sequence` command takes a build-order file, the variant,
-and the source distribution server URL. The outputs are patched source
+The `build-sequence` command takes a build-order file and the variant. The outputs are patched source
 distributions and built wheels for each item in the build-order file.
 
 ### Step-by-step commands

--- a/e2e/test_build_order.sh
+++ b/e2e/test_build_order.sh
@@ -41,7 +41,7 @@ fromager \
     --sdists-repo "$OUTDIR/sdists-repo" \
     --wheels-repo "$OUTDIR/wheels-repo" \
     --settings-dir="$SCRIPTDIR/changelog_settings" \
-    build-sequence "$OUTDIR/build-order.json" $WHEEL_SERVER_URL
+    build-sequence "$OUTDIR/build-order.json"
 
 find "$OUTDIR/wheels-repo/"
 
@@ -79,7 +79,7 @@ fromager \
     --sdists-repo "$OUTDIR/sdists-repo" \
     --wheels-repo "$OUTDIR/wheels-repo" \
     --settings-dir="$SCRIPTDIR/changelog_settings" \
-    build-sequence --skip-existing "$OUTDIR/build-order.json" $WHEEL_SERVER_URL
+    build-sequence --skip-existing "$OUTDIR/build-order.json"
 
 find "$OUTDIR/wheels-repo/"
 
@@ -104,7 +104,7 @@ fromager \
     --sdists-repo "$OUTDIR/sdists-repo" \
     --wheels-repo "$OUTDIR/wheels-repo" \
     --settings-dir="$SCRIPTDIR/changelog_settings" \
-    build-sequence "$OUTDIR/build-order.json" $WHEEL_SERVER_URL
+    build-sequence "$OUTDIR/build-order.json"
 
 find "$OUTDIR/wheels-repo/"
 
@@ -128,7 +128,7 @@ fromager \
     --sdists-repo "$OUTDIR/sdists-repo" \
     --wheels-repo "$OUTDIR/wheels-repo" \
     --settings-dir="$SCRIPTDIR/changelog_settings-2" \
-    build-sequence --skip-existing "$OUTDIR/build-order.json" $WHEEL_SERVER_URL
+    build-sequence --skip-existing "$OUTDIR/build-order.json"
 
 find "$OUTDIR/wheels-repo/"
 


### PR DESCRIPTION
fixes #374 
fixes #92 

Breaking change in the `build-sequence` command: it doesn't need the sdist_server_url arg anymore