### PR TITLE
Fix resolver_dist and config migration

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -61,7 +61,7 @@ $ fromager --settings-dir=overrides/settings ...
 download_source:
     url: "https://github.com/pytorch/pytorch/releases/download/v${version}/pytorch-v${version}.tar.gz"
     destination_filename: "${canonicalized_name}-${version}.tar.gz"
-resolve_source:
+resolver_dist:
     sdist_server_url: "https://pypi.org/simple"
     include_wheels: true
     include_sdists: false
@@ -75,8 +75,9 @@ variants:
         env:
             OPENBLAS_NUM_THREADS: "1"
     gaudi:
-        # use pre-built binary wheels for this variant
+        # use pre-built binary wheels from a custom index for this variant
         pre_built: true
+        wheel_server_url: https://internal.pypi.example/simple
 ```
 
 ### Download source
@@ -91,7 +92,7 @@ support templating. The only supported template variable are:
 - `canonicalized_name` - it is replaced by the canonicalized name of the
   package specified in the requirement, specifically it applies `canonicalize_name(req.nam)`
 
-### Resolve source
+### Resolver dist
 
 The source distribution index server used by the package resolver can
 be overriden for a particular package. The resolver can also be told

--- a/e2e/build_settings/stevedore.yaml
+++ b/e2e/build_settings/stevedore.yaml
@@ -1,7 +1,7 @@
 download_source:
   url: https://files.pythonhosted.org/packages/e7/c1/b210bf1071c96ecfcd24c2eeb4c828a2a24bf74b38af13896d02203b1eec/stevedore-${version}.tar.gz
   destination_filename: stevedore-custom-${version}.tar.gz
-resolve_source:
+resolver_dist:
   sdist_server_url: "https://pypi.org/simple"
   include_sdists: false
   include_wheels: true

--- a/src/fromager/commands/migrate_config.py
+++ b/src/fromager/commands/migrate_config.py
@@ -64,10 +64,16 @@ def _migrate_package_envfiles(
     """
     with settings_file.open(encoding="utf-8") as f:
         settings_data: dict[str, typing.Any] = yaml.safe_load(f)
-    settings_pkgs: dict[str, typing.Any] = settings_data.get("packages", {})
+
+    settings_pkgs: dict[NormalizedName, typing.Any] = {
+        canonicalize_name(name): value
+        for name, value in settings_data.get("packages", {}).items()
+    }
 
     pre_built: PrebuiltMap = {}
     for variantname, entries in settings_data.get("pre_built", {}).items():
+        if not entries:
+            continue
         variant = packagesettings.Variant(variantname)
         for pkgname in entries:
             name = NormalizedName(pkgname)

--- a/src/fromager/packagesettings.py
+++ b/src/fromager/packagesettings.py
@@ -106,7 +106,7 @@ MODEL_CONFIG = pydantic.ConfigDict(
 )
 
 
-class ResolveSource(pydantic.BaseModel):
+class ResolverDist(pydantic.BaseModel):
     """Packages resolver dist"""
 
     model_config = MODEL_CONFIG
@@ -202,7 +202,7 @@ class PackageSettings(pydantic.BaseModel):
         download_source:
             url: https://egg.test
             destination_filename: new_filename
-        resolve_source:
+        resolver_dist:
             sdist_server_url: https://sdist.test/egg
             include_sdists: true
             include_wheels: false
@@ -235,7 +235,7 @@ class PackageSettings(pydantic.BaseModel):
     download_source: DownloadSource = Field(default_factory=DownloadSource)
     """Alternative source download settings"""
 
-    resolve_source: ResolveSource = Field(default_factory=ResolveSource)
+    resolver_dist: ResolverDist = Field(default_factory=ResolverDist)
     """Resolve distribution version"""
 
     build_options: BuildOptions = Field(default_factory=BuildOptions)
@@ -245,7 +245,7 @@ class PackageSettings(pydantic.BaseModel):
     """Variant configuration"""
 
     @pydantic.field_validator(
-        "download_source", "resolve_source", "variants", mode="before"
+        "download_source", "resolver_dist", "variants", mode="before"
     )
     @classmethod
     def before_none_dict(
@@ -480,22 +480,22 @@ class PackageBuildInfo:
         else:
             return None
 
-    def resolve_source_sdist_server_url(self, default: str) -> str:
+    def resolver_sdist_server_url(self, default: str) -> str:
         """Package index server URL for resolving package versions"""
-        url = self._ps.resolve_source.sdist_server_url
+        url = self._ps.resolver_dist.sdist_server_url
         if url is None:
             url = default
         return url
 
     @property
-    def resolve_source_include_wheels(self) -> bool:
+    def resolver_include_wheels(self) -> bool:
         """Include wheels when resolving package versions?"""
-        return self._ps.resolve_source.include_wheels
+        return self._ps.resolver_dist.include_wheels
 
     @property
-    def resolve_source_include_sdists(self) -> bool:
+    def resolver_include_sdists(self) -> bool:
         """Include sdists when resolving package versions?"""
-        return self._ps.resolve_source.include_sdists
+        return self._ps.resolver_dist.include_sdists
 
     def build_dir(self, sdist_root_dir: pathlib.Path) -> pathlib.Path:
         """Build directory for package (e.g. subdirectory)"""

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -108,14 +108,14 @@ def default_resolve_source(
     "Return URL to source and its version."
 
     pbi = ctx.package_build_info(req)
-    override_sdist_server_url = pbi.resolve_source_sdist_server_url(sdist_server_url)
+    override_sdist_server_url = pbi.resolver_sdist_server_url(sdist_server_url)
 
     url, version = resolver.resolve(
         ctx=ctx,
         req=req,
         sdist_server_url=override_sdist_server_url,
-        include_sdists=pbi.resolve_source_include_sdists,
-        include_wheels=pbi.resolve_source_include_wheels,
+        include_sdists=pbi.resolver_include_sdists,
+        include_wheels=pbi.resolver_include_wheels,
     )
     return url, version
 

--- a/tests/test_packagesettings.py
+++ b/tests/test_packagesettings.py
@@ -43,7 +43,7 @@ FULL_EXPECTED = {
     },
     "name": "test-pkg",
     "has_config": True,
-    "resolve_source": {
+    "resolver_dist": {
         "include_sdists": True,
         "include_wheels": False,
         "sdist_server_url": "https://sdist.test/egg",
@@ -82,7 +82,7 @@ EMPTY_EXPECTED = {
         "destination_filename": None,
     },
     "has_config": True,
-    "resolve_source": {
+    "resolver_dist": {
         "sdist_server_url": None,
         "include_sdists": True,
         "include_wheels": False,
@@ -176,10 +176,10 @@ def test_pbi_test_pkg(testdata_context: context.WorkContext) -> None:
         pbi.download_source_destination_filename(Version("1.0.2"))
         == "test-pkg-1.0.2.tar.gz"
     )
-    assert pbi.resolve_source_include_sdists is True
-    assert pbi.resolve_source_include_wheels is False
+    assert pbi.resolver_include_sdists is True
+    assert pbi.resolver_include_wheels is False
     assert (
-        pbi.resolve_source_sdist_server_url("https://pypi.org/simple")
+        pbi.resolver_sdist_server_url("https://pypi.org/simple")
         == "https://sdist.test/egg"
     )
     assert pbi.build_tag(Version("1.0.2")) == (2, "")
@@ -209,10 +209,10 @@ def test_pbi_other(testdata_context: context.WorkContext) -> None:
     assert pbi.download_source_url(Version("1.0.0")) is None
     assert pbi.download_source_destination_filename(Version("1.0.0")) is None
     assert pbi.download_source_destination_filename(Version("1.0.0")) is None
-    assert pbi.resolve_source_include_sdists is True
-    assert pbi.resolve_source_include_wheels is False
+    assert pbi.resolver_include_sdists is True
+    assert pbi.resolver_include_wheels is False
     assert (
-        pbi.resolve_source_sdist_server_url("https://pypi.org/simple")
+        pbi.resolver_sdist_server_url("https://pypi.org/simple")
         == "https://pypi.org/simple"
     )
     assert pbi.build_tag(Version("1.0.0")) == ()

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -61,9 +61,9 @@ def test_default_download_source_from_settings(
 @patch("fromager.sources._download_source_check")
 @patch.multiple(
     packagesettings.PackageBuildInfo,
-    resolve_source_include_sdists=False,
-    resolve_source_include_wheels=True,
-    resolve_source_sdist_server_url=Mock(return_value="url"),
+    resolver_include_sdists=False,
+    resolver_include_wheels=True,
+    resolver_sdist_server_url=Mock(return_value="url"),
 )
 def test_default_download_source_with_predefined_resolve_dist(
     download_source_check: Mock,

--- a/tests/testdata/config-0.27/expected/torch.yaml
+++ b/tests/testdata/config-0.27/expected/torch.yaml
@@ -4,7 +4,7 @@ download_source:
 env:
   USE_FFMPEG: '0'
   USE_OPENCV: '0'
-resolve_source:
+resolver_dist:
   include_sdists: false
   include_wheels: true
   sdist_server_url: https://pypi.org/simple

--- a/tests/testdata/config-0.27/settings.yaml
+++ b/tests/testdata/config-0.27/settings.yaml
@@ -7,7 +7,7 @@ packages:
     download_source:
       url: "https://github.com/pytorch/pytorch/releases/download/v${version}/pytorch-v${version}.tar.gz"
       destination_filename: "torch-${version}.tar.gz"
-    resolve_source:
+    resolver_dist:
       sdist_server_url: "https://pypi.org/simple"
       include_sdists: false
       include_wheels: true

--- a/tests/testdata/context/overrides/settings/test_pkg.yaml
+++ b/tests/testdata/context/overrides/settings/test_pkg.yaml
@@ -17,7 +17,7 @@ env:
 download_source:
     url: https://egg.test/${canonicalized_name}/v${version}.tar.gz
     destination_filename: ${canonicalized_name}-${version}.tar.gz
-resolve_source:
+resolver_dist:
     sdist_server_url: https://sdist.test/egg
     include_sdists: true
     include_wheels: false


### PR DESCRIPTION
The option is called `resolver_dist`, not `resolve_source`. Rename helper properties and function to match the names of Fromager 0.27.

Fix config migration when a variant block is None instead of empty mapping.