### PR TITLE
raise setuptools minimum version and remove cap

### DIFF
--- a/e2e/constraints.txt
+++ b/e2e/constraints.txt
@@ -1,1 +1,2 @@
-setuptools < 72.0.0  # https://github.com/pypa/setuptools/issues/4519
+# This file is here in case we need to quickly add a constraint to
+# fix CI jobs.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ python-pypi-mirror
 PyYAML
 requests
 resolvelib
-setuptools<72.0.0
+setuptools>=73.0.0 # https://github.com/pypa/setuptools/issues/4519
 stevedore
 tomlkit
 tqdm


### PR DESCRIPTION
The setuptools issue introduced in 72.0.0 has been fixed in later
releases, so move our minimum past the bad release series and remove the
cap to allow newer versions.