### PR TITLE
Bug Fix: terminate when error is encountered

### DIFF
--- a/src/fromager/__main__.py
+++ b/src/fromager/__main__.py
@@ -2,6 +2,7 @@
 
 import logging
 import pathlib
+import sys
 
 import click
 
@@ -250,6 +251,7 @@ def invoke_main() -> None:
         logger.error(f"ERROR: {err}")
         if _DEBUG:
             raise
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This commit fixes a bug related to error message handling. The `main` will now exit using `sys.exit(1)` when there is an error 