### PR TITLE
Fixer for pyproject.toml build-system settings

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -191,6 +191,42 @@ in subdirectories, with the filenames prefixed with the source directory name is
 also supported. The newer format, using subdirectories, is preferred because it
 avoids name collisions between variant source trees.
 
+## `project_override` section
+
+The `project_override` configures the `pyproject.toml` auto-fixer. It can
+automatically create a missing `pyproject.toml` or modify an existing file.
+Packages are matched by canonical name.
+
+- `remove_build_requires` is a list of package names. Any build requirement
+  in the list is removed
+- `update_build_requires` a list of requirement specifiers. Existing specs
+  are replaced and missing specs are added. The option can be used to add,
+  remove, or change a version constraint.
+
+```yaml
+project_override:
+    remove_build_requires:
+        - cmake
+    update_build_requires:
+        - setuptools>=68.0.0
+        - torch
+        - triton
+```
+
+Incoming `pyproject.toml`:
+
+```yaml
+[build-system]
+requires = ["cmake", "setuptools>48.0", "torch>=2.3.0"]
+```
+
+Output:
+
+```yaml
+[build-system]
+requires = ["setuptools>=68.0.0", "torch", "triton"]
+```
+
 ## Override plugins
 
 For more complex customization requirements, create an override plugin.

