### PR TITLE
add tests for canonicalizing extras names in evaluate_marker

### DIFF
--- a/tests/test_requirements_file.py
+++ b/tests/test_requirements_file.py
@@ -1,7 +1,16 @@
 import pathlib
 import textwrap
+from itertools import product
 
-from fromager.requirements_file import RequirementType, parse_requirements_file
+import pytest
+from packaging.markers import Marker
+from packaging.requirements import Requirement
+
+from fromager.requirements_file import (
+    RequirementType,
+    evaluate_marker,
+    parse_requirements_file,
+)
 
 
 def test_get_requirements_requirements_file(tmp_path: pathlib.Path):
@@ -50,3 +59,15 @@ def test_compare_req_type():
     # make sure they equal themselves
     for r in RequirementType:
         assert r == r
+
+
+@pytest.mark.parametrize(
+    "parent_e,marker_e,extras_e", list(product(["b-c", "b_c", "B_C"], repeat=3))
+)
+def test_evaluate_marker_canonical_names(parent_e, marker_e, extras_e):
+    parent_req = Requirement(f"a[{parent_e}]")
+    req = Requirement("d")
+    marker = Marker(f"extra == '{marker_e}'")
+    req.marker = marker
+    extras = set([extras_e])
+    assert evaluate_marker(parent_req=parent_req, req=req, extras=extras)


### PR DESCRIPTION
Add tests to verify that the names of extras are canonicalized properly
when used by evaluate_marker().