### PR TITLE
use zipfile library instead of wheel command to unpack a wheel

### DIFF
--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -151,14 +151,10 @@ def add_extra_metadata_to_wheels(
     data_to_add = {}
 
     with tempfile.TemporaryDirectory() as dir_name:
-        cmd = ["wheel", "unpack", str(wheel_file), "--dest", dir_name]
-        external_commands.run(
-            cmd,
-            cwd=dir_name,
-            network_isolation=ctx.network_isolation,
-        )
-
         wheel_root_dir = pathlib.Path(dir_name) / dist_filename
+        wheel_root_dir.mkdir()
+        zipfile.ZipFile(str(wheel_file)).extractall(str(wheel_root_dir))
+
         dist_info_dir = wheel_root_dir / f"{dist_filename}.dist-info"
         if not dist_info_dir.is_dir():
             raise ValueError(


### PR DESCRIPTION
fixes #507 

We save at the very least the cost of spawning a new process to unpack the wheel for each dependency