### PR TITLE
Add debug message for expected build tag

### DIFF
--- a/e2e/test_bootstrap_constraints.sh
+++ b/e2e/test_bootstrap_constraints.sh
@@ -38,7 +38,7 @@ fi
 $pass
 
 EXPECTED_LINES="
-pbr==6.1.0
+pbr==6.1.1
 # ERROR
 stevedore==4.0.0
 stevedore==5.2.0

--- a/src/fromager/bootstrapper.py
+++ b/src/fromager/bootstrapper.py
@@ -323,6 +323,12 @@ class Bootstrapper:
             wheelfile_name = pathlib.Path(urlparse(wheel_url).path)
             pbi = self.ctx.package_build_info(req)
             expected_build_tag = pbi.build_tag(resolved_version)
+            # Log the expected build tag for debugging
+            logger.info(f"{req.name}: has expected build tag {expected_build_tag}")
+            # Get changelogs for debug info
+            changelogs = pbi.get_changelog(resolved_version)
+            logger.debug(f"{req.name} has change logs {changelogs}")
+
             dist_name, dist_version, build_tag, _ = wheels.extract_info_from_wheel_file(
                 req, wheelfile_name
             )

--- a/src/fromager/packagesettings.py
+++ b/src/fromager/packagesettings.py
@@ -627,11 +627,16 @@ class PackageBuildInfo:
             return sdist_root_dir / relative_build_dir
         return sdist_root_dir
 
+    def get_changelog(self, version: Version) -> list[str]:
+        pv = typing.cast(PackageVersion, version)
+        variant_changelog = self._variant_changelog
+        package_changelog = self._ps.changelog.get(pv, [])
+        return variant_changelog + package_changelog
+
     def build_tag(self, version: Version) -> BuildTag:
         """Build tag for version's changelog and this variant"""
         pv = typing.cast(PackageVersion, version)
-        release = len(self._ps.changelog.get(pv, []))
-        release += len(self._variant_changelog)
+        release = len(self.get_changelog(pv))
         if release == 0:
             return ()
         # suffix = "." + self.variant.replace("-", "_")


### PR DESCRIPTION
This commit adds a debug message for `expected_build_tag` and logs the change log entries for debug

Further, new version of pbr released few days ago which breaks our e2e test for `test_bootstrap_constraints.sh`. The pbr version is now updated to `6.1.1` for the test

Signed-off by: Rohan Devasthale