### PR TITLE
remove debug messages about arguments accepted by plugins

### DIFF
--- a/src/fromager/overrides.py
+++ b/src/fromager/overrides.py
@@ -67,7 +67,6 @@ def invoke(fn: typing.Callable, **kwargs: typing.Any) -> typing.Any:
                 f"{fn.__module__}.{fn.__name__} override does not take argument {arg_name}"
             )
             kwargs.pop(arg_name)
-        logger.debug(f"{fn.__name__} takes argument: {arg_name}")
     return fn(**kwargs)
 
 


### PR DESCRIPTION
We currently log when a plugin _does_ accept an argument. That information was useful in the past to debug the invocation code, but it is no longer needed and it makes the debug logs more verbose than necessary.