### PR TITLE
fix: always use sdist name $name-$version.tar.gz

### DIFF
--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -650,7 +650,7 @@ def default_build_sdist(
     #
     # For cases where the PEP 517 approach works, use
     # pep517_build_sdist().
-    sdist_filename = ctx.sdists_builds / (build_dir.name + ".tar.gz")
+    sdist_filename = ctx.sdists_builds / f"{req.name}-{version}.tar.gz"
     if sdist_filename.exists():
         sdist_filename.unlink()
     # The format argument is specified based on


### PR DESCRIPTION
Fromager was using the package's `build_dir` as sdist name. This lead to wrong and invalid sdist names for packages with a `build_dir` option. For example our downstream build of Triton has a sdist with file name `python.tar.gz` because it has `build_dir: python` setting.