### PR TITLE
Add sdist_backend setting, default to PEP 517

### DIFF
--- a/src/fromager/gitutils.py
+++ b/src/fromager/gitutils.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
 import logging
 import pathlib
+import typing
 from urllib.parse import urlparse
 
 from packaging.requirements import Requirement
 
-from fromager import context, external_commands
+from . import external_commands
+
+if typing.TYPE_CHECKING:
+    from . import context
 
 logger = logging.getLogger(__name__)
 

--- a/src/fromager/metrics.py
+++ b/src/fromager/metrics.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import logging
 import time
@@ -7,7 +9,8 @@ from datetime import timedelta
 from packaging.requirements import Requirement
 from packaging.version import Version
 
-from . import context
+if typing.TYPE_CHECKING:
+    from . import context
 
 
 def timeit(description: str) -> typing.Callable:

--- a/tests/test_packagesettings.py
+++ b/tests/test_packagesettings.py
@@ -7,7 +7,7 @@ import pytest
 from packaging.utils import NormalizedName
 from packaging.version import Version
 
-from fromager import build_environment, context
+from fromager import build_environment, context, sources
 from fromager.packagesettings import (
     BuildDirectory,
     EnvVars,
@@ -29,6 +29,7 @@ FULL_EXPECTED: dict[str, typing.Any] = {
         "build_ext_parallel": True,
         "cpu_cores_per_job": 4,
         "memory_per_job_gb": 4.0,
+        "sdist_backend": sources.SDistBackend.TARBALL,
     },
     "changelog": {
         Version("1.0.1"): ["fixed bug"],
@@ -85,6 +86,7 @@ EMPTY_EXPECTED: dict[str, typing.Any] = {
         "build_ext_parallel": False,
         "cpu_cores_per_job": 1,
         "memory_per_job_gb": 1.0,
+        "sdist_backend": sources.SDistBackend.PEP517,
     },
     "changelog": {},
     "config_settings": [],

--- a/tests/testdata/context/overrides/settings/test_pkg.yaml
+++ b/tests/testdata/context/overrides/settings/test_pkg.yaml
@@ -3,6 +3,7 @@ build_options:
     build_ext_parallel: true
     cpu_cores_per_job: 4
     memory_per_job_gb: 4
+    sdist_backend: tarball
 changelog:
     "1.0.1":
         - fixed bug


### PR DESCRIPTION
Fromager now defaults to PEP 571 hooks to create sdists. This re-generates the metadata of sdists, too. Fresh metadata solves problems like core metadata violation with Hatchling < 1.26.

- Packages with `build_dir` option use old `tarball` method by default.
- Packages with `mesonpy` build backend use old `tarball` method. `meson
  dist` currently only works with Git or Mercurial repos.
- Packages with `build_sdist` hook are not affected.
- `build_options.sdist_backend: tarball` restores the previous behavior.