### PR TITLE
standardize patch directories using override module names

### DIFF
--- a/e2e/test_bootstrap_extras.sh
+++ b/e2e/test_bootstrap_extras.sh
@@ -41,8 +41,8 @@ $OUTDIR/work-dir/setuptools-*/build.log
 
 $OUTDIR/wheels-repo/downloads/PySocks-*.whl
 $OUTDIR/sdists-repo/downloads/PySocks-*.tar.gz
-$OUTDIR/sdists-repo/builds/PySocks-*.tar.gz
-$OUTDIR/work-dir/PySocks-*/build.log
+$OUTDIR/sdists-repo/builds/pysocks-*.tar.gz
+$OUTDIR/work-dir/pysocks-*/build.log
 "
 
 for pattern in $EXPECTED_FILES; do

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -213,10 +213,19 @@ def _takes_arg(f: typing.Callable, arg_name: str) -> bool:
 
 def unpack_source(
     ctx: context.WorkContext,
+    req: Requirement,
+    version: Version,
     source_filename: pathlib.Path,
 ) -> tuple[pathlib.Path, bool]:
-    sdist_root_name = _sdist_root_name(source_filename)
-    unpack_dir = ctx.work_dir / sdist_root_name
+    # sdist names are less standardized and the names of the directories they
+    # contain are also not very standard. Force the names into a predictable
+    # form based on the override module name for the requirement.
+    req_name = overrides.pkgname_to_override_module(req.name)
+    expected_name = f"{req_name}-{version}"
+
+    # The unpack_dir is a parent dir where we put temporary outputs during the
+    # build process, including the unpacked source in a subdirectory.
+    unpack_dir = ctx.work_dir / expected_name
     if unpack_dir.exists():
         if ctx.cleanup:
             logger.debug("cleaning up %s", unpack_dir)
