### PR TITLE
fix linter for generic patches directory

### DIFF
--- a/src/fromager/commands/lint.py
+++ b/src/fromager/commands/lint.py
@@ -30,7 +30,7 @@ def lint(
                 )
         else:
             expected_package_name = overrides.pkgname_to_override_module(entry.name)
-            if actual_package_name != expected_package_name:
+            if entry.name != expected_package_name:
                 errors += 1
                 logger.error(
                     f"ERROR: Patch directory {entry.name} should be {expected_package_name}"


### PR DESCRIPTION
`actual_package_name` is not defined for the else block and so it always ends up erroring out when using unversioned patches directory