### PR TITLE
network isolation: set hostname to localhost

### DIFF
--- a/src/fromager/run_network_isolation.sh
+++ b/src/fromager/run_network_isolation.sh
@@ -1,10 +1,13 @@
-#!/usr/bin/env -S unshare -rn /bin/bash
+#!/usr/bin/env -S unshare --uts --net --map-root-user /bin/bash
 #
 # Run command with network isolation (CLONE_NEWNET) and set up loopback
 # interface in the new network namespace. This is somewhat similar to
 # Bubblewrap `bwrap --unshare-net --dev-bind / /`, but works in an
 # unprivilged container. The user is root inside the new namespace and mapped
 # to the euid/egid if the parent namespace.
+#
+# Unshare UTS namespace, so we can set the hostname to "localhost", so
+# lookup of "localhost" does not fail.
 #
 # Ubuntu 24.04: needs `sysctl kernel.apparmor_restrict_unprivileged_userns=0`
 # to address `unshare: write failed /proc/self/uid_map: Operation not permitted`.
@@ -20,6 +23,11 @@ fi
 
 # bring loopback up
 ip link set lo up
+
+# set hostname to "localhost"
+if command -v hostname 2>&1 >/dev/null; then
+   hostname localhost
+fi
 
 # replace with command
 exec "$@"


### PR DESCRIPTION
Unshare UTS namespace and set hostname to "localhost". Some build systems lookup "localhost". We didn't run into the problem, yet, because Fedora-based distros have `127.0.0.1 localhost` in `/etc/hosts`.

Thanks to Michał Górny @mgorny for suggesting the change.