### PR TITLE
Fix: enable loopback device in network isolation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,14 @@ jobs:
           default: true
           override: true
 
+      - name: Disable AppArmor restriction for unprivileged user namespaces
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo sysctl kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Check unshare is working
+        if: matrix.os == 'ubuntu-latest'
+        run: unshare -rn echo "unshare works"
+
       - name: Install dependencies
         run: python -m pip install tox
 
@@ -115,6 +123,14 @@ jobs:
           toolchain: ${{ matrix.rust-version }}
           default: true
           override: true
+
+      - name: Disable AppArmor restriction for unprivileged user namespaces
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo sysctl kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Check unshare is working
+        if: matrix.os == 'ubuntu-latest'
+        run: unshare -rn echo "unshare works"
 
       - name: Install dependencies
         run: python -m pip install tox

--- a/src/fromager/run_network_isolation.sh
+++ b/src/fromager/run_network_isolation.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env -S unshare -rn /bin/bash
+#
+# Run command with network isolation (CLONE_NEWNET) and set up loopback
+# interface in the new network namespace. This is somewhat similar to
+# Bubblewrap `bwrap --unshare-net --dev-bind / /`, but works in an
+# unprivilged container. The user is root inside the new namespace and mapped
+# to the euid/egid if the parent namespace.
+#
+# Ubuntu 24.04: needs `sysctl kernel.apparmor_restrict_unprivileged_userns=0`
+# to address `unshare: write failed /proc/self/uid_map: Operation not permitted`.
+#
+
+set -e
+set -o pipefail
+
+if [ "$#" -eq 0 ]; then
+   echo "$0 command" >&2
+   exit 2
+fi
+
+# bring loopback up
+ip link set lo up
+
+# replace with command
+exec "$@"

--- a/tests/test_external_commands.py
+++ b/tests/test_external_commands.py
@@ -62,16 +62,19 @@ def test_external_commands_network_isolation(
     )
 
 
+NETWORK_ISOLATION_ERROR: Exception | None = None
 try:
     external_commands.detect_network_isolation()
-except Exception:
+except Exception as err:
+    NETWORK_ISOLATION_ERROR = err
     SUPPORTS_NETWORK_ISOLATION: bool = False
 else:
     SUPPORTS_NETWORK_ISOLATION = True
 
 
 @pytest.mark.skipif(
-    not SUPPORTS_NETWORK_ISOLATION, reason="network isolation is not supported"
+    not SUPPORTS_NETWORK_ISOLATION,
+    reason=f"network isolation is not supported: {NETWORK_ISOLATION_ERROR}",
 )
 def test_external_commands_network_isolation_real():
     with pytest.raises(external_commands.NetworkIsolationError) as e:


### PR DESCRIPTION
Some software like OpenMPI's `mpicc` do not work correctly without a loopback device. Replace the `unshare` call with a wrapper script that combines `unshare -rn` and `ip link set lo up` before `exec`-ing the final command.

`unshare` is a `util-linux-core` command and therefore available pretty much in all Linux distributions.