### PR TITLE
improve error messages from resolver

### DIFF
--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -215,7 +215,7 @@ def test_provider_constraint_mismatch():
         reporter = resolvelib.BaseReporter()
         rslvr = resolvelib.Resolver(provider, reporter)
 
-        with pytest.raises(resolvelib.resolvers.ResolutionImpossible):
+        with pytest.raises(resolvelib.resolvers.exceptions.ResolverException):
             rslvr.resolve([Requirement("hydra-core")])
 
 


### PR DESCRIPTION
Add better logging and exceptions in the resolver code to convey more information about what is happening when no match is found.

Log debug messages for cases like ignoring all candidate files or having no candidates at all.

Use standard ResolverException error types and use messages specific to the different cases for searching for different types of files (sdists or wheels).

Move all of the logic for checking version compatibility into is_satisified_by() method of the base class for more consistent logging via different paths.