### PR TITLE
shlex.quote environment values

### DIFF
--- a/src/fromager/external_commands.py
+++ b/src/fromager/external_commands.py
@@ -72,7 +72,7 @@ def run(
 
     logger.debug(
         "running: %s %s in %s",
-        " ".join(f"{k}={v}" for k, v in extra_environ.items()),
+        " ".join(f"{k}={shlex.quote(v)}" for k, v in extra_environ.items()),
         " ".join(shlex.quote(str(s)) for s in cmd),
         cwd or ".",
     )


### PR DESCRIPTION
`external_commands.run()` now quotes environment values, too. This enables copy and pasting when an environment variable contains spaces.

See: #455