### PR TITLE
Log requirement name for download and patching

### DIFF
--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -371,7 +371,7 @@ def download_wheel(
     wheel_filename = output_directory / os.path.basename(urlparse(wheel_url).path)
     if not wheel_filename.exists():
         logger.info(f"{req.name}: downloading pre-built wheel {wheel_url}")
-        wheel_filename = _download_wheel_check(output_directory, wheel_url)
+        wheel_filename = _download_wheel_check(req, output_directory, wheel_url)
         logger.info(f"{req.name}: saved wheel to {wheel_filename}")
     else:
         logger.info(f"{req.name}: have existing wheel {wheel_filename}")
@@ -379,8 +379,14 @@ def download_wheel(
     return wheel_filename
 
 
-def _download_wheel_check(destination_dir, wheel_url):
-    wheel_filename = sources.download_url(destination_dir, wheel_url)
+def _download_wheel_check(
+    req: Requirement, destination_dir: pathlib.Path, wheel_url: str
+) -> pathlib.Path:
+    wheel_filename = sources.download_url(
+        req=req,
+        destination_dir=destination_dir,
+        url=wheel_url,
+    )
     # validates whether the wheel is correct or not. will raise an error in the wheel is invalid
     wheel.wheelfile.WheelFile(wheel_filename)
     return wheel_filename

--- a/tests/test_wheels.py
+++ b/tests/test_wheels.py
@@ -19,8 +19,9 @@ def test_invalid_wheel_file_exception(
     fake_dir.mkdir()
     text_file = fake_dir / "fake_wheel.txt"
     text_file.write_text("This is a test file")
+    req = Requirement("test_pkg")
     with pytest.raises(wheel.cli.WheelError):
-        wheels._download_wheel_check(fake_dir, fake_url)
+        wheels._download_wheel_check(req, fake_dir, fake_url)
 
 
 @patch("fromager.build_environment.BuildEnvironment.run")


### PR DESCRIPTION
Source download, wheel download, and patching did not prefix the log message with the requirement name.