### PR TITLE
do not show full traceback by default

### DIFF
--- a/src/fromager/resolver.py
+++ b/src/fromager/resolver.py
@@ -93,7 +93,10 @@ def resolve_from_provider(
 ) -> tuple[str, Version]:
     reporter: resolvelib.BaseReporter = resolvelib.BaseReporter()
     rslvr: resolvelib.Resolver = resolvelib.Resolver(provider, reporter)
-    result = rslvr.resolve([req])
+    try:
+        result = rslvr.resolve([req])
+    except resolvelib.resolvers.exceptions.ResolutionImpossible as err:
+        raise ValueError(f"Unable to resolve {req}") from err
     # resolvelib actually just returns one candidate per requirement.
     # result.mapping is map from an identifier to its resolved candidate
     candidate: Candidate


### PR DESCRIPTION
Change the behavior of the main program to show only the summary of an
exception and not the full traceback, by default. Add a `--debug` flag to 
expose the traceback information for debugging, if needed.

Fixes #181