### PR TITLE
fix: handle undefined variable in substitute_template

### DIFF
--- a/tests/test_packagesettings.py
+++ b/tests/test_packagesettings.py
@@ -468,3 +468,14 @@ def test_parallel_jobs(
 )
 def test_substitute_template(value: str, template_env: dict[str, str], expected: str):
     assert substitute_template(value, template_env) == expected
+
+
+def test_substitute_template_key_error():
+    # This test expects a ValueError to be raised by substitute_template
+    with pytest.raises(ValueError) as excinfo:
+        substitute_template("${DEFAULT:-default} ${UNKNOWN}", {})
+    # Verify that the error message matches the expected message
+    assert (
+        str(excinfo.value)
+        == "Undefined environment variable KeyError('UNKNOWN') referenced in expression '${DEFAULT} ${UNKNOWN}'"
+    )


### PR DESCRIPTION
Summary
This PR addresses incorrect behavior in the substitute_template function where missing variables without defaults were silently replaced with None, instead of raising a KeyError as expected.
Fixes: https://github.com/python-wheel-build/fromager/issues/553

Changes :
Fixed src/fromager/packagesettings.py:substitute_template logic to:

Only apply default values when explicitly specified using the :-default syntax.

Leave variables without defaults unresolved, allowing string.Template.substitute to raise a KeyError for unknown variables.

Added a test case to ensure a KeyError is raised when ${UNKNOWN} is used without a default and the variable is not in template_env.
 Tests:
Added tests/test_packagesettings.py::test_substitute_template_key_error() to validate the raised exception behavior.

Ensured all existing parameterized tests still pass.
![Screenshot From 2025-04-17 16-56-51](https://github.com/user-attachments/assets/28bd8fd9-7a48-4c8a-9b75-c2c48e0c7d0e)

![Screenshot From 2025-04-17 16-57-23](https://github.com/user-attachments/assets/b9feb07e-95ea-4014-bf54-57575b26c45e)

