### PR TITLE
Redesign parallel build configuration

### DIFF
--- a/requirements-mypy.txt
+++ b/requirements-mypy.txt
@@ -1,6 +1,7 @@
   mypy
   pytest
   types-html5lib
+  types-psutil
   types-PyYAML
   types-requests
   types-toml

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ elfdeps>=0.2.0
 html5lib
 packaging
 pkginfo
+psutil
 pydantic
 PyGithub
 pyproject_hooks>=1.0.0,!=1.1.0

--- a/src/fromager/__main__.py
+++ b/src/fromager/__main__.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import logging
-import os
 import pathlib
 
 import click
@@ -119,7 +118,8 @@ else:
     "-j",
     "--jobs",
     type=int,
-    help="number of jobs available to run in parallel",
+    default=None,
+    help="maximum number of jobs to run in parallel",
 )
 @click.option(
     "--network-isolation/--no-network-isolation",
@@ -143,7 +143,7 @@ def main(
     wheel_server_url: str,
     cleanup: bool,
     variant: str,
-    jobs: int,
+    jobs: int | None,
     network_isolation: bool,
 ) -> None:
     # Set the overall logger level to debug and allow the handlers to filter
@@ -190,6 +190,7 @@ def main(
             settings_dir=settings_dir,
             patches_dir=patches_dir,
             variant=variant,
+            max_jobs=jobs,
         ),
         constraints_file=constraints_file,
         patches_dir=patches_dir,
@@ -199,8 +200,8 @@ def main(
         wheel_server_url=wheel_server_url,
         cleanup=cleanup,
         variant=variant,
-        jobs=jobs if jobs is None or jobs > 0 else os.cpu_count(),
         network_isolation=network_isolation,
+        max_jobs=jobs,
     )
     wkctx.setup()
     ctx.obj = wkctx

--- a/src/fromager/context.py
+++ b/src/fromager/context.py
@@ -36,8 +36,8 @@ class WorkContext:
         wheel_server_url: str,
         cleanup: bool = True,
         variant: str = "cpu",
-        jobs: int | None = None,
         network_isolation: bool = False,
+        max_jobs: int | None = None,
     ):
         if active_settings is None:
             active_settings = packagesettings.Settings(
@@ -45,6 +45,7 @@ class WorkContext:
                 package_settings=[],
                 patches_dir=patches_dir,
                 variant=variant,
+                max_jobs=max_jobs,
             )
         self.settings = active_settings
         self.input_constraints_file = constraints_file
@@ -64,7 +65,6 @@ class WorkContext:
         self.wheel_server_url = wheel_server_url
         self.cleanup = cleanup
         self.variant = variant
-        self.jobs = jobs
         self.network_isolation = network_isolation
 
         self._build_order_filename = self.work_dir / "build-order.json"

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -234,13 +234,13 @@ def build_wheel(
     # TODO: refactor?
     # Build Rust without network access
     extra_environ["CARGO_NET_OFFLINE"] = "true"
-    # configure max jobs settings. should cover most of the cases, if not then the user can use ctx.jobs in their plugin
-    if ctx.jobs:
-        extra_environ["MAKEFLAGS"] = (
-            f"{extra_environ.get('MAKEFLAGS', '')} -j{ctx.jobs}"
-        )
-        extra_environ["CMAKE_BUILD_PARALLEL_LEVEL"] = f"{ctx.jobs}"
-        extra_environ["MAX_JOBS"] = f"{ctx.jobs}"
+
+    # configure max jobs settings, settings depend on package, available
+    # CPU cores, and available virtual memory.
+    jobs = pbi.parallel_jobs()
+    extra_environ["MAKEFLAGS"] = f"{extra_environ.get('MAKEFLAGS', '')} -j{jobs}"
+    extra_environ["CMAKE_BUILD_PARALLEL_LEVEL"] = str(jobs)
+    extra_environ["MAX_JOBS"] = str(jobs)
 
     # Start the timer
     start = datetime.now().replace(microsecond=0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,7 @@ def testdata_context(
             settings_dir=overrides / "settings",
             patches_dir=patches_dir,
             variant=variant,
+            max_jobs=None,
         ),
         constraints_file=None,
         patches_dir=overrides / "patches",

--- a/tests/testdata/context/overrides/settings/test_pkg.yaml
+++ b/tests/testdata/context/overrides/settings/test_pkg.yaml
@@ -1,4 +1,7 @@
 build_dir: python
+build_options:
+    cpu_cores_per_job: 4
+    memory_per_job_gb: 4
 changelog:
     "1.0.1":
         - fixed bug


### PR DESCRIPTION
The configuration for parallel build jobs can take available memory into account. Scaling factors for memory and CPU cores can be set per package.

- `--jobs` now sets the maximum number of cores to use (default: all cores)

Per package override is configured in `settings/mypackage.yaml`

```yaml
build_options:
    cpu_scaling: 4
    memory_scaling: 4
```