@@ -224,10 +233,8 @@ def unpack_source(
         else:
             logger.info("reusing %s", unpack_dir)
             return (unpack_dir / unpack_dir.name, False)
-    # We create a unique directory based on the sdist name, but that
-    # may not be the same name as the root directory of the content in
-    # the sdist (due to case, punctuation, etc.), so after we unpack
-    # it look for what was created.
+
+    # sdists might be tarballs or zip files.
     logger.debug("unpacking %s to %s", source_filename, unpack_dir)
     if str(source_filename).endswith(".tar.gz"):
         with tarfile.open(source_filename, "r") as t:
@@ -242,18 +249,26 @@ def unpack_source(
     else:
         raise ValueError(f"Do not know how to unpack source archive {source_filename}")
 
-    # if tarball named foo-2.3.1.tar.gz was downloaded, then ensure that after unpacking, the source directory's path is foo-2.3.1/foo-2.3.1
+    # We create a unique directory based on the requirement name, but that may
+    # not be the same name as the root directory of the content in the sdist
+    # (due to case, punctuation, etc.), so after we unpack it look for what was
+    # created and ensure the extracted directory matches the override module
+    # name and version of the requirement.
     unpacked_root_dir = next(iter(unpack_dir.glob("*")))
-    new_unpacked_root_dir = unpacked_root_dir.parent / sdist_root_name
-    if unpacked_root_dir.name != new_unpacked_root_dir.name:
+    if unpacked_root_dir.name != expected_name:
+        desired_name = unpacked_root_dir.parent / expected_name
         try:
-            shutil.move(str(unpacked_root_dir), str(new_unpacked_root_dir))
+            shutil.move(
+                str(unpacked_root_dir),
+                str(desired_name),
+            )
         except Exception as err:
             raise Exception(
-                f"Could not rename {unpacked_root_dir.name} to {new_unpacked_root_dir.name}: {err}"
+                f"Could not rename {unpacked_root_dir.name} to {desired_name}: {err}"
             ) from err
+        unpacked_root_dir = desired_name
 
-    return (new_unpacked_root_dir, True)
+    return (unpacked_root_dir, True)
 
 
 def patch_source(
@@ -366,7 +381,12 @@ def default_prepare_source(
     source_filename: pathlib.Path,
     version: Version,
 ) -> tuple[pathlib.Path, bool]:
-    source_root_dir, is_new = unpack_source(ctx, source_filename)
+    source_root_dir, is_new = unpack_source(
+        ctx=ctx,
+        req=req,
+        version=version,
+        source_filename=source_filename,
+    )
     if is_new:
         prepare_new_source(
             ctx=ctx,

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -261,14 +261,13 @@ def patch_source(
     source_root_dir: pathlib.Path,
     req: Requirement,
 ) -> None:
-    # Flag to check whether patch has been applied
-    has_applied = False
+    patch_count = 0
     # apply any unversioned patch first
     for p in overrides.patches_for_source_dir(
         ctx.settings.patches_dir, overrides.pkgname_to_override_module(req.name)
     ):
         _apply_patch(p, source_root_dir)
-        has_applied = True
+        patch_count += 1
 
     # make sure that we don't apply the generic unversioned patch again
     if source_root_dir.name != overrides.pkgname_to_override_module(req.name):
@@ -276,10 +275,11 @@ def patch_source(
             ctx.settings.patches_dir, source_root_dir.name
         ):
             _apply_patch(p, source_root_dir)
-            has_applied = True
+            patch_count += 1
 
+    logger.debug("%s: applied %d patches", req.name, patch_count)
     # If no patch has been applied, call warn for old patch
-    if not has_applied:
+    if not patch_count:
         _warn_for_old_patch(source_root_dir, ctx.settings.patches_dir)
 
 

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -1,42 +1,39 @@
 import pathlib
-from importlib import metadata
 from unittest import mock
 from unittest.mock import patch
 
 import pytest
+from packaging.requirements import Requirement
+from packaging.version import Version
 
 from fromager import overrides
 
 
-def test_patches_for_source_dir(tmp_path: pathlib.Path):
+def test_patches_for_requirement(tmp_path: pathlib.Path):
     patches_dir = tmp_path / "patches"
     patches_dir.mkdir()
 
     project_patch_dir = patches_dir / "project-1.2.3"
     project_patch_dir.mkdir()
 
-    project_variant_patch_dir = patches_dir / "project-1.2.3-variant"
-    project_variant_patch_dir.mkdir()
-
     p1 = project_patch_dir / "001.patch"
     p2 = project_patch_dir / "002.patch"
     np1 = project_patch_dir / "not-a-patch.txt"
-    p3 = project_variant_patch_dir / "003.patch"
-    np2 = project_variant_patch_dir / "not-a-patch.txt"
 
     # Create all of the test files
-    for p in [p1, p2, p3]:
+    for p in [p1, p2]:
         p.write_text("this is a patch file")
-    for f in [np1, np2]:
+    for f in [np1]:
         f.write_text("this is not a patch file")
 
-    results = list(overrides.patches_for_source_dir(patches_dir, "project-1.2.3"))
-    assert results == [p1, p2]
-
     results = list(
-        overrides.patches_for_source_dir(patches_dir, "project-1.2.3-variant")
+        overrides.patches_for_requirement(
+            patches_dir=patches_dir,
+            req=Requirement("project"),
+            version=Version("1.2.3"),
+        )
     )
-    assert results == [p3]
+    assert results == [p1, p2]
 
 
 def test_invoke_override_with_exact_args():
@@ -73,86 +70,3 @@ def test_find_and_invoke(
     assert overrides.find_and_invoke(
         "pkg", "foo", default_foo, arg1="value1", arg2="value2"
     )
-
-
-def test_regex_dummy_package(tmp_path: pathlib.Path):
-    req_name = "foo"
-    patches_dir = tmp_path / "patches_dir"
-    patches_dir.mkdir()
-
-    lst = [
-        patches_dir / "foo-1.1.0",
-        patches_dir / "foo-bar-2.0.0",
-        patches_dir / "foo-v2.3.0",
-        patches_dir / "foo-bar-bar-v2.3.1",
-        patches_dir / "foo-bar-v5.5.5",
-        patches_dir / "foo-3.4.4",
-        patches_dir / "foo-v2.3.0.1",
-    ]
-
-    expected = [
-        patches_dir / "foo-1.1.0",
-        patches_dir / "foo-v2.3.0",
-        patches_dir / "foo-3.4.4",
-        patches_dir / "foo-v2.3.0.1",
-    ]
-
-    actual = overrides._filter_patches_based_on_req(lst, req_name)
-    assert len(expected) == len(actual)
-    assert expected == actual
-
-
-def test_regex_for_deepspeed(tmp_path: pathlib.Path):
-    req_name = "deepspeed"
-    patches_dir = tmp_path / "patches_dir"
-    patches_dir.mkdir()
-
-    lst = [
-        patches_dir / "deepspeed-1.1.0",
-        patches_dir / "deepspeed-deep-2.0.0",
-        patches_dir / "deepspeed-v2.3.0.post1",
-        patches_dir / "deepspeed-v5.5.5",
-        patches_dir / "deepspeed-3.4.4",
-        patches_dir / "deepspeed-sdg-3.4.4",
-    ]
-
-    expected = [
-        patches_dir / "deepspeed-1.1.0",
-        patches_dir / "deepspeed-v2.3.0.post1",
-        patches_dir / "deepspeed-v5.5.5",
-        patches_dir / "deepspeed-3.4.4",
-    ]
-
-    actual = overrides._filter_patches_based_on_req(lst, req_name)
-    assert len(expected) == len(actual)
-    assert expected == actual
-
-
-def test_regex_for_vllm(tmp_path: pathlib.Path):
-    req_name = "vllm"
-    patches_dir = tmp_path / "patches_dir"
-    patches_dir.mkdir()
-
-    lst = [
-        patches_dir / "vllm-1.1.0.9",
-        patches_dir / "vllm-llm-2.1.0.0",
-        patches_dir / "vllm-v2.3.5.0.post1",
-        patches_dir / "vllm-v5.5.5.1",
-    ]
-
-    expected = [
-        patches_dir / "vllm-1.1.0.9",
-        patches_dir / "vllm-v2.3.5.0.post1",
-        patches_dir / "vllm-v5.5.5.1",
-    ]
-
-    actual = overrides._filter_patches_based_on_req(lst, req_name)
-    assert len(expected) == len(actual)
-    assert expected == actual
-
-
-def test_get_dist_info():
-    fromager_version = metadata.version("fromager")
-    plugin_dist, plugin_version = overrides._get_dist_info("fromager.submodule")
-    assert plugin_dist == "fromager"
-    assert plugin_version == fromager_version

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -121,7 +121,12 @@ def test_patch_sources_apply_unversioned_and_versioned(
     source_root_dir = tmp_path / "deepspeed-0.5.0"
     source_root_dir.mkdir()
 
-    sources.patch_source(tmp_context, source_root_dir, Requirement("deepspeed==0.5.0"))
+    sources.patch_source(
+        ctx=tmp_context,
+        source_root_dir=source_root_dir,
+        req=Requirement("deepspeed==0.5.0"),
+        version=Version("0.5.0"),
+    )
     assert apply_patch.call_count == 2
     apply_patch.assert_has_calls(
         [
@@ -151,10 +156,15 @@ def test_patch_sources_apply_only_unversioned(
     unversioned_patch_file = deepspeed_unversioned_patch / "deepspeed-update.patch"
     unversioned_patch_file.write_text("This is a test patch")
 
-    source_root_dir = tmp_path / "deepspeed"
+    source_root_dir = tmp_path / "deepspeed-0.5.0"
     source_root_dir.mkdir()
 
-    sources.patch_source(tmp_context, source_root_dir, Requirement("deepspeed==0.5.0"))
+    sources.patch_source(
+        ctx=tmp_context,
+        source_root_dir=source_root_dir,
+        req=Requirement("deepspeed"),
+        version=Version("0.6.0"),
+    )
     assert apply_patch.call_count == 1
     apply_patch.assert_has_calls(
         [
@@ -179,7 +189,11 @@ def test_warning_for_older_patch(mock, tmp_path: pathlib.Path):
     source_root_dir = tmp_path / "deepspeed-0.6.0"
     source_root_dir.mkdir()
 
-    sources._warn_for_old_patch(source_root_dir, patches_dir)
+    sources._warn_for_old_patch(
+        req=Requirement("deepspeed"),
+        version=Version("0.6.0"),
+        patches_dir=patches_dir,
+    )
     mock.assert_called()
 
 
@@ -199,5 +213,9 @@ def test_warning_for_older_patch_different_req(mock, tmp_path: pathlib.Path):
     source_root_dir = tmp_path / "deepspeed-0.5.0"
     source_root_dir.mkdir()
 
-    sources._warn_for_old_patch(source_root_dir, patches_dir)
+    sources._warn_for_old_patch(
+        req=Requirement("deepspeed"),
+        version=Version("0.5.0"),
+        patches_dir=patches_dir,
+    )
     mock.assert_not_called()


### PR DESCRIPTION
Require patch directories be named using the override module form of the
name of the package being patched. In addition to being more predictable,
this allows us to simplify the logic for detecting patches for other
versions of a project that are not being applied.

Standardize the naming of unpacked source distributions to make the name
predictable.

We log the individual filenames when patches are applied, but if we do not
have a patch there is no indication that we tried to patch the source at
all.

Fixes #421