### PR TITLE
Fix MAKEFLAGS -j argument

### DIFF
--- a/src/fromager/packagesettings.py
+++ b/src/fromager/packagesettings.py
@@ -609,7 +609,7 @@ class PackageBuildInfo:
         # CPU cores, and available virtual memory.
         jobs = self.parallel_jobs()
         extra_environ: dict[str, str] = {
-            "MAKEFLAGS": f"{template_env.get('MAKEFLAGS', '')} -j{jobs}",
+            "MAKEFLAGS": f"{template_env.get('MAKEFLAGS', '')} -j{jobs}".strip(),
             "CMAKE_BUILD_PARALLEL_LEVEL": str(jobs),
             "MAX_JOBS": str(jobs),
         }

--- a/tests/test_packagesettings.py
+++ b/tests/test_packagesettings.py
@@ -137,7 +137,7 @@ def test_pbi_test_pkg_extra_environ(
     testdata_context.settings.max_jobs = 1
     parallel = {
         "CMAKE_BUILD_PARALLEL_LEVEL": "1",
-        "MAKEFLAGS": " -j1",
+        "MAKEFLAGS": "-j1",
         "MAX_JOBS": "1",
     }
 


### PR DESCRIPTION
If MAKEFLAGS is undefined, MAKEFLAGS is set to " -j{number of cpus}", for example, " -j8".  This results in an error when cutting-and-pasting commands from the bootstrap.log to the command line.

(app-root) /work$ MAKEFLAGS= -j192 CMAKE_BUILD_PARALLEL_LEVEL=192 MAX_JOBS=192 VIRTUAL_ENV=/work-dir/torch-2.4.1/build-3.11.7 PATH=/work-dir/torch-2.4.1/build-3.11.7/bin:/usr/lib64/ccache:/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin USE_FFMPEG=0 USE_KINETO=1 USE_LEVELDB=0 USE_LMDB=1 USE_OPENCV=0 LLVM_SYSPATH=/usr/lib64/llvm-aotriton LLVM_INCLUDE_DIRS=/usr/lib64/llvm-aotriton/include LLVM_LIBRARY_DIR=/usr/lib64/llvm-aotriton/lib OPENBLAS_NUM_THREADS=1 CMAKE_ARGS=-DUSE_CUDA=OFF PYTORCH_BUILD_VERSION=2.4.1 PYTORCH_BUILD_NUMBER=0 CARGO_NET_OFFLINE=true /usr/bin/unshare --net --map-current-user /work-dir/torch-2.4.1/build-3.11.7/bin/python3 -m pip -vvv --disable-pip-version-check wheel --no-build-isolation --only-binary :all: --wheel-dir /wheels-repo/build --no-deps --index-url http://localhost:36883/simple/ --log /work-dir/torch-2.4.1/build.log /work-dir/torch-2.4.1/torch-2.4.1 sh: -j192: command not found
(app-root) /work$

ie) the space in MAKEFLAGS causes an error.

If MAKEFLAGS is undefined, set MAKEFLAGS to "-j{number of cpus}" so the commands can be easily pasted.