### PR TITLE
Add __future__.annotations and delayed imports

### DIFF
--- a/src/fromager/build_environment.py
+++ b/src/fromager/build_environment.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib.metadata
 import logging
 import pathlib
@@ -10,12 +12,14 @@ import typing
 from packaging.requirements import Requirement
 
 from . import (
-    context,
     dependencies,
     external_commands,
     resolver,
 )
 from .requirements_file import RequirementType
+
+if typing.TYPE_CHECKING:
+    from . import context
 
 logger = logging.getLogger(__name__)
 

--- a/src/fromager/dependencies.py
+++ b/src/fromager/dependencies.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import logging
 import os
@@ -9,7 +11,10 @@ import pyproject_hooks
 import tomlkit
 from packaging.requirements import Requirement
 
-from . import context, external_commands, overrides, requirements_file
+from . import external_commands, overrides, requirements_file
+
+if typing.TYPE_CHECKING:
+    from . import context
 
 logger = logging.getLogger(__name__)
 

--- a/src/fromager/finders.py
+++ b/src/fromager/finders.py
@@ -1,13 +1,17 @@
-#!/usr/bin/env python3
+from __future__ import annotations
 
 import logging
 import pathlib
 import re
+import typing
 
 from packaging.requirements import Requirement
 from packaging.utils import BuildTag, canonicalize_name
 
-from . import context, overrides
+from . import overrides
+
+if typing.TYPE_CHECKING:
+    from . import context
 
 logger = logging.getLogger(__name__)
 

--- a/src/fromager/hooks.py
+++ b/src/fromager/hooks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import pathlib
 import typing
@@ -5,7 +7,8 @@ import typing
 from packaging.requirements import Requirement
 from stevedore import extension, hook
 
-from fromager import context
+if typing.TYPE_CHECKING:
+    from . import context
 
 _mgrs: dict[str, hook.HookManager] = {}
 logger = logging.getLogger(__name__)

--- a/src/fromager/pyproject.py
+++ b/src/fromager/pyproject.py
@@ -1,5 +1,7 @@
 """Tooling for pyproject.toml"""
 
+from __future__ import annotations
+
 import logging
 import pathlib
 import typing
@@ -8,7 +10,8 @@ import tomlkit
 from packaging.requirements import Requirement
 from packaging.utils import NormalizedName, canonicalize_name
 
-from . import context
+if typing.TYPE_CHECKING:
+    from . import context
 
 logger = logging.getLogger(__name__)
 

--- a/src/fromager/resolver.py
+++ b/src/fromager/resolver.py
@@ -3,6 +3,8 @@
 # Modified to look at sdists instead of wheels and to avoid trying to
 # resolve any dependencies.
 #
+from __future__ import annotations
+
 import logging
 import os
 import typing
@@ -25,11 +27,14 @@ from packaging.utils import (
 from packaging.version import Version
 from resolvelib.resolvers import RequirementInformation
 
-from . import context, overrides
+from . import overrides
 from .candidate import Candidate
 from .constraints import Constraints
 from .extras_provider import ExtrasProvider
 from .request_session import session
+
+if typing.TYPE_CHECKING:
+    from . import context
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +72,7 @@ def default_resolver_provider(
     sdist_server_url: str,
     include_sdists: bool,
     include_wheels: bool,
-) -> "PyPIProvider | GenericProvider | GitHubTagProvider":
+) -> PyPIProvider | GenericProvider | GitHubTagProvider:
     """Lookup resolver provider to resolve package versions"""
     return PyPIProvider(
         include_sdists=include_sdists,
@@ -78,7 +83,7 @@ def default_resolver_provider(
 
 
 def resolve_from_provider(
-    provider: "BaseProvider", req: Requirement
+    provider: BaseProvider, req: Requirement
 ) -> tuple[str, Version]:
     reporter = resolvelib.BaseReporter()
     rslvr: resolvelib.Resolver = resolvelib.Resolver(provider, reporter)

--- a/src/fromager/sdist.py
+++ b/src/fromager/sdist.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import operator
 import pathlib
@@ -10,7 +12,6 @@ from packaging.version import Version
 
 from . import (
     build_environment,
-    context,
     dependencies,
     finders,
     progress,
@@ -21,6 +22,9 @@ from . import (
 )
 from .dependency_graph import DependencyGraph
 from .requirements_file import RequirementType
+
+if typing.TYPE_CHECKING:
+    from . import context
 
 logger = logging.getLogger(__name__)
 

--- a/src/fromager/server.py
+++ b/src/fromager/server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import http.server
 import logging
@@ -6,7 +8,10 @@ import shutil
 import threading
 import typing
 
-from . import context, external_commands
+from . import external_commands
+
+if typing.TYPE_CHECKING:
+    from . import context
 
 logger = logging.getLogger(__name__)
 

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 import json
 import logging
@@ -14,8 +16,6 @@ from packaging.requirements import Requirement
 from packaging.version import Version
 
 from . import (
-    build_environment,
-    context,
     dependencies,
     external_commands,
     overrides,
@@ -25,6 +25,9 @@ from . import (
     vendor_rust,
 )
 from .request_session import session
+
+if typing.TYPE_CHECKING:
+    from . import build_environment, context
 
 logger = logging.getLogger(__name__)
 

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 import logging
 import os
@@ -18,13 +20,14 @@ from packaging.utils import canonicalize_name, parse_wheel_filename
 from packaging.version import Version
 
 from . import (
-    build_environment,
-    context,
     external_commands,
     overrides,
     resolver,
     sources,
 )
+
+if typing.TYPE_CHECKING:
+    from . import build_environment, context
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Move imports of `context` and `build_environment` modules to `if typing.TYPE_CHECKING` blocks and introduce `from __future__ import annotations`. Most modules need these modules just for type annotations. This avoids import cycles in the future.