### PR TITLE
Show a summary table in build-sequence and bootstrap

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ PyGithub
 pyproject_hooks>=1.0.0,!=1.1.0
 python-pypi-mirror
 PyYAML
+rich
 requests
 resolvelib
 setuptools>=73.0.0 # https://github.com/pypa/setuptools/issues/4519

--- a/src/fromager/dependency_graph.py
+++ b/src/fromager/dependency_graph.py
@@ -235,15 +235,23 @@ class DependencyGraph:
 
         self.nodes[parent_key].add_child(node, req=req, req_type=req_type)
 
-    def get_install_dependencies(self) -> typing.Iterable[DependencyNode]:
+    def get_dependency_edges(
+        self, match_dep_types: list[RequirementType] | None = None
+    ) -> typing.Iterable[DependencyEdge]:
         visited = set()
         for edge in self._depth_first_traversal(
             self.nodes[ROOT].children,
-            match_dep_types=[RequirementType.INSTALL, RequirementType.TOP_LEVEL],
+            match_dep_types=match_dep_types,
         ):
             if edge.destination_node.key not in visited:
-                yield edge.destination_node
+                yield edge
                 visited.add(edge.destination_node.key)
+
+    def get_install_dependencies(self) -> typing.Iterable[DependencyNode]:
+        for edge in self.get_dependency_edges(
+            match_dep_types=[RequirementType.INSTALL, RequirementType.TOP_LEVEL]
+        ):
+            yield edge.destination_node
 
     def get_nodes_by_name(self, req_name: str | None) -> list[DependencyNode]:
         if not req_name:


### PR DESCRIPTION
The `build-sequence` command now prints summary tables at the end. There is one table for built, pre-built, and skipped entries. The tables contain name, version, and source url. They are rendered as Markdown and also saved to a file in the work directory.

The table is generated with `rich`. The package is well-known, maintained, and comes with more useful feature for future enhancements, e.g. `rich.tree`.

Fixes: #272
Fixes: #438