### PR TITLE
Prefer bubblewrap for network isolation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,12 @@ jobs:
           default: true
           override: true
 
+      - name: install bwrap
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install bubblewrap
+
       - name: Install dependencies
         run: python -m pip install tox
 

--- a/src/fromager/__main__.py
+++ b/src/fromager/__main__.py
@@ -124,7 +124,7 @@ else:
 @click.option(
     "--network-isolation/--no-network-isolation",
     default=SUPPORTS_NETWORK_ISOLATION,
-    help="Build sdist and wheen with network isolation (unshare -cn)",
+    help="Build sdist and wheen with network isolation (bwrap, unshare -nr)",
     show_default=True,
 )
 @click.pass_context


### PR DESCRIPTION
Bubblewrap is another tool for unsharing namespaces. It sets up a network namespace with a disconnected loopback.

Fixes: #472