### PR TITLE
feat: add caching to resolver

### DIFF
--- a/src/fromager/bootstrapper.py
+++ b/src/fromager/bootstrapper.py
@@ -333,7 +333,10 @@ class Bootstrapper:
             )
         else:
             source_url, resolved_version = sources.resolve_source(
-                ctx=self.ctx, req=req, sdist_server_url=resolver.PYPI_SERVER_URL
+                ctx=self.ctx,
+                req=req,
+                sdist_server_url=resolver.PYPI_SERVER_URL,
+                req_type=req_type,
             )
         return (source_url, resolved_version)
 
@@ -356,7 +359,7 @@ class Bootstrapper:
         else:
             servers = wheels.get_wheel_server_urls(self.ctx, req)
             wheel_url, resolved_version = wheels.resolve_prebuilt_wheel(
-                ctx=self.ctx, req=req, wheel_server_urls=servers
+                ctx=self.ctx, req=req, wheel_server_urls=servers, req_type=req_type
             )
         return (wheel_url, resolved_version)
 
@@ -445,6 +448,7 @@ class Bootstrapper:
         if not version_source:
             return None
         try:
+            # no need to pass req type to enable caching since we are already using the graph as our cache
             provider = resolver.GenericProvider(
                 version_source=lambda x, y, z: version_source,
                 constraints=self.ctx.constraints,

--- a/src/fromager/build_environment.py
+++ b/src/fromager/build_environment.py
@@ -53,7 +53,10 @@ class MissingDependency(Exception):  # noqa: N818
         for r in all_reqs:
             try:
                 _, version = resolver.resolve(
-                    ctx=ctx, req=r, sdist_server_url=resolver.PYPI_SERVER_URL
+                    ctx=ctx,
+                    req=r,
+                    sdist_server_url=resolver.PYPI_SERVER_URL,
+                    req_type=req_type,
                 )
             except Exception as err:
                 resolutions.append(f"{r} -> {err}")

--- a/src/fromager/requirements_file.py
+++ b/src/fromager/requirements_file.py
@@ -29,6 +29,9 @@ class RequirementType(StrEnum):
                 return self.value in allowed_values and other.value in allowed_values
         return super.__eq__(self, other)
 
+    def __ne__(self, value: object) -> bool:
+        return not self == value
+
 
 class SourceType(StrEnum):
     PREBUILT = "prebuilt"

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -26,6 +26,7 @@ from . import (
     vendor_rust,
 )
 from .request_session import session
+from .requirements_file import RequirementType
 
 if typing.TYPE_CHECKING:
     from . import build_environment, context
@@ -76,6 +77,7 @@ def resolve_source(
     ctx: context.WorkContext,
     req: Requirement,
     sdist_server_url: str,
+    req_type: RequirementType | None = None,
 ) -> tuple[str, Version]:
     "Return URL to source and its version."
     constraint = ctx.constraints.get_constraint(req.name)
@@ -91,6 +93,7 @@ def resolve_source(
             ctx=ctx,
             req=req,
             sdist_server_url=sdist_server_url,
+            req_type=req_type,
         )
     except (
         resolvelib.InconsistentCandidate,
@@ -114,7 +117,10 @@ def resolve_source(
 
 
 def default_resolve_source(
-    ctx: context.WorkContext, req: Requirement, sdist_server_url: str
+    ctx: context.WorkContext,
+    req: Requirement,
+    sdist_server_url: str,
+    req_type: RequirementType | None = None,
 ) -> tuple[str, Version]:
     "Return URL to source and its version."
 
@@ -127,6 +133,7 @@ def default_resolve_source(
         sdist_server_url=override_sdist_server_url,
         include_sdists=pbi.resolver_include_sdists,
         include_wheels=pbi.resolver_include_wheels,
+        req_type=req_type,
     )
     return url, version
 

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -19,12 +19,7 @@ from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name, parse_wheel_filename
 from packaging.version import Version
 
-from . import (
-    external_commands,
-    overrides,
-    resolver,
-    sources,
-)
+from . import external_commands, overrides, requirements_file, resolver, sources
 
 if typing.TYPE_CHECKING:
     from . import build_environment, context
@@ -385,6 +380,7 @@ def resolve_prebuilt_wheel(
     ctx: context.WorkContext,
     req: Requirement,
     wheel_server_urls: list[str],
+    req_type: requirements_file.RequirementType | None = None,
 ) -> tuple[str, Version]:
     "Return URL to wheel and its version."
     for url in wheel_server_urls:
@@ -395,6 +391,7 @@ def resolve_prebuilt_wheel(
                 sdist_server_url=url,
                 include_sdists=False,
                 include_wheels=True,
+                req_type=req_type,
             )
         except Exception:
             continue

--- a/tests/test_build_environment.py
+++ b/tests/test_build_environment.py
@@ -18,7 +18,7 @@ def test_missing_dependency_format(
         "flit_core": "3.9.0",
         "setuptools": "69.5.1",
     }
-    resolve_dist.side_effect = lambda ctx, req, sdist_server_url: (
+    resolve_dist.side_effect = lambda ctx, req, sdist_server_url, req_type: (
         "",
         Version(resolutions[req.name]),
     )

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -40,6 +40,7 @@ def test_default_download_source_from_settings(
         sdist_server_url=sdist_server_url,
         include_sdists=True,
         include_wheels=False,
+        req_type=None,
     )
 
     sources.default_download_source(
@@ -82,6 +83,7 @@ def test_default_download_source_with_predefined_resolve_dist(
         sdist_server_url="url",
         include_sdists=False,
         include_wheels=True,
+        req_type=None,
     )
 
 


### PR DESCRIPTION
fixes #359 

Summarizing the needs from #358 (and from our previous calls)

- we shouldn't use caching for install type requirements because we always want the latest version that matches the reqs and constraints and we cannot guarantee that the latest version will exist in the cache. For example:
  - first we resolve `numpy<2` which ends up populating the cache with say `numpy==1`. Then we want to resolve `numpy>=1` as an install type req. if we end up using the cache it would return `numpy==1` even though there is a `numpy==2` that we can use.
  - we want install type reqs to be the latest possible version so that they have the latest possible cve fixes in them

- the cache is something internal to the resolver and should not be influenced directly by the caller of the resolver