### PR TITLE
Ensure PKG-INFO in sdists

### DIFF
--- a/e2e/test_bootstrap_git_url.sh
+++ b/e2e/test_bootstrap_git_url.sh
@@ -54,3 +54,6 @@ for pattern in $EXPECTED_FILES; do
 done
 
 $pass
+
+twine check $OUTDIR/sdists-repo/builds/*.tar.gz
+twine check $OUTDIR/wheels-repo/downloads/*.whl

--- a/e2e/test_bootstrap_git_url_tag.sh
+++ b/e2e/test_bootstrap_git_url_tag.sh
@@ -54,3 +54,6 @@ for pattern in $EXPECTED_FILES; do
 done
 
 $pass
+
+twine check $OUTDIR/sdists-repo/builds/*.tar.gz
+twine check $OUTDIR/wheels-repo/downloads/*.whl

--- a/e2e/test_pep517_build_sdist.sh
+++ b/e2e/test_pep517_build_sdist.sh
@@ -60,3 +60,5 @@ for pattern in $EXPECTED_FILES; do
 done
 
 $pass
+
+twine check $OUTDIR/sdists-repo/builds/*.tar.gz

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,5 @@ pytest
 requests-mock
 setuptools_scm>=8
 setuptools>=64
+# Twine 6.1.0 added strict metadata validation
+twine>=6.1.0


### PR DESCRIPTION
GitLab tar balls are not valid Python sdists because they are missing a `PKG-INFO` file. The file is required for `setuptools-scm` and for latest Twine. `ensure_pkg_info` helper ensures that a source tree has a minimal `PKG-INFO`.