### PR TITLE
Create build log file before post build hook

### DIFF
--- a/src/fromager/commands/build.py
+++ b/src/fromager/commands/build.py
@@ -193,6 +193,12 @@ def _build(
         build_env=build_env,
     )
 
+    per_wheel_logger.removeHandler(file_handler)
+    file_handler.close()
+
+    new_filename = wheel_log.with_name(wheel_filename.stem + ".log")
+    wheel_log.rename(new_filename)
+
     hooks.run_post_build_hooks(
         ctx=wkctx,
         req=req,
@@ -201,12 +207,6 @@ def _build(
         sdist_filename=sdist_filename,
         wheel_filename=wheel_filename,
     )
-
-    per_wheel_logger.removeHandler(file_handler)
-    file_handler.close()
-
-    new_filename = wheel_log.with_name(wheel_filename.stem + ".log")
-    wheel_log.rename(new_filename)
 
     return wheel_filename
 


### PR DESCRIPTION
This commit creates build log file before post build hook

Fixes: https://github.com/python-wheel-build/fromager/issues/447
