### PR TITLE
only delete build-env if it exists

### DIFF
--- a/src/fromager/bootstrapper.py
+++ b/src/fromager/bootstrapper.py
@@ -619,7 +619,7 @@ class Bootstrapper:
             logger.debug(f"{req.name}: cleaning up source tree {sdist_root_dir}")
             shutil.rmtree(sdist_root_dir)
             logger.debug(f"{req.name}: cleaned up source tree {sdist_root_dir}")
-        if build_env:
+        if build_env and build_env.path.exists():
             logger.debug(f"{req.name}: cleaning up build environment {build_env.path}")
             shutil.rmtree(build_env.path)
             logger.debug(f"{req.name}: cleaned up build environment {build_env.path}")


### PR DESCRIPTION
There are cases where we rebuild dependencies during bootstrap, so we need to ensure the cleanup code is robust in the face of repeats. This change ensures that we do not try to delete the build environment directory if we think we have one, but it has already been cleaned up.