### PR TITLE
fix: log requirement name in more places

### DIFF
--- a/src/fromager/commands/step.py
+++ b/src/fromager/commands/step.py
@@ -115,7 +115,9 @@ def build_sdist(
     """
     req = Requirement(f"{dist_name}=={dist_version}")
     source_root_dir = _find_source_root_dir(wkctx, wkctx.work_dir, req, dist_version)
-    build_env = build_environment.BuildEnvironment(wkctx, source_root_dir.parent, None)
+    build_env = build_environment.BuildEnvironment(
+        ctx=wkctx, parent_dir=source_root_dir.parent, build_requirements=None, req=req
+    )
     sdist_filename = sources.build_sdist(
         ctx=wkctx,
         req=req,
@@ -200,7 +202,9 @@ def build_wheel(
     req = Requirement(f"{dist_name}=={dist_version}")
     source_root_dir = _find_source_root_dir(wkctx, wkctx.work_dir, req, dist_version)
     server.start_wheel_server(wkctx)
-    build_env = build_environment.BuildEnvironment(wkctx, source_root_dir.parent, None)
+    build_env = build_environment.BuildEnvironment(
+        ctx=wkctx, parent_dir=source_root_dir.parent, build_requirements=None, req=req
+    )
     wheel_filename = wheels.build_wheel(
         ctx=wkctx,
         req=req,

--- a/tests/test_packagesettings.py
+++ b/tests/test_packagesettings.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 
 import pydantic
 import pytest
+from packaging.requirements import Requirement
 from packaging.utils import NormalizedName
 from packaging.version import Version
 
@@ -203,7 +204,10 @@ def test_pbi_test_pkg_extra_environ(
     )
 
     build_env = build_environment.BuildEnvironment(
-        testdata_context, parent_dir=tmp_path, build_requirements=None
+        testdata_context,
+        parent_dir=tmp_path,
+        build_requirements=None,
+        req=Requirement("test_pkg"),
     )
     result = pbi.get_extra_environ(
         template_env={"EXTRA": "spam", "PATH": "/sbin:/bin"}, build_env=build_env

--- a/tests/test_wheels.py
+++ b/tests/test_wheels.py
@@ -27,8 +27,10 @@ def test_invalid_wheel_file_exception(
 def test_default_build_wheel(
     mock_run: Mock, tmp_path: pathlib.Path, testdata_context: context.WorkContext
 ) -> None:
-    build_env = build_environment.BuildEnvironment(testdata_context, tmp_path, None)
     req = Requirement("test_pkg")
+    build_env = build_environment.BuildEnvironment(
+        ctx=testdata_context, parent_dir=tmp_path, build_requirements=None, req=req
+    )
     pbi = testdata_context.package_build_info(req)
     assert pbi.config_settings
 


### PR DESCRIPTION
Several place did not log the requirement name. Now virtual env and build dependency lines also log the name of the requirement.