### PR TITLE
add hook entry point for bootstrap

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -97,6 +97,7 @@ jobs:
           - migrate_graph
           - override
           - pep517_build_sdist
+          - post_bootstrap_hook
           - prebuilt_wheels_alt_server
           - report_missing_dependency
           - rust_vendor

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -26,6 +26,7 @@ pull_request_rules:
   - name: Automatic merge on approval
     conditions:
       - and:
+          - "-draft"
           - check-success=e2e (3.11, 1.75, bootstrap, ubuntu-latest)
           - check-success=e2e (3.11, 1.75, bootstrap_build_tags, ubuntu-latest)
           - check-success=e2e (3.11, 1.75, bootstrap_cache, ubuntu-latest)
@@ -49,6 +50,7 @@ pull_request_rules:
           - check-success=e2e (3.11, 1.75, optimize_build, ubuntu-latest)
           - check-success=e2e (3.11, 1.75, override, ubuntu-latest)
           - check-success=e2e (3.11, 1.75, pep517_build_sdist, ubuntu-latest)
+          - check-success=e2e (3.11, 1.75, post_bootstrap_hook, ubuntu-latest)
           - check-success=e2e (3.11, 1.75, prebuilt_wheel_hook, ubuntu-latest)
           - check-success=e2e (3.11, 1.75, prebuilt_wheels_alt_server, ubuntu-latest)
           - check-success=e2e (3.11, 1.75, report_missing_dependency, ubuntu-latest)
@@ -99,6 +101,8 @@ pull_request_rules:
           - check-success=e2e (3.12, 1.75, override, ubuntu-latest)
           - check-success=e2e (3.12, 1.75, pep517_build_sdist, macos-latest)
           - check-success=e2e (3.12, 1.75, pep517_build_sdist, ubuntu-latest)
+          - check-success=e2e (3.12, 1.75, post_bootstrap_hook, macos-latest)
+          - check-success=e2e (3.12, 1.75, post_bootstrap_hook, ubuntu-latest)
           - check-success=e2e (3.12, 1.75, prebuilt_wheel_hook, macos-latest)
           - check-success=e2e (3.12, 1.75, prebuilt_wheel_hook, ubuntu-latest)
           - check-success=e2e (3.12, 1.75, prebuilt_wheels_alt_server, macos-latest)
@@ -107,7 +111,6 @@ pull_request_rules:
           - check-success=e2e (3.12, 1.75, report_missing_dependency, ubuntu-latest)
           - check-success=e2e (3.12, 1.75, rust_vendor, macos-latest)
           - check-success=e2e (3.12, 1.75, rust_vendor, ubuntu-latest)
