### PR TITLE
Remove dependency on PyGithub

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ packaging
 pkginfo
 psutil
 pydantic
-PyGithub
 pyproject_hooks>=1.0.0,!=1.1.0
 python-pypi-mirror
 PyYAML


### PR DESCRIPTION
Fromager uses `PyGithub` to retrieve a list of tag names and tarball URLs from GitHub. The feature can be implemented a with a few lines of code and requests. `PyGithub` depends on several packages with extension modules: `cffi`, `cryptography`, `PyNaCl`, and `wrapt`. All packages except for `cffi` don't have pre-built wheels for ppc64le and s390x on PyPI. Fewer platlib packages makes Fromager easier to run on these architectures.

The change removes support for `GITHUB_TOKEN` auth. We have never needed it in upstream or downstream of Fromager.

The remaining packages with mandatory extension are `psutil` and `pydantic_core`. `psutil` has a small C extension and no pre-built binaries for ppc64le and s390x. `pydantic_core` and its build dependency `maturin` are written in Rust. Upstream provides wheels for x86_64, aarch64, ppc64le, and s390x.

The packages `charset_normalizer` and `PyYAML` have optional extension accelerator modules. The packages can be built as pure Python wheels, e.g. with env var `PYYAML_FORCE_LIBYAML=0` for `PyYAML`.

With this change, only a C compiler and system headers are required to build `psutil`.

See: #468