### PR TITLE
Only invoke vendor_rust if network isolation set

### DIFF
--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -412,7 +412,8 @@ def prepare_new_source(
         req=req,
         sdist_root_dir=source_root_dir,
     )
-    vendor_rust.vendor_rust(req, source_root_dir)
+    if ctx.network_isolation:
+        vendor_rust.vendor_rust(req, source_root_dir)
 
 
 @metrics.timeit(description="build sdist")


### PR DESCRIPTION
See: #529

While improving the vendor logic for more complex source cases this fixes building cryptography if network isolation turned off

Signed-off-by: Pris Nasrat <pris.nasrat@chainguard.dev>