-          - "-draft"
 
           # At least 1 reviewer
           - "#approved-reviews-by>=1"

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -336,3 +336,40 @@ def prebuilt_wheel(
         f"{req.name}: running prebuilt wheel hook for {wheel_filename}"
     )
 ```
+
+### post_bootstrap
+
+The `post_bootstrap` hook runs after a package is bootstrapped, before its
+installation dependencies are bootstrapped. It can be used to perform validation
+checks for the sdist and wheel that results from the bootstrap operation.
+
+Configure a `post_bootstrap` hook in your `pyproject.toml` like this:
+
+```toml
+[project.entry-points."fromager.hooks"]
+post_bootstrap = "package_plugins.module:function"
+```
+
+The input arguments to the `post_bootstrap` hook are the `WorkContext`,
+`Requirement` being built, the distribution name and version, and the sdist and
+wheel filenames.
+
+NOTE: The files should not be renamed or moved.
+
+NOTE: The `sdist_filename` argument can be None if the wheel is pre-built and
+the `wheel_filename` argument can be None if bootstrapping is running in
+sdist-only mode.
+
+```python
+def post_bootstrap(
+    ctx: context.WorkContext,
+    req: Requirement,
+    dist_name: str,
+    dist_version: str,
+    sdist_filename: pathlib.Path | None,
+    wheel_filename: pathlib.Path | None,
+):
+    logger.info(
+        f"{req.name}: running post bootstrap hook for {sdist_filename} and {wheel_filename}"
+    )
+```

--- a/e2e/fromager_hooks/pyproject.toml
+++ b/e2e/fromager_hooks/pyproject.toml
@@ -4,9 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flit-core-overrides"
-authors = [
-    {name = "Doug Hellmann", email="dhellmann@redhat.com"},
-]
+authors = [{ name = "Doug Hellmann", email = "dhellmann@redhat.com" }]
 description = "test package"
 dynamic = ["version"]
 classifiers = [
@@ -31,3 +29,4 @@ dependencies = []
 [project.entry-points."fromager.hooks"]
 post_build = "package_plugins.hooks:after_build_wheel"
 prebuilt_wheel = "package_plugins.hooks:after_prebuilt_wheel"
+post_bootstrap = "package_plugins.hooks:after_bootstrap"

--- a/e2e/fromager_hooks/src/package_plugins/hooks.py
+++ b/e2e/fromager_hooks/src/package_plugins/hooks.py
@@ -24,6 +24,22 @@ def after_build_wheel(
     test_file.write_text(f"{dist_name}=={dist_version}")
 
 
+def after_bootstrap(
+    ctx: context.WorkContext,
+    req: Requirement,
+    dist_name: str,
+    dist_version: str,
+    sdist_filename: pathlib.Path | None,
+    wheel_filename: pathlib.Path | None,
+):
+    logger.info(
+        f"{req.name}: running post bootstrap hook in {__name__} for {sdist_filename} and {wheel_filename}"
+    )
+    test_file = ctx.work_dir / "test-output-file.txt"
+    logger.info(f"{req.name}: post-bootstrap hook writing to {test_file}")
+    test_file.write_text(f"{dist_name}=={dist_version}")
+
+
 def after_prebuilt_wheel(
     ctx: context.WorkContext,
     req: Requirement,
@@ -34,6 +50,6 @@ def after_prebuilt_wheel(
     logger.info(
         f"{req.name}: running post build hook in {__name__} for {wheel_filename}"
     )
-    test_file =  ctx.work_dir / "test-prebuilt.txt"
+    test_file = ctx.work_dir / "test-prebuilt.txt"
     logger.info(f"{req.name}: prebuilt-wheel hook writing to {test_file}")
     test_file.write_text(f"{dist_name}=={dist_version}")

--- a/e2e/test_post_bootstrap_hook.sh
+++ b/e2e/test_post_bootstrap_hook.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# -*- indent-tabs-mode: nil; tab-width: 2; sh-indentation: 2; -*-
+
+# Test post-bootstrap hook
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$SCRIPTDIR/common.sh"
+
+# What are we building?
+DIST="setuptools"
+VERSION="75.8.0"
+
+# Install hook for test
+pip install e2e/fromager_hooks
+
+# Bootstrap the project
+fromager \
+  --debug \
+    --sdists-repo="$OUTDIR/sdists-repo" \
+    --wheels-repo="$OUTDIR/wheels-repo" \
+    --work-dir="$OUTDIR/work-dir" \
+    --settings-dir="$SCRIPTDIR/prebuilt_settings" \
+    bootstrap "${DIST}==${VERSION}"
+
+
+
+EXPECTED_FILES="
+work-dir/test-output-file.txt
+"
+
+pass=true
+for f in $EXPECTED_FILES; do
+  if [ ! -f "$OUTDIR/$f" ]; then
+    echo "FAIL: Did not find $OUTDIR/$f" 1>&2
+    pass=false
+  fi
+done
+
+cat $OUTDIR/work-dir/test-output-file.txt
+
+if $pass; then
+  if ! grep -q "${DIST}==${VERSION}" $OUTDIR/work-dir/test-output-file.txt; then
+    echo "FAIL: Did not find content in post-bootstrap hook output file" 1>&2
+    pass=false
+  fi
+fi
+
+$pass

--- a/src/fromager/hooks.py
+++ b/src/fromager/hooks.py
@@ -61,6 +61,32 @@ def run_post_build_hooks(
         )
 
 
+def run_post_bootstrap_hooks(
+    ctx: context.WorkContext,
+    req: Requirement,
+    dist_name: str,
+    dist_version: str,
+    sdist_filename: pathlib.Path | None,
+    wheel_filename: pathlib.Path | None,
+) -> None:
+    hook_mgr = _get_hooks("post_bootstrap")
+    if hook_mgr.names():
+        logger.info(
+            f"{req.name}: starting post-bootstrap hooks for sdist {sdist_filename} and wheel {wheel_filename}"
+        )
+    for ext in hook_mgr:
+        # NOTE: Each hook is responsible for doing its own logging for
+        # start/stop because we don't have a good name to use here.
+        ext.plugin(
+            ctx=ctx,
+            req=req,
+            dist_name=dist_name,
+            dist_version=dist_version,
+            sdist_filename=sdist_filename,
+            wheel_filename=wheel_filename,
+        )
+
+
 def run_prebuilt_wheel_hooks(
     ctx: context.WorkContext,
     req: Requirement,


### PR DESCRIPTION
Add a hook entry point invocation for after we have bootstrapped a package. It is given the source distribution filename and the wheel filename, just like for the post-build hook, except that the sdist can be None if the wheel is pre-built and the wheel can be None if we are bootstrapping in sdist-only mode.