--- a/src/fromager/pyproject.py
+++ b/src/fromager/pyproject.py
@@ -1,0 +1,142 @@
+"""Tooling for pyproject.toml"""
+
+import logging
+import pathlib
+import typing
+
+import tomlkit
+from packaging.requirements import Requirement
+from packaging.utils import NormalizedName, canonicalize_name
+
+from . import context
+
+logger = logging.getLogger(__name__)
+
+TomlDict = dict[str, typing.Any]
+
+# section / key names
+BUILD_SYSTEM = "build-system"
+BUILD_BACKEND = "build-backend"
+BUILD_REQUIRES = "requires"
+
+
+class PyprojectFix:
+    """Auto-fixer for pyproject.toml settings
+
+    - add missing pyproject.toml
+    - add or update `[build-system] requires`
+
+    Requirements in `update_build_requires` are added to
+    `[build-system] requires`. If a requirement name matches an existing
+    name, then the requirement is replaced.
+
+    Requirements in `remove_build_requires` are removed from
+    `[build-system] requires`.
+    """
+
+    def __init__(
+        self,
+        req: Requirement,
+        *,
+        build_dir: pathlib.Path,
+        update_build_requires: list[str],
+        remove_build_requires: list[NormalizedName],
+    ) -> None:
+        self.req = req
+        self.build_dir = build_dir
+        self.update_requirements = update_build_requires
+        self.remove_requirements = remove_build_requires
+        self.pyproject_toml = self.build_dir / "pyproject.toml"
+        self.setup_py = self.build_dir / "setup.py"
+
+    def run(self) -> None:
+        doc = self._load()
+        build_system = self._default_build_system(doc)
+        self._update_build_requires(build_system)
+        logger.debug(
+            "%s: pyproject.toml %s: %s=%r, %s=%r",
+            self.req.name,
+            BUILD_SYSTEM,
+            BUILD_BACKEND,
+            build_system.get(BUILD_BACKEND),
+            BUILD_REQUIRES,
+            build_system.get(BUILD_REQUIRES),
+        )
+        self._save(doc)
+
+    def _load(self) -> tomlkit.TOMLDocument:
+        """Load pyproject toml or create empty TOML doc"""
+        try:
+            doc = tomlkit.parse(self.pyproject_toml.read_bytes())
+            logger.debug("%s: loaded pyproject.toml", self.req.name)
+        except FileNotFoundError:
+            logger.debug("%s: no pyproject.toml, create empty doc", self.req.name)
+            doc = tomlkit.parse(b"")
+        return doc
+
+    def _save(self, doc: tomlkit.TOMLDocument) -> None:
+        """Write pyproject.toml to build directory"""
+        with self.pyproject_toml.open("w") as f:
+            tomlkit.dump(doc, f)
+
+    def _default_build_system(self, doc: tomlkit.TOMLDocument) -> TomlDict:
+        """Add / fix basic 'build-system' dict"""
+        build_system: TomlDict | None = doc.get(BUILD_SYSTEM)
+        if build_system is None:
+            logger.debug("%s: adding %s", self.req.name, BUILD_SYSTEM)
+            build_system = doc.setdefault(BUILD_SYSTEM, {})
+        # ensure `[build-system] requires` exists
+        build_system.setdefault(BUILD_REQUIRES, [])
+        return build_system
+
+    def _update_build_requires(self, build_system: TomlDict) -> None:
+        old_requires = build_system[BUILD_REQUIRES]
+        # always include setuptools
+        req_map: dict[NormalizedName, Requirement] = {
+            canonicalize_name("setuptools"): Requirement("setuptools"),
+        }
+        # parse original build reqirements (if available)
+        for reqstr in old_requires:
+            req = Requirement(reqstr)
+            req_map[canonicalize_name(req.name)] = req
+        # remove unwanted requirements
+        for name in self.remove_requirements:
+            req_map.pop(canonicalize_name(name), None)
+        # add / update requirements
+        for reqstr in self.update_requirements:
+            req = Requirement(reqstr)
+            req_map[canonicalize_name(req.name)] = req
+
+        new_requires = sorted(str(req) for req in req_map.values())
+        if set(new_requires) != set(old_requires):
+            # ignore order of items
+            build_system[BUILD_REQUIRES] = new_requires
+            logger.info(
+                "%s: changed build-system requires from %r to %r",
+                self.req.name,
+                old_requires,
+                new_requires,
+            )
+
+
+def apply_project_override(
+    ctx: context.WorkContext, req: Requirement, sdist_root_dir: pathlib.Path
+) -> None:
+    """Apply project_overrides"""
+    pbi = ctx.package_build_info(req)
+    update_build_requires = pbi.project_override.update_build_requires
+    remove_build_requires = pbi.project_override.remove_build_requires
+    if update_build_requires or remove_build_requires:
+        logger.debug(
+            f"{req.name}: applying project_override: "
+            f"{update_build_requires=}, {remove_build_requires=}"
+        )
+        build_dir = pbi.build_dir(sdist_root_dir)
+        PyprojectFix(
+            req,
+            build_dir=build_dir,
+            update_build_requires=update_build_requires,
+            remove_build_requires=remove_build_requires,
+        ).run()
+    else:
+        logger.debug(f"{req.name}: no project_override")

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -19,6 +19,7 @@ from . import (
     dependencies,
     external_commands,
     overrides,
+    pyproject,
     resolver,
     tarballs,
     vendor_rust,
@@ -367,9 +368,32 @@ def default_prepare_source(
 ) -> tuple[pathlib.Path, bool]:
     source_root_dir, is_new = unpack_source(ctx, source_filename)
     if is_new:
-        patch_source(ctx, source_root_dir, req)
-        vendor_rust.vendor_rust(req, source_root_dir)
+        prepare_new_source(
+            ctx=ctx,
+            req=req,
+            source_root_dir=source_root_dir,
+            version=version,
+        )
     return source_root_dir, is_new
+
+
+def prepare_new_source(
+    ctx: context.WorkContext,
+    req: Requirement,
+    source_root_dir: pathlib.Path,
+    version: Version,
+) -> None:
+    """Default steps for new sources
+
+    `default_prepare_source` runs this function when the sources are new.
+    """
+    patch_source(ctx, source_root_dir, req)
+    pyproject.apply_project_override(
+        ctx=ctx,
+        req=req,
+        sdist_root_dir=source_root_dir,
+    )
+    vendor_rust.vendor_rust(req, source_root_dir)
 
 
 def build_sdist(

--- a/tests/test_packagesettings.py
+++ b/tests/test_packagesettings.py
@@ -1,4 +1,5 @@
 import pathlib
+import typing
 from unittest.mock import Mock, patch
 
 import pydantic
@@ -20,7 +21,7 @@ TEST_PKG = "test-pkg"
 TEST_EMPTY_PKG = "test-empty-pkg"
 TEST_OTHER_PKG = "test-other-pkg"
 
-FULL_EXPECTED = {
+FULL_EXPECTED: dict[str, typing.Any] = {
     "build_dir": pathlib.Path("python"),
     "build_options": {
         "build_ext_parallel": True,
@@ -43,6 +44,10 @@ FULL_EXPECTED = {
     },
     "name": "test-pkg",
     "has_config": True,
+    "project_override": {
+        "remove_build_requires": ["cmake"],
+        "update_build_requires": ["setuptools>=68.0.0", "torch"],
+    },
     "resolver_dist": {
         "include_sdists": True,
         "include_wheels": False,
@@ -67,7 +72,7 @@ FULL_EXPECTED = {
     },
 }
 
-EMPTY_EXPECTED = {
+EMPTY_EXPECTED: dict[str, typing.Any] = {
     "name": "test-empty-pkg",
     "build_dir": None,
     "build_options": {
@@ -82,6 +87,10 @@ EMPTY_EXPECTED = {
         "destination_filename": None,
     },
     "has_config": True,
+    "project_override": {
+        "remove_build_requires": [],
+        "update_build_requires": [],
+    },
     "resolver_dist": {
         "sdist_server_url": None,
         "include_sdists": True,

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -1,0 +1,103 @@
+import pathlib
+import textwrap
+import typing
+
+import tomlkit
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
+from fromager import context, pyproject
+
+PYPROJECT_TOML = """
+[build-system]
+requires = ["cmake", "setuptools>48.0", "torch>=2.3.0"]
+"""
+
+TEST_SETTINGS = {
+    "pyproject_overrides": {
+        "auto_build_requires": {
+            "ninja": "ninja",
+            "packaging": "packaging",
+            "pybind11": "pybind11",
+            "setuptools": "setuptools",
+            "torch": "torch<2.4.0,>=2.3.1",
+            "wheels": "wheels",
+        },
+        "remove_build_requires": [
+            "cmake",
+        ],
+        "replace_build_requires": {"setuptools": "setuptools>=68.0.0"},
+    }
+}
+
+
+def test_pyproject_no_toml(
+    tmp_context: context.WorkContext, tmp_path: pathlib.Path
+) -> None:
+    req = Requirement("testproject==1.0.0")
+    fixer = pyproject.PyprojectFix(
+        req,
+        build_dir=tmp_path,
+        update_build_requires=["setuptools>=68.0.0"],
+        remove_build_requires=[canonicalize_name("cmake")],
+    )
+    fixer.run()
+    with tmp_path.joinpath("pyproject.toml").open(encoding="utf-8") as f:
+        doc = tomlkit.load(f)
+    assert isinstance(doc["build-system"], typing.Container)
+    assert dict(doc["build-system"].items()) == {
+        "requires": ["setuptools>=68.0.0"],
+    }
+
+
+def test_pyproject_with_toml(
+    tmp_context: context.WorkContext, tmp_path: pathlib.Path
+) -> None:
+    tmp_path.joinpath("pyproject.toml").write_text(
+        textwrap.dedent("""
+            [build-system]
+            build-backend = "maturin"
+            requires = ["setuptools>=64", "setuptools_scm>=8", "maturin", "cmake>3.0", "torch<2.4.0,>=2.3.1"]
+        """)
+    )
+    req = Requirement("testproject==1.0.0")
+    fixer = pyproject.PyprojectFix(
+        req,
+        build_dir=tmp_path,
+        update_build_requires=["setuptools>=68.0.0", "torch"],
+        remove_build_requires=[canonicalize_name("cmake")],
+    )
+    fixer.run()
+    with tmp_path.joinpath("pyproject.toml").open(encoding="utf-8") as f:
+        doc = tomlkit.load(f)
+    assert isinstance(doc["build-system"], typing.Container)
+    assert dict(doc["build-system"].items()) == {
+        "build-backend": "maturin",
+        "requires": [
+            "maturin",
+            "setuptools>=68.0.0",
+            "setuptools_scm>=8",
+            "torch",
+        ],
+    }
+
+
+def test_pyproject_fix(
+    tmp_path: pathlib.Path,
+    testdata_context: context.WorkContext,
+) -> None:
+    pyproject_toml = tmp_path / "python" / "pyproject.toml"
+    pyproject_toml.parent.mkdir()
+    pyproject_toml.write_text(PYPROJECT_TOML)
+
+    req = Requirement("test-pkg==1.0.0")
+    pyproject.apply_project_override(testdata_context, req, tmp_path)
+
+    doc = tomlkit.loads(pyproject_toml.read_text())
+    assert isinstance(doc["build-system"], typing.Container)
+    assert dict(doc["build-system"].items()) == {
+        "requires": [
+            "setuptools>=68.0.0",
+            "torch",
+        ],
+    }

--- a/tests/testdata/context/overrides/settings/test_pkg.yaml
+++ b/tests/testdata/context/overrides/settings/test_pkg.yaml
@@ -17,6 +17,12 @@ env:
 download_source:
     url: https://egg.test/${canonicalized_name}/v${version}.tar.gz
     destination_filename: ${canonicalized_name}-${version}.tar.gz
+project_override:
+    remove_build_requires:
+        - cmake
+    update_build_requires:
+        - setuptools>=68.0.0
+        - torch
 resolver_dist:
     sdist_server_url: https://sdist.test/egg
     include_sdists: true


### PR DESCRIPTION
- add missing pyproject.toml
- add or update `[build-system] requires`

Requirements in `update_build_requires` are added to `[build-system] requires`. If a requirement name matches an existing name, then the requirement is replaced.

Requirements in `remove_build_requires` are removed from `[build-system] requires`.

Fixes: #260
Fixes: #274