### PR TITLE
Add setting for Requires-External metadata

### DIFF
--- a/src/fromager/packagesettings.py
+++ b/src/fromager/packagesettings.py
@@ -207,6 +207,8 @@ class ProjectOverride(pydantic.BaseModel):
         - setuptools
       remove_build_requires:
         - ninja
+      requires_external:
+        - openssl-libs
     """
 
     model_config = MODEL_CONFIG
@@ -217,6 +219,19 @@ class ProjectOverride(pydantic.BaseModel):
 
     remove_build_requires: list[Package] = Field(default_factory=list)
     """Remove requirement from pyproject.toml `[build-system] requires`
+    """
+
+    requires_external: list[str] = Field(default_factory=list)
+    """Add / update Requires-External core metadata field
+
+    Each entry contains a string describing some dependency in the system
+    that the distribution is to be used. See
+    https://packaging.python.org/en/latest/specifications/core-metadata/#requires-external-multiple-use
+
+    .. note::
+       Fromager does not modify ``METADATA`` file, yet. Read the information
+       from an ``importlib.metadata`` distribution with
+       ``tomlkit.loads(dist(pkgname).read_text("fromager-build-settings"))``.
     """
 
     @pydantic.field_validator("update_build_requires")

--- a/tests/test_packagesettings.py
+++ b/tests/test_packagesettings.py
@@ -53,6 +53,7 @@ FULL_EXPECTED: dict[str, typing.Any] = {
     "project_override": {
         "remove_build_requires": ["cmake"],
         "update_build_requires": ["setuptools>=68.0.0", "torch"],
+        "requires_external": ["openssl-libs"],
     },
     "resolver_dist": {
         "include_sdists": True,
@@ -97,6 +98,7 @@ EMPTY_EXPECTED: dict[str, typing.Any] = {
     "project_override": {
         "remove_build_requires": [],
         "update_build_requires": [],
+        "requires_external": [],
     },
     "resolver_dist": {
         "sdist_server_url": None,

--- a/tests/testdata/context/overrides/settings/test_pkg.yaml
+++ b/tests/testdata/context/overrides/settings/test_pkg.yaml
@@ -26,6 +26,8 @@ project_override:
     update_build_requires:
         - setuptools>=68.0.0
         - torch
+    requires_external:
+        - openssl-libs
 resolver_dist:
     sdist_server_url: https://sdist.test/egg
     include_sdists: true


### PR DESCRIPTION
The new setting `project_override.requires_external` can be used to store dependencies on external packages. The main use case are cffi and ctypes bindings to shared libraries, e.g. `soundfile` depends on `libsndfile` system library.

The implementation does not modify `METADATA` file, yet. Fromager has no utilities to modify a `METADATA` file safely. Instead the information can be read from `fromager-build-settings` TOML file in the dist-info directory.

See: #494
See: https://packaging.python.org/en/latest/specifications/core-metadata/#requires-external-multiple-use