### PR TITLE
Improve parallel job configuration

### DIFF
--- a/src/fromager/packagesettings.py
+++ b/src/fromager/packagesettings.py
@@ -148,6 +148,13 @@ class BuildOptions(pydantic.BaseModel):
 
     model_config = MODEL_CONFIG
 
+    build_ext_parallel: bool = False
+    """Configure build_ext[parallel] in DIST_EXTRA_CONFIG
+
+    This enables parallel builds of setuptools extensions. Incompatible
+    with some packages, e.g. numba 0.60.0.
+    """
+
     cpu_cores_per_job: int = Field(default=1, ge=1)
     """Scale parallel jobs by available CPU cores
 
@@ -564,6 +571,11 @@ class PackageBuildInfo:
         )
 
         return parallel_builds
+
+    @property
+    def build_ext_parallel(self) -> bool:
+        """Configure [build_ext]parallel for setuptools?"""
+        return self._ps.build_options.build_ext_parallel
 
     def serialize(self, **kwargs) -> dict[str, typing.Any]:
         return self._ps.serialize(**kwargs)

--- a/tests/test_packagesettings.py
+++ b/tests/test_packagesettings.py
@@ -23,6 +23,7 @@ TEST_OTHER_PKG = "test-other-pkg"
 FULL_EXPECTED = {
     "build_dir": pathlib.Path("python"),
     "build_options": {
+        "build_ext_parallel": True,
         "cpu_cores_per_job": 4,
         "memory_per_job_gb": 4.0,
     },
@@ -70,6 +71,7 @@ EMPTY_EXPECTED = {
     "name": "test-empty-pkg",
     "build_dir": None,
     "build_options": {
+        "build_ext_parallel": False,
         "cpu_cores_per_job": 1,
         "memory_per_job_gb": 1.0,
     },

--- a/tests/testdata/context/overrides/settings/test_pkg.yaml
+++ b/tests/testdata/context/overrides/settings/test_pkg.yaml
@@ -1,5 +1,6 @@
 build_dir: python
 build_options:
+    build_ext_parallel: true
     cpu_cores_per_job: 4
     memory_per_job_gb: 4
 changelog:


### PR DESCRIPTION
Use `DIST_EXTRA_CONFIG` env var to configure `setuptools` to use parallel builds in `build_ext`. This speeds up compilation of packages such as Cython. The feature is disabled by default, because it breaks some packages like Numba 0.60.0.

Apply package env variables last. Package configuration can now override variables like `MAX_JOBS`.