### PR TITLE
feat: add exclude_vcs option to tar_reproducible

### DIFF
--- a/tests/test_tarballs.py
+++ b/tests/test_tarballs.py
@@ -1,10 +1,11 @@
 import os
+import pathlib
 import tarfile
 
 from fromager import tarballs
 
 
-def test_modes_change(tmp_path):
+def test_modes_change(tmp_path: pathlib.Path) -> None:
     root = tmp_path / "root"
     root.mkdir()
     a = root / "a"
@@ -26,7 +27,7 @@ def test_modes_change(tmp_path):
     assert t1_contents == t2_contents, "file contents differ"
 
 
-def test_prefix_strip(tmp_path):
+def test_prefix_strip(tmp_path: pathlib.Path) -> None:
     root = tmp_path / "root"
     root.mkdir()
     subdir = root / "subdir"
@@ -42,7 +43,7 @@ def test_prefix_strip(tmp_path):
     assert names == [".", "subdir", "subdir/a"]
 
 
-def test_no_prefix_strip(tmp_path):
+def test_no_prefix_strip(tmp_path: pathlib.Path) -> None:
     root = tmp_path / "root"
     root.mkdir()
     subdir = root / "subdir"
@@ -56,3 +57,39 @@ def test_no_prefix_strip(tmp_path):
     with tarfile.open(t1, "r") as tf:
         names = tf.getnames()
     assert names == [str(p).lstrip(os.sep) for p in [root, subdir, a]]
+
+
+def test_no_vcs_exclude(tmp_path: pathlib.Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    subdir = root / ".git"
+    subdir.mkdir()
+    a = subdir / "config"
+    a.write_text("this is a VCS file")
+
+    t1 = tmp_path / "out1.tar"
+    with tarfile.open(t1, "w") as tf:
+        tarballs.tar_reproducible(tar=tf, basedir=root)
+    with tarfile.open(t1, "r") as tf:
+        names = tf.getnames()
+    assert names == [str(p).lstrip(os.sep) for p in [root, subdir, a]]
+
+
+def test_vcs_exclude(tmp_path: pathlib.Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    a = root / "a"
+    a.write_text("this is file a")
+
+    for vcs in tarballs.VCS_DIRS:
+        subdir = root / vcs
+        subdir.mkdir()
+        a = subdir / "config"
+        a.write_text("this is a VCS file")
+
+    t1 = tmp_path / "out1.tar"
+    with tarfile.open(t1, "w") as tf:
+        tarballs.tar_reproducible(tar=tf, basedir=root, exclude_vcs=True)
+    with tarfile.open(t1, "r") as tf:
+        names = tf.getnames()
+    assert names == [str(p).lstrip(os.sep) for p in [root, root / "a"]]


### PR DESCRIPTION
The `tar_reproducible` now has an option to exclude and ignore files and directories from VCS like `.git`.