### PR TITLE
Improve RequirementType enum, fix req_type in bootstrap

### DIFF
--- a/src/fromager/bootstrapper.py
+++ b/src/fromager/bootstrapper.py
@@ -162,10 +162,19 @@ class Bootstrapper:
         install_dependencies = dependencies.get_install_dependencies_of_wheel(
             req, wheel_filename, unpack_dir
         )
+
+        if req_type.is_build_requirement:
+            # install dependencies of build requirements are also build
+            # system requirements.
+            child_req_type = RequirementType.BUILD_SYSTEM
+        else:
+            # top-level and install requirements
+            child_req_type = RequirementType.INSTALL
+
         self.progressbar.update_total(len(install_dependencies))
         for dep in self._sort_requirements(install_dependencies):
             try:
-                self.bootstrap(dep, RequirementType.INSTALL)
+                self.bootstrap(dep, child_req_type)
             except Exception as err:
                 raise ValueError(f"could not handle {self._explain}") from err
             self.progressbar.update()

--- a/src/fromager/build_environment.py
+++ b/src/fromager/build_environment.py
@@ -293,7 +293,7 @@ def prepare_build_environment(
         if match:
             raise MissingDependency(
                 ctx,
-                RequirementType.BUILD,
+                next_req_type,
                 match.groups()[0],
                 build_system_dependencies
                 | build_backend_dependencies

--- a/src/fromager/requirements_file.py
+++ b/src/fromager/requirements_file.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 class RequirementType(StrEnum):
     INSTALL = "install"
     TOP_LEVEL = "toplevel"
-    BUILD = "build"
     BUILD_SYSTEM = "build-system"
     BUILD_BACKEND = "build-backend"
     BUILD_SDIST = "build-sdist"
@@ -22,7 +21,7 @@ class RequirementType(StrEnum):
     @property
     def is_build_requirement(self) -> bool:
         """Is requirement a build time requirement?"""
-        return self.value in {"build", "build-system", "build-backend", "build-sdist"}
+        return self.value in {"build-system", "build-backend", "build-sdist"}
 
     @property
     def is_install_requirement(self) -> bool:

--- a/src/fromager/requirements_file.py
+++ b/src/fromager/requirements_file.py
@@ -19,20 +19,15 @@ class RequirementType(StrEnum):
     BUILD_BACKEND = "build-backend"
     BUILD_SDIST = "build-sdist"
 
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, RequirementType):
-            if self.value == "build" or other.value == "build":
-                allowed_values = [
-                    "build-backend",
-                    "build-system",
-                    "build-sdist",
-                    "build",
-                ]
-                return self.value in allowed_values and other.value in allowed_values
-        return super.__eq__(self, other)
+    @property
+    def is_build_requirement(self) -> bool:
+        """Is requirement a build time requirement?"""
+        return self.value in {"build", "build-system", "build-backend", "build-sdist"}
 
-    def __ne__(self, value: object) -> bool:
-        return not self == value
+    @property
+    def is_install_requirement(self) -> bool:
+        """Is requirement an installation requirement?"""
+        return self.value in {"install", "toplevel"}
 
 
 class SourceType(StrEnum):

--- a/src/fromager/resolver.py
+++ b/src/fromager/resolver.py
@@ -317,7 +317,7 @@ class BaseProvider(ExtrasProvider):
         cache = self.get_cache()
         # we only want caching for build reqs because for install time reqs we always want to get the latest version
         # we can't guarantee that the latest version is available in the cache so install time reqs cannot use the cache
-        if self.req_type != RequirementType.BUILD:
+        if self.req_type is None or not self.req_type.is_build_requirement:
             return []
         return [
             c

--- a/tests/test_bootstrapper.py
+++ b/tests/test_bootstrapper.py
@@ -373,9 +373,9 @@ def test_explain(tmp_context: WorkContext):
 
     bt.why = [
         (RequirementType.TOP_LEVEL, Requirement("foo"), Version("1.0.0")),
-        (RequirementType.BUILD, Requirement("bar==4.0.0"), Version("4.0.0")),
+        (RequirementType.BUILD_SYSTEM, Requirement("bar==4.0.0"), Version("4.0.0")),
     ]
     assert (
         bt._explain
-        == f"{RequirementType.BUILD} dependency bar==4.0.0 (4.0.0) for {RequirementType.TOP_LEVEL} dependency foo (1.0.0)"
+        == f"{RequirementType.BUILD_SYSTEM} dependency bar==4.0.0 (4.0.0) for {RequirementType.TOP_LEVEL} dependency foo (1.0.0)"
     )

--- a/tests/test_build_environment.py
+++ b/tests/test_build_environment.py
@@ -29,11 +29,11 @@ def test_missing_dependency_format(
         req,
     ]
     ex = build_environment.MissingDependency(
-        tmp_context, RequirementType.BUILD, req, other_reqs
+        tmp_context, RequirementType.BUILD_BACKEND, req, other_reqs
     )
     s = str(ex)
     # Ensure we report the thing we're actually missing
-    assert "Failed to install build dependency setuptools>=40.8.0. " in s
+    assert "Failed to install build-backend dependency setuptools>=40.8.0. " in s
     # Ensure we report what version we expected of that thing
     assert "setuptools>=40.8.0 -> 69.5.1" in s
     # Ensure we report what version we expect of all of the other dependencies

--- a/tests/test_requirements_file.py
+++ b/tests/test_requirements_file.py
@@ -44,14 +44,12 @@ def test_get_requirements_file_with_comments_and_blanks(tmp_path: pathlib.Path):
 def test_req_type_flag():
     assert not RequirementType.INSTALL.is_build_requirement
     assert not RequirementType.TOP_LEVEL.is_build_requirement
-    assert RequirementType.BUILD.is_build_requirement
     assert RequirementType.BUILD_SYSTEM.is_build_requirement
     assert RequirementType.BUILD_SDIST.is_build_requirement
     assert RequirementType.BUILD_BACKEND.is_build_requirement
 
     assert RequirementType.INSTALL.is_install_requirement
     assert RequirementType.TOP_LEVEL.is_install_requirement
-    assert not RequirementType.BUILD.is_install_requirement
     assert not RequirementType.BUILD_SYSTEM.is_install_requirement
     assert not RequirementType.BUILD_SDIST.is_install_requirement
     assert not RequirementType.BUILD_BACKEND.is_install_requirement

--- a/tests/test_requirements_file.py
+++ b/tests/test_requirements_file.py
@@ -41,24 +41,24 @@ def test_get_requirements_file_with_comments_and_blanks(tmp_path: pathlib.Path):
     assert requirements == ["a", "b", "c"]
 
 
-def test_compare_req_type():
-    assert RequirementType.BUILD == RequirementType.BUILD_BACKEND
-    assert RequirementType.BUILD == RequirementType.BUILD_SDIST
-    assert RequirementType.BUILD == RequirementType.BUILD_SYSTEM
+def test_req_type_flag():
+    assert not RequirementType.INSTALL.is_build_requirement
+    assert not RequirementType.TOP_LEVEL.is_build_requirement
+    assert RequirementType.BUILD.is_build_requirement
+    assert RequirementType.BUILD_SYSTEM.is_build_requirement
+    assert RequirementType.BUILD_SDIST.is_build_requirement
+    assert RequirementType.BUILD_BACKEND.is_build_requirement
 
-    # reverse order
-    assert RequirementType.BUILD_SYSTEM == RequirementType.BUILD
-    assert RequirementType.BUILD_SDIST == RequirementType.BUILD
-    assert RequirementType.BUILD_BACKEND == RequirementType.BUILD
+    assert RequirementType.INSTALL.is_install_requirement
+    assert RequirementType.TOP_LEVEL.is_install_requirement
+    assert not RequirementType.BUILD.is_install_requirement
+    assert not RequirementType.BUILD_SYSTEM.is_install_requirement
+    assert not RequirementType.BUILD_SDIST.is_install_requirement
+    assert not RequirementType.BUILD_BACKEND.is_install_requirement
 
-    assert RequirementType.INSTALL != RequirementType.BUILD_BACKEND
-    assert RequirementType.INSTALL != RequirementType.BUILD_SYSTEM
-    assert RequirementType.INSTALL != RequirementType.BUILD_SDIST
-    assert RequirementType.INSTALL != RequirementType.BUILD
-
-    # make sure they equal themselves
     for r in RequirementType:
         assert r == r
+        assert r.is_build_requirement or r.is_install_requirement
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
bootstrap was treating install requirements of build systems and build
backends as plain install requirements. Instead any installation
requirement of a build backend should be treated as a build requirement,
too.

The previous implementation of `RequirementType` enum was confusing and
had subtile bugs. It was surprising that one enum member was equal to
several other enum members. The `__ne__` implementation was wrong and
the presence of `__eq__` without a `__hash__` in the subclass broke
hashability.

```
>>> from fromager.requirements_file import RequirementType
>>> hash(RequirementType.BUILD)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unhashable type: 'RequirementType'
>>> RequirementType.BUILD.__eq__(None)
NotImplemented
>>> RequirementType.BUILD.__ne__(None)
True
```

The `__ne__` method should have returned `NotImplemented` marker, too.

The new implementation removes `__eq__` and instead introduces
`is_build_requirement` and `is_install_requirement` flags.
`if req_type.is_build_requirement:` is easier to understand.

