### PR TITLE
feat: Add PEP 517 config-settings option

### DIFF
--- a/src/fromager/packagesettings.py
+++ b/src/fromager/packagesettings.py
@@ -295,6 +295,12 @@ class PackageSettings(pydantic.BaseModel):
     changelog: VariantChangelog = Field(default_factory=dict)
     """Changelog entries"""
 
+    config_settings: list[str] = Field(default_factory=list)
+    """PEP 517 arbitrary configuration for wheel builds
+
+    https://peps.python.org/pep-0517/#config-settings
+    """
+
     env: EnvVars = Field(default_factory=dict)
     """Common env var for all variants"""
 
@@ -725,6 +731,10 @@ class PackageBuildInfo:
     def build_ext_parallel(self) -> bool:
         """Configure [build_ext]parallel for setuptools?"""
         return self._ps.build_options.build_ext_parallel
+
+    @property
+    def config_settings(self) -> list[str]:
+        return self._ps.config_settings
 
     @property
     def project_override(self) -> ProjectOverride:

--- a/tests/test_packagesettings.py
+++ b/tests/test_packagesettings.py
@@ -34,6 +34,9 @@ FULL_EXPECTED: dict[str, typing.Any] = {
         Version("1.0.1"): ["fixed bug"],
         Version("1.0.2"): ["more bugs", "rebuild"],
     },
+    "config_settings": [
+        "setup-args=-Dsystem-freetype=true",
+    ],
     "download_source": {
         "destination_filename": "${canonicalized_name}-${version}.tar.gz",
         "url": "https://egg.test/${canonicalized_name}/v${version}.tar.gz",
@@ -84,6 +87,7 @@ EMPTY_EXPECTED: dict[str, typing.Any] = {
         "memory_per_job_gb": 1.0,
     },
     "changelog": {},
+    "config_settings": [],
     "env": {},
     "download_source": {
         "url": None,

--- a/tests/test_wheels.py
+++ b/tests/test_wheels.py
@@ -1,14 +1,18 @@
 import pathlib
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 import wheel.cli  # type: ignore
+from packaging.requirements import Requirement
+from packaging.version import Version
 
-from fromager import wheels
+from fromager import build_environment, context, wheels
 
 
 @patch("fromager.sources.download_url")
-def test_invalid_wheel_file_exception(mock_download_url, tmp_path: pathlib.Path):
+def test_invalid_wheel_file_exception(
+    mock_download_url: Mock, tmp_path: pathlib.Path
+) -> None:
     mock_download_url.return_value = pathlib.Path(tmp_path / "test" / "fake_wheel.txt")
     fake_url = "https://www.thisisafakeurl.com"
     fake_dir = tmp_path / "test"
@@ -17,3 +21,27 @@ def test_invalid_wheel_file_exception(mock_download_url, tmp_path: pathlib.Path)
     text_file.write_text("This is a test file")
     with pytest.raises(wheel.cli.WheelError):
         wheels._download_wheel_check(fake_dir, fake_url)
+
+
+@patch("fromager.build_environment.BuildEnvironment.run")
+def test_default_build_wheel(
+    mock_run: Mock, tmp_path: pathlib.Path, testdata_context: context.WorkContext
+) -> None:
+    build_env = build_environment.BuildEnvironment(testdata_context, tmp_path, None)
+    req = Requirement("test_pkg")
+    pbi = testdata_context.package_build_info(req)
+    assert pbi.config_settings
+
+    wheels.default_build_wheel(
+        ctx=testdata_context,
+        build_env=build_env,
+        extra_environ={},
+        req=req,
+        sdist_root_dir=tmp_path,
+        version=Version("1.0"),
+        build_dir=tmp_path,
+    )
+
+    mock_run.assert_called_once()
+    cmd = mock_run.call_args[0][0]
+    assert "--config-settings=setup-args=-Dsystem-freetype=true" in cmd

--- a/tests/testdata/context/overrides/settings/test_pkg.yaml
+++ b/tests/testdata/context/overrides/settings/test_pkg.yaml
@@ -9,6 +9,8 @@ changelog:
     "1.0.2":
         - more bugs
         - rebuild
+config_settings:
+    - setup-args=-Dsystem-freetype=true
 env:
     EGG: spam
     EGG_AGAIN: "$EGG"


### PR DESCRIPTION
PEP 517 config-settings are used to pass arbitrary settings to the wheel build backend. The Meson build backend uses the feature to customize builds, e.g. to change the BLAS and LAPACK backend of NumPy. Config-settings are needed to build matplotlib with system packages.