### PR TITLE
feat: Support multiple constraints files

### DIFF
--- a/e2e/test_bootstrap_prerelease.sh
+++ b/e2e/test_bootstrap_prerelease.sh
@@ -27,8 +27,11 @@ fi
 
 $pass
 
-CONSTRAINTS_FILE="$OUTDIR/flit_core_constraints.txt"
-echo "flit_core==2.0rc3" > $CONSTRAINTS_FILE
+CONSTRAINTS_FILE_1="$OUTDIR/flit_core_constraints.txt"
+echo "flit_core==2.0rc3" > $CONSTRAINTS_FILE_1
+
+CONSTRAINTS_FILE_2="$OUTDIR/misc_constraints.txt"
+echo "setuptools>=75.8.0" > $CONSTRAINTS_FILE_2
 
 DEBUG_RESOLVER=true fromager \
   --verbose \
@@ -36,7 +39,8 @@ DEBUG_RESOLVER=true fromager \
   --sdists-repo="$OUTDIR/sdists-repo" \
   --wheels-repo="$OUTDIR/wheels-repo" \
   --work-dir="$OUTDIR/work-dir" \
-  --constraints-file="$CONSTRAINTS_FILE" \
+  --constraints-file="$CONSTRAINTS_FILE_1" \
+  --constraints-file="$CONSTRAINTS_FILE_2" \
   bootstrap $DIST || true
 
 

--- a/src/fromager/clickext.py
+++ b/src/fromager/clickext.py
@@ -7,6 +7,19 @@ from packaging.version import Version
 from . import requirements_file
 
 
+def verify_url_callback(
+    ctx: click.Context, param: click.Parameter, value: tuple[str]
+) -> tuple[str]:
+    for item in value:
+        if not item.startswith(("https://", "http://", "file://")):
+            raise click.BadParameter(
+                f"value must be a http, https, or file URL, got {item}",
+                ctx=ctx,
+                param=param,
+            )
+    return value
+
+
 class ClickPath(click.Path):
     """ClickPath that returns pathlib.Path"""
 

--- a/src/fromager/constraints.py
+++ b/src/fromager/constraints.py
@@ -20,6 +20,9 @@ class Constraints:
     def __iter__(self) -> typing.Iterable[NormalizedName]:
         yield from self._data
 
+    def __bool__(self) -> bool:
+        return bool(self._data)
+
     def add_constraint(self, unparsed: str) -> None:
         """Add new constraint, must not conflict with any existing constraints"""
         req = Requirement(unparsed)
@@ -34,11 +37,17 @@ class Constraints:
             self._data[canon_name] = req
 
     def load_constraints_file(self, constraints_file: str | pathlib.Path) -> None:
-        """Load constraints from a constraints file"""
+        """Load constraints from a constraints file or URI"""
         logger.info("loading constraints from %s", constraints_file)
         content = requirements_file.parse_requirements_file(constraints_file)
         for line in content:
             self.add_constraint(line)
+
+    def dump_constraints_file(self, constraints_file: pathlib.Path) -> None:
+        """Dump all constraints into a file"""
+        with constraints_file.open("w", encoding="utf-8") as f:
+            for req in self._data.values():
+                f.write(f"{req}\n")
 
     def get_constraint(self, name: str) -> Requirement | None:
         return self._data.get(canonicalize_name(name))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ def tmp_context(tmp_path: pathlib.Path) -> context.WorkContext:
     variant = "cpu"
     ctx = context.WorkContext(
         active_settings=None,
-        constraints_file=None,
+        constraints_files=[],
         patches_dir=patches_dir,
         sdists_repo=tmp_path / "sdists-repo",
         wheels_repo=tmp_path / "wheels-repo",
@@ -46,7 +46,7 @@ def testdata_context(
             variant=variant,
             max_jobs=None,
         ),
-        constraints_file=None,
+        constraints_files=[],
         patches_dir=overrides / "patches",
         sdists_repo=tmp_path / "sdists-repo",
         wheels_repo=tmp_path / "wheels-repo",

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -64,6 +64,15 @@ def test_load_non_existant_constraints_file(tmp_path: pathlib.Path):
         c.load_constraints_file(non_existant_file)
 
 
+def test_magic_methods():
+    c = constraints.Constraints()
+    assert not c
+    assert list(c) == []
+    c.add_constraint("flit_core==2.0rc3")
+    assert c
+    assert list(c) == ["flit-core"]
+
+
 def test_load_constraints_file(tmp_path: pathlib.Path):
     constraint_file = tmp_path / "constraint.txt"
     constraint_file.write_text("egg\ntorch==3.1.0 # comment\n")
@@ -71,3 +80,13 @@ def test_load_constraints_file(tmp_path: pathlib.Path):
     c.load_constraints_file(constraint_file)
     assert list(c) == ["egg", "torch"]  # type: ignore
     assert c.get_constraint("torch") == Requirement("torch==3.1.0")
+
+
+def test_dump_constraints_file(tmp_path: pathlib.Path):
+    c = constraints.Constraints()
+    c.add_constraint("foo<=1.1")
+    c.add_constraint("bar>=2.0")
+
+    constraint_file = tmp_path / "constraint.txt"
+    c.dump_constraints_file(constraint_file)
+    assert constraint_file.read_text().split("\n") == ["foo<=1.1", "bar>=2.0", ""]

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -8,18 +8,21 @@ def test_pip_constraints_args(tmp_path):
     constraints_file.write_text("\n")  # the file has to exist
     ctx = context.WorkContext(
         active_settings=None,
-        constraints_file=str(constraints_file),
+        constraints_files=[constraints_file],
         patches_dir=tmp_path / "overrides/patches",
         sdists_repo=tmp_path / "sdists-repo",
         wheels_repo=tmp_path / "wheels-repo",
         work_dir=tmp_path / "work-dir",
     )
     ctx.setup()
-    assert ["--constraint", os.fspath(constraints_file)] == ctx.pip_constraint_args
+    assert ctx.pip_constraint_args == [
+        "--constraint",
+        os.fspath(ctx.work_dir / "combined-constraints.txt"),
+    ]
 
     ctx = context.WorkContext(
         active_settings=None,
-        constraints_file=None,
+        constraints_files=[],
         patches_dir=tmp_path / "overrides/patches",
         sdists_repo=tmp_path / "sdists-repo",
         wheels_repo=tmp_path / "wheels-repo",


### PR DESCRIPTION
Fromager now supports multiple constraints files. The option `fromager --constraints-file` can be supplied multiple times. The option no longer accepts URLs. Remote constraints files are now specified with `--constraints-url`. The split was necessary to correctly parse environment variables with multiple entries and white spaces in local file names. Paths are split at `:`, URLs are split at ` ` (white space).

There can only be one constraint per package.

Internally, remote constraints from `https://` URLs are no longer retrieved twice. Instead all constraints are merged and the final set is dumped into a single constraints file.

Fixes: #539