### PR TITLE
Detect if we have already seen the dependency before downloading sources

### DIFF
--- a/e2e/test_bootstrap_cache.sh
+++ b/e2e/test_bootstrap_cache.sh
@@ -60,10 +60,6 @@ $OUTDIR/wheels-repo/downloads/setuptools-*.whl
 $OUTDIR/wheels-repo/downloads/pbr-*.whl
 $OUTDIR/wheels-repo/downloads/stevedore-*.whl
 
-$OUTDIR/sdists-repo/downloads/stevedore-*.tar.gz
-$OUTDIR/sdists-repo/downloads/setuptools-*.tar.gz
-$OUTDIR/sdists-repo/downloads/pbr-*.tar.gz
-
 $OUTDIR/work-dir/pbr-*/*-requirements.txt
 $OUTDIR/work-dir/setuptools-*/*-requirements.txt
 $OUTDIR/work-dir/stevedore-*/*-requirements.txt
@@ -101,10 +97,6 @@ EXPECTED_FILES="
 $OUTDIR/wheels-repo/downloads/setuptools-*.whl
 $OUTDIR/wheels-repo/downloads/pbr-*.whl
 $OUTDIR/wheels-repo/downloads/stevedore-*.whl
-
-$OUTDIR/sdists-repo/downloads/stevedore-*.tar.gz
-$OUTDIR/sdists-repo/downloads/setuptools-*.tar.gz
-$OUTDIR/sdists-repo/downloads/pbr-*.tar.gz
 
 $OUTDIR/work-dir/build-order.json
 $OUTDIR/work-dir/constraints.txt

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -173,8 +173,7 @@ def _download_source_check(
             raise zipfile.BadZipFile(f"Empty zip file encountered: {source_filename}")
     elif source_filename.suffix == ".tgz" or source_filename.suffix == ".gz":
         with tarfile.open(source_filename) as tar:
-            contents = tar.getnames()
-            if not contents:
+            if not tar.next():
                 raise TypeError(f"Empty tar file encountered: {source_filename}")
     else:
         raise TypeError(


### PR DESCRIPTION
fixes #510 

Resolving and then immediately detecting if we have seen the dependency allows us to avoid paying the cost of trying to download and verify the sdist tarball each time that dependency is requested.

On our downstream systems just torch itself was spending 3 minutes total in `download_source` in a single bootstrap run with all performance features enabled. This brings it down to 5 seconds for torch (didn't measure it for other dependencies)