### PR TITLE
virtualenv: always install setuptools and wheel, no download

### DIFF
--- a/src/fromager/build_environment.py
+++ b/src/fromager/build_environment.py
@@ -161,9 +161,23 @@ class BuildEnvironment:
             return
 
         logger.debug("creating build environment in %s", self.path)
+        # Python 3.12 virtual envs don't have wheel and setuptools by
+        # default. Some packages still assume they are installed.
         external_commands.run(
-            [sys.executable, "-m", "virtualenv", str(self.path)],
-            network_isolation=False,
+            [
+                sys.executable,
+                "-m",
+                "virtualenv",
+                "--python",
+                sys.executable,
+                "--pip=bundle",
+                "--setuptools=bundle",
+                "--wheel=bundle",
+                "--no-periodic-update",
+                "--no-download",
+                str(self.path),
+            ],
+            network_isolation=self._ctx.network_isolation,
         )
         logger.info("created build environment in %s", self.path)
 


### PR DESCRIPTION
`virtualenv` behaves differently on Python >=3.12 than on <=3.11. On 3.12+ it does not install setuptools and wheel. Packages are suppose to declare these build requirements in their `pyproject.toml`. Some packages haven't been updated, yet. Let's always install setuptools and wheel.

Also disable downloads and updates of embedded wheels to prevent network access.