### PR TITLE
Implement requirement logging adapter

### DIFF
--- a/e2e/fromager_hooks/src/package_plugins/hooks.py
+++ b/e2e/fromager_hooks/src/package_plugins/hooks.py
@@ -17,10 +17,10 @@ def after_build_wheel(
     wheel_filename: pathlib.Path,
 ):
     logger.info(
-        f"{req.name}: running post build hook in {__name__} for {sdist_filename} and {wheel_filename}"
+        f"running post build hook in {__name__} for {sdist_filename} and {wheel_filename}"
     )
     test_file = sdist_filename.parent / "test-output-file.txt"
-    logger.info(f"{req.name}: post-build hook writing to {test_file}")
+    logger.info(f"post-build hook writing to {test_file}")
     test_file.write_text(f"{dist_name}=={dist_version}")
 
 
@@ -33,10 +33,10 @@ def after_bootstrap(
     wheel_filename: pathlib.Path | None,
 ):
     logger.info(
-        f"{req.name}: running post bootstrap hook in {__name__} for {sdist_filename} and {wheel_filename}"
+        f"running post bootstrap hook in {__name__} for {sdist_filename} and {wheel_filename}"
     )
     test_file = ctx.work_dir / "test-output-file.txt"
-    logger.info(f"{req.name}: post-bootstrap hook writing to {test_file}")
+    logger.info(f"post-bootstrap hook writing to {test_file}")
     test_file.write_text(f"{dist_name}=={dist_version}")
 
 
@@ -48,8 +48,8 @@ def after_prebuilt_wheel(
     wheel_filename: pathlib.Path,
 ):
     logger.info(
-        f"{req.name}: running post build hook in {__name__} for {wheel_filename}"
+        f"running post build hook in {__name__} for {wheel_filename}"
     )
     test_file = ctx.work_dir / "test-prebuilt.txt"
-    logger.info(f"{req.name}: prebuilt-wheel hook writing to {test_file}")
+    logger.info(f"prebuilt-wheel hook writing to {test_file}")
     test_file.write_text(f"{dist_name}=={dist_version}")

--- a/src/fromager/__main__.py
+++ b/src/fromager/__main__.py
@@ -14,8 +14,9 @@ from . import (
     overrides,
     packagesettings,
 )
+from .log import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 TERSE_LOG_FMT = "%(message)s"
 VERBOSE_LOG_FMT = "%(levelname)s:%(name)s:%(lineno)d: %(message)s"

--- a/src/fromager/bootstrapper.py
+++ b/src/fromager/bootstrapper.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import operator
 import pathlib
 import shutil
@@ -25,12 +24,13 @@ from . import (
     wheels,
 )
 from .dependency_graph import DependencyGraph
+from .log import get_logger, requirement_ctxvar
 from .requirements_file import RequirementType, SourceType
 
 if typing.TYPE_CHECKING:
     from . import context
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # package name, extras, version, sdist/wheel
 SeenKey = tuple[NormalizedName, tuple[str, ...], str, typing.Literal["sdist", "wheel"]]
@@ -70,7 +70,7 @@ class Bootstrapper:
         constraint = self.ctx.constraints.get_constraint(req.name)
         if constraint:
             logger.info(
-                f"{req.name}: incoming requirement {req} matches constraint {constraint}. Will apply both."
+                f"incoming requirement {req} matches constraint {constraint}. Will apply both."
             )
 
         pbi = self.ctx.package_build_info(req)
@@ -98,15 +98,13 @@ class Bootstrapper:
         # Avoid cyclic dependencies and redundant processing.
         if self._has_been_seen(req, resolved_version, build_sdist_only):
             logger.debug(
-                f"{req.name}: redundant {req_type} dependency {req} "
+                f"redundant {req_type} dependency {req} "
                 f"({resolved_version}, sdist_only={build_sdist_only}) for {self._explain}"
             )
             return resolved_version
         self._mark_as_seen(req, resolved_version, build_sdist_only)
 
-        logger.info(
-            f"{req.name}: new {req_type} dependency {req} resolves to {resolved_version}"
-        )
+        logger.info(f"new {req_type} dependency {req} resolves to {resolved_version}")
 
         # Build the dependency chain up to the point of this new
         # requirement using a new list so we can avoid modifying the list
@@ -160,7 +158,7 @@ class Bootstrapper:
 
             if cached_wheel_filename:
                 logger.debug(
-                    f"{req.name}: getting install requirements from cached "
+                    f"getting install requirements from cached "
                     f"wheel {cached_wheel_filename.name}"
                 )
                 # prefer existing wheel even in sdist_only mode
@@ -170,7 +168,7 @@ class Bootstrapper:
             elif build_sdist_only:
                 # get install dependencies from sdist and pyproject_hooks (only top-level and install)
                 logger.debug(
-                    f"{req.name}: getting install requirements from sdist "
+                    f"getting install requirements from sdist "
                     f"{req.name}=={resolved_version} ({req_type})"
                 )
                 wheel_filename = None
@@ -180,7 +178,7 @@ class Bootstrapper:
             else:
                 # build wheel (build requirements, full build mode)
                 logger.debug(
-                    f"{req.name}: building wheel {req.name}=={resolved_version} "
+                    f"building wheel {req.name}=={resolved_version} "
                     f"to get install requirements ({req_type})"
                 )
                 wheel_filename, sdist_filename, build_env = self._build_wheel(
@@ -287,7 +285,7 @@ class Bootstrapper:
                     f"{req.name} have sdist version {resolved_version}: {find_sdist_result}"
                 )
         except Exception as err:
-            logger.warning(f"{req.name}: failed to build source distribution: {err}")
+            logger.warning(f"failed to build source distribution: {err}")
         return (sdist_filename, build_env)
 
     def _build_wheel(
@@ -301,7 +299,7 @@ class Bootstrapper:
             req, resolved_version, sdist_root_dir, build_dependencies
         )
 
-        logger.info(f"{req.name}: starting build of {self._explain}")
+        logger.info(f"starting build of {self._explain}")
         built_filename = wheels.build_wheel(
             ctx=self.ctx,
             req=req,
@@ -313,9 +311,7 @@ class Bootstrapper:
         # When we update the mirror, the built file moves to the
         # downloads directory.
         wheel_filename = self.ctx.wheels_downloads / built_filename.name
-        logger.info(
-            f"{req.name}: built wheel for version {resolved_version}: {wheel_filename}"
-        )
+        logger.info(f"built wheel for version {resolved_version}: {wheel_filename}")
         return wheel_filename, sdist_filename, build_env
 
     def _prepare_build_dependencies(
@@ -363,9 +359,11 @@ class Bootstrapper:
         self.progressbar.update_total(len(build_dependencies))
 
         for dep in self._sort_requirements(build_dependencies):
+            token = requirement_ctxvar.set(dep)
             try:
                 resolved = self.bootstrap(req=dep, req_type=build_type)
             except Exception as err:
+                requirement_ctxvar.reset(token)
                 raise ValueError(f"could not handle {self._explain}") from err
             # We may need these dependencies installed in order to run build hooks
             # Example: frozenlist build-system.requires includes expandvars because
@@ -378,6 +376,7 @@ class Bootstrapper:
                 dep_req_type=build_type,
             )
             self.progressbar.update()
+            requirement_ctxvar.reset(token)
 
     def _download_prebuilt(
         self,
@@ -386,7 +385,7 @@ class Bootstrapper:
         resolved_version: Version,
         wheel_url: str,
     ) -> tuple[pathlib.Path, pathlib.Path]:
-        logger.info(f"{req.name}: {req_type} requirement {req} uses a pre-built wheel")
+        logger.info(f"{req_type} requirement {req} uses a pre-built wheel")
 
         wheel_filename = wheels.download_wheel(req, wheel_url, self.ctx.wheels_prebuilt)
 
@@ -397,7 +396,7 @@ class Bootstrapper:
         # index.
         dest_name = self.ctx.wheels_downloads / wheel_filename.name
         if not dest_name.exists():
-            logger.info(f"{req.name}: updating temporary mirror with pre-built wheel")
+            logger.info("updating temporary mirror with pre-built wheel")
             shutil.copy(wheel_filename, dest_name)
             server.update_wheel_mirror(self.ctx)
         unpack_dir = self._create_unpack_dir(req, resolved_version)
@@ -409,7 +408,7 @@ class Bootstrapper:
         if not self.cache_wheel_server_url:
             return None, None
         logger.info(
-            f"{req.name}: checking if wheel was already uploaded to {self.cache_wheel_server_url}"
+            f"checking if wheel was already uploaded to {self.cache_wheel_server_url}"
         )
         try:
             wheel_url, _ = resolver.resolve(
@@ -423,7 +422,7 @@ class Bootstrapper:
             pbi = self.ctx.package_build_info(req)
             expected_build_tag = pbi.build_tag(resolved_version)
             # Log the expected build tag for debugging
-            logger.info(f"{req.name}: has expected build tag {expected_build_tag}")
+            logger.info(f"has expected build tag {expected_build_tag}")
             # Get changelogs for debug info
             changelogs = pbi.get_changelog(resolved_version)
             logger.debug(f"{req.name} has change logs {changelogs}")
@@ -433,7 +432,7 @@ class Bootstrapper:
             )
             if expected_build_tag and expected_build_tag != build_tag:
                 logger.info(
-                    f"{req.name}: found wheel for {resolved_version} in cache but build tag does not match. Got {build_tag} but expected {expected_build_tag}"
+                    f"found wheel for {resolved_version} in cache but build tag does not match. Got {build_tag} but expected {expected_build_tag}"
                 )
                 return None, None
 
@@ -444,7 +443,7 @@ class Bootstrapper:
                 # Only update the local server if we actually downloaded
                 # something from a different server.
                 server.update_wheel_mirror(self.ctx)
-            logger.info(f"{req.name}: found built wheel on cache server")
+            logger.info("found built wheel on cache server")
             unpack_dir = self._create_unpack_dir(req, resolved_version)
             dist_filename = f"{dist_name}-{dist_version}"
             metadata_dir = pathlib.Path(f"{dist_filename}.dist-info")
@@ -464,18 +463,16 @@ class Bootstrapper:
                     zipinfo.filename = filename
                     archive.extract(zipinfo, unpack_dir)
 
-                logger.info(f"{req.name}: extracted build requirements from wheel")
+                logger.info("extracted build requirements from wheel")
                 return unpack_dir / metadata_dir, cached_wheel
             except Exception:
                 # implies that the wheel server hosted non-fromager built wheels
-                logger.info(
-                    f"{req.name}: could not extract build requirements from wheel"
-                )
+                logger.info("could not extract build requirements from wheel")
                 shutil.rmtree(unpack_dir)
                 return None, cached_wheel
         except Exception:
             logger.info(
-                f"{req.name}: did not find wheel for {resolved_version} in {self.cache_wheel_server_url}"
+                f"did not find wheel for {resolved_version} in {self.cache_wheel_server_url}"
             )
             return None, None
 
@@ -491,9 +488,7 @@ class Bootstrapper:
         )
         if cached_resolution:
             source_url, resolved_version = cached_resolution
-            logger.debug(
-                f"{req.name}: resolved from previous bootstrap to {resolved_version}"
-            )
+            logger.debug(f"resolved from previous bootstrap to {resolved_version}")
         else:
             source_url, resolved_version = sources.resolve_source(
                 ctx=self.ctx,
@@ -516,9 +511,7 @@ class Bootstrapper:
 
         if cached_resolution:
             wheel_url, resolved_version = cached_resolution
-            logger.debug(
-                f"{req.name}: resolved from previous bootstrap to {resolved_version}"
-            )
+            logger.debug(f"resolved from previous bootstrap to {resolved_version}")
         else:
             servers = wheels.get_wheel_server_urls(self.ctx, req)
             wheel_url, resolved_version = wheels.resolve_prebuilt_wheel(
@@ -548,7 +541,7 @@ class Bootstrapper:
             # this should never happen since we already resolved top level reqs and their
             # resolution should be in the root nodes
             raise ValueError(
-                f"{req.name}: {req} appears as a toplevel requirement but it's resolution does not exist in the root node of the graph"
+                f"{req} appears as a toplevel requirement but it's resolution does not exist in the root node of the graph"
             )
 
         if not self.prev_graph:
@@ -618,9 +611,7 @@ class Bootstrapper:
             )
             return resolver.resolve_from_provider(provider, req)
         except Exception as err:
-            logger.debug(
-                f"{req.name}: could not resolve {req} from {version_source}: {err}"
-            )
+            logger.debug(f"could not resolve {req} from {version_source}: {err}")
             return None
 
     def _create_unpack_dir(self, req: Requirement, resolved_version: Version):
@@ -641,13 +632,13 @@ class Bootstrapper:
         # Cleanup the source tree and build environment, leaving any other
         # artifacts that were created.
         if sdist_root_dir and sdist_root_dir.exists():
-            logger.debug(f"{req.name}: cleaning up source tree {sdist_root_dir}")
+            logger.debug(f"cleaning up source tree {sdist_root_dir}")
             shutil.rmtree(sdist_root_dir)
-            logger.debug(f"{req.name}: cleaned up source tree {sdist_root_dir}")
+            logger.debug(f"cleaned up source tree {sdist_root_dir}")
         if build_env and build_env.path.exists():
-            logger.debug(f"{req.name}: cleaning up build environment {build_env.path}")
+            logger.debug(f"cleaning up build environment {build_env.path}")
             shutil.rmtree(build_env.path)
-            logger.debug(f"{req.name}: cleaned up build environment {build_env.path}")
+            logger.debug(f"cleaned up build environment {build_env.path}")
 
     def _add_to_graph(
         self,
@@ -736,7 +727,7 @@ class Bootstrapper:
         key = (canonicalize_name(req.name), str(version))
         if key in self._build_requirements:
             return
-        logger.info(f"{req.name}: adding {key} to build order")
+        logger.info(f"adding {key} to build order")
         self._build_requirements.add(key)
         info = {
             "req": str(req),

--- a/src/fromager/build_environment.py
+++ b/src/fromager/build_environment.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import importlib.metadata
-import logging
 import os
 import pathlib
 import platform
@@ -19,7 +18,9 @@ from .requirements_file import RequirementType
 if typing.TYPE_CHECKING:
     from . import context
 
-logger = logging.getLogger(__name__)
+from .log import get_logger
+
+logger = get_logger(__name__)
 
 # Pip has no API, so parse its output looking for what it couldn't install.
 # Verbose regular expressions ignore blank spaces, so we have to escape those to
@@ -159,12 +160,10 @@ class BuildEnvironment:
 
     def _createenv(self) -> None:
         if self.path.exists():
-            logger.info(
-                "%s: reusing build environment in %s", self._req.name, self.path
-            )
+            logger.info("reusing build environment in %s", self.path)
             return
 
-        logger.debug("%s: creating build environment in %s", self._req.name, self.path)
+        logger.debug("creating build environment in %s", self.path)
         # Python 3.12 virtual envs don't have wheel and setuptools by
         # default. Some packages still assume they are installed.
         external_commands.run(
@@ -183,7 +182,7 @@ class BuildEnvironment:
             ],
             network_isolation=self._ctx.network_isolation,
         )
-        logger.info("%s: created build environment in %s", self._req.name, self.path)
+        logger.info("created build environment in %s", self.path)
 
         req_filename = self.path / "requirements.txt"
         # FIXME: Ensure each requirement is pinned to a specific version.
@@ -213,8 +212,7 @@ class BuildEnvironment:
             network_isolation=False,
         )
         logger.info(
-            "%s: installed dependencies into build environment in %s",
-            self._req.name,
+            "installed dependencies into build environment in %s",
             self.path,
         )
 
@@ -226,7 +224,7 @@ def prepare_build_environment(
     req: Requirement,
     sdist_root_dir: pathlib.Path,
 ) -> BuildEnvironment:
-    logger.info(f"{req.name}: preparing build environment")
+    logger.info("preparing build environment")
 
     next_req_type = RequirementType.BUILD_SYSTEM
     build_system_dependencies = dependencies.get_build_system_dependencies(
@@ -244,9 +242,7 @@ def prepare_build_environment(
                 ctx=ctx, req=req, dep=dep, dep_version=None, dep_req_type=next_req_type
             )
         except Exception as err:
-            logger.error(
-                f"{req.name}: failed to install {next_req_type} dependency {dep}: {err}"
-            )
+            logger.error(f"failed to install {next_req_type} dependency {dep}: {err}")
             raise MissingDependency(
                 ctx,
                 next_req_type,
@@ -270,9 +266,7 @@ def prepare_build_environment(
                 ctx=ctx, req=req, dep=dep, dep_version=None, dep_req_type=next_req_type
             )
         except Exception as err:
-            logger.error(
-                f"{req.name}: failed to install {next_req_type} dependency {dep}: {err}"
-            )
+            logger.error(f"failed to install {next_req_type} dependency {dep}: {err}")
             raise MissingDependency(
                 ctx,
                 next_req_type,
@@ -293,9 +287,7 @@ def prepare_build_environment(
                 ctx=ctx, req=req, dep=dep, dep_version=None, dep_req_type=next_req_type
             )
         except Exception as err:
-            logger.error(
-                f"{req.name}: failed to install {next_req_type} dependency {dep}: {err}"
-            )
+            logger.error(f"failed to install {next_req_type} dependency {dep}: {err}")
             raise MissingDependency(
                 ctx,
                 next_req_type,
@@ -318,7 +310,7 @@ def prepare_build_environment(
         # Pip has no API, so parse its output looking for what it
         # couldn't install. If we don't find something, just re-raise
         # the exception we already have.
-        logger.error(f"{req.name}: failed to create build environment for {dep}: {err}")
+        logger.error(f"failed to create build environment for {dep}: {err}")
         logger.info(f"looking for pattern in {err.output!r}")
         match = _pip_missing_dependency_pattern.search(err.output)
         if match:
@@ -346,12 +338,10 @@ def maybe_install(
         try:
             actual_version = importlib.metadata.version(dep.name)
             if str(dep_version) == actual_version:
-                logger.debug(
-                    f"{req.name}: already have {dep.name} version {dep_version} installed"
-                )
+                logger.debug(f"already have {dep.name} version {dep_version} installed")
                 return
             logger.info(
-                f"{req.name}: found {dep.name} {actual_version} installed, updating to {dep_version}"
+                f"found {dep.name} {actual_version} installed, updating to {dep_version}"
             )
             _safe_install(
                 ctx, req, Requirement(f"{dep.name}=={dep_version}"), dep_req_type
@@ -370,7 +360,7 @@ def _safe_install(
     dep: Requirement,
     dep_req_type: RequirementType,
 ):
-    logger.debug("%s: installing %s %s", req.name, dep_req_type, dep)
+    logger.debug("installing %s %s", dep_req_type, dep)
     external_commands.run(
         [
             sys.executable,
@@ -390,4 +380,4 @@ def _safe_install(
         ],
         network_isolation=False,
     )
-    logger.info("%s: installed %s requirement %s", req.name, dep_req_type, dep)
+    logger.info("installed %s requirement %s", dep_req_type, dep)

--- a/src/fromager/commands/bootstrap.py
+++ b/src/fromager/commands/bootstrap.py
@@ -1,4 +1,3 @@
-import logging
 import typing
 
 import click
@@ -18,13 +17,15 @@ from .. import (
     sources,
     wheels,
 )
+from ..log import get_logger, requirement_ctxvar
 from ..requirements_file import RequirementType
 from .graph import find_why
 
 # Map child_name==child_version to list of (parent_name==parent_version, Requirement)
 ReverseRequirements = dict[str, list[tuple[str, Requirement]]]
 
-logger = logging.getLogger(__name__)
+
+logger = get_logger(__name__)
 
 
 def _get_requirements_from_args(
@@ -47,7 +48,7 @@ def _get_requirements_from_args(
         # their parent, so they include values like the parent's extras settings.
         if not requirements_file.evaluate_marker(req, req):
             logger.info(
-                f"{req.name}: ignoring {requirements_file.RequirementType.TOP_LEVEL} dependency {req} because of its marker expression"
+                f"ignoring {requirements_file.RequirementType.TOP_LEVEL} dependency {req} because of its marker expression"
             )
         else:
             to_build.append(req)
@@ -135,6 +136,7 @@ def bootstrap(
     # in the toplevel without having to fall back to history
     logger.info("resolving top-level dependencies before building")
     for req in to_build:
+        token = requirement_ctxvar.set(req)
         pbi = wkctx.package_build_info(req)
         if pbi.pre_built:
             servers = wheels.get_wheel_server_urls(wkctx, req)
@@ -160,6 +162,7 @@ def bootstrap(
             download_url=source_url,
             pre_built=pbi.pre_built,
         )
+        requirement_ctxvar.reset(token)
 
     with progress.progress_context(total=len(to_build)) as progressbar:
         bt = bootstrapper.Bootstrapper(
@@ -171,8 +174,10 @@ def bootstrap(
         )
 
         for req in to_build:
+            token = requirement_ctxvar.set(req)
             bt.bootstrap(req, requirements_file.RequirementType.TOP_LEVEL)
             progressbar.update()
+            requirement_ctxvar.reset(token)
 
     # If we put pre-built wheels in the downloads directory, we should
     # remove them so we can treat that directory as a source of wheels

--- a/src/fromager/commands/build.py
+++ b/src/fromager/commands/build.py
@@ -31,7 +31,9 @@ from fromager import (
     wheels,
 )
 
-logger = logging.getLogger(__name__)
+from ..log import get_logger, requirement_ctxvar
+
+logger = get_logger(__name__)
 
 
 @dataclasses.dataclass()
@@ -99,12 +101,14 @@ def build(
     wkctx.wheel_server_url = wheel_server_url
     server.start_wheel_server(wkctx)
     req = Requirement(f"{dist_name}=={dist_version}")
+    token = requirement_ctxvar.set(req)
     source_url, version = sources.resolve_source(
         ctx=wkctx,
         req=req,
         sdist_server_url=sdist_server_url,
     )
     wheel_filename = _build(wkctx, version, req, source_url)
+    requirement_ctxvar.reset(token)
     print(wheel_filename)
 
 
@@ -167,6 +171,7 @@ def build_sequence(
             source_download_url = entry["source_url"]
 
             req = Requirement(f"{dist_name}=={resolved_version}")
+            token = requirement_ctxvar.set(req)
 
             if not force:
                 is_built, wheel_filename = _is_wheel_built(
@@ -232,6 +237,7 @@ def build_sequence(
                 )
             )
             print(wheel_filename)
+            requirement_ctxvar.reset(token)
     metrics.summarize(wkctx, "Building")
 
     _summary(wkctx, entries)
@@ -419,7 +425,7 @@ def _is_wheel_built(
     req = Requirement(f"{dist_name}=={resolved_version}")
 
     try:
-        logger.info(f"{req.name}: checking if {req} was already built")
+        logger.info(f"checking if {req} was already built")
         url, _ = wheels.resolve_prebuilt_wheel(
             ctx=wkctx,
             req=req,
@@ -446,5 +452,5 @@ def _is_wheel_built(
 
         return is_built, pathlib.Path(wheel_filename)
     except Exception:
-        logger.info(f"{req.name}: could not locate prebuilt wheel. Will build {req}")
+        logger.info(f"could not locate prebuilt wheel. Will build {req}")
         return False, None

--- a/src/fromager/commands/download_sequence.py
+++ b/src/fromager/commands/download_sequence.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 import typing
 from concurrent import futures
@@ -9,8 +8,9 @@ from packaging.requirements import Requirement
 from packaging.version import Version
 
 from .. import context, progress, read, sources, wheels
+from ..log import get_logger, requirement_ctxvar
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @click.command()
@@ -62,6 +62,7 @@ def download_sequence(
 
     def download_one(entry: dict[str, typing.Any]):
         req = Requirement(f"{entry['dist']}=={entry['version']}")
+        token = requirement_ctxvar.set(req)
 
         if entry["prebuilt"]:
             if include_wheels:
@@ -99,6 +100,7 @@ def download_sequence(
                 )
             except Exception as err:
                 logger.error(f"failed to download wheel for {req}: {err}")
+        requirement_ctxvar.reset(token)
 
     num_items = len(build_order)
     logger.debug(

--- a/src/fromager/commands/graph.py
+++ b/src/fromager/commands/graph.py
@@ -1,6 +1,5 @@
 import itertools
 import json
-import logging
 import pathlib
 import sys
 import typing
@@ -19,7 +18,9 @@ from fromager.dependency_graph import (
 )
 from fromager.requirements_file import RequirementType
 
-logger = logging.getLogger(__name__)
+from ..log import get_logger
+
+logger = get_logger(__name__)
 
 
 @click.group()

--- a/src/fromager/commands/lint.py
+++ b/src/fromager/commands/lint.py
@@ -1,10 +1,9 @@
-import logging
-
 import click
 
 from .. import context, overrides
+from ..log import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @click.command()

--- a/src/fromager/commands/lint_requirements.py
+++ b/src/fromager/commands/lint_requirements.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 
 import click
@@ -6,7 +5,9 @@ from packaging.requirements import InvalidRequirement, Requirement
 
 from fromager import requirements_file
 
-logger = logging.getLogger(__name__)
+from ..log import get_logger
+
+logger = get_logger(__name__)
 
 
 @click.command()

--- a/src/fromager/commands/migrate_config.py
+++ b/src/fromager/commands/migrate_config.py
@@ -1,4 +1,3 @@
-import logging
 import pathlib
 import typing
 
@@ -8,7 +7,9 @@ from packaging.utils import NormalizedName, canonicalize_name
 
 from fromager import clickext, context, overrides, packagesettings
 
-logger = logging.getLogger(__name__)
+from ..log import get_logger
+
+logger = get_logger(__name__)
 
 PkgEnv = dict[NormalizedName, packagesettings.EnvVars]
 VariantPkgEnv = dict[

--- a/src/fromager/constraints.py
+++ b/src/fromager/constraints.py
@@ -1,4 +1,3 @@
-import logging
 import pathlib
 import typing
 
@@ -7,8 +6,9 @@ from packaging.utils import NormalizedName, canonicalize_name
 from packaging.version import Version
 
 from . import requirements_file
+from .log import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class Constraints:

--- a/src/fromager/context.py
+++ b/src/fromager/context.py
@@ -1,5 +1,4 @@
 import collections
-import logging
 import os
 import pathlib
 from urllib.parse import urlparse
@@ -9,8 +8,9 @@ from packaging.utils import NormalizedName, canonicalize_name
 from packaging.version import Version
 
 from . import constraints, dependency_graph, packagesettings, request_session
+from .log import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Map package names to (requirement type, dependency name, version)
 BuildRequirements = dict[str, list[tuple[str, NormalizedName, Version, Requirement]]]

--- a/src/fromager/dependencies.py
+++ b/src/fromager/dependencies.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import copy
-import logging
 import os
 import pathlib
 import tempfile
@@ -18,7 +17,9 @@ from . import build_environment, external_commands, overrides, requirements_file
 if typing.TYPE_CHECKING:
     from . import context
 
-logger = logging.getLogger(__name__)
+from .log import get_logger
+
+logger = get_logger(__name__)
 
 BUILD_SYSTEM_REQ_FILE_NAME = "build-system-requirements.txt"
 BUILD_BACKEND_REQ_FILE_NAME = "build-backend-requirements.txt"
@@ -31,15 +32,13 @@ def get_build_system_dependencies(
     req: Requirement,
     sdist_root_dir: pathlib.Path,
 ) -> set[Requirement]:
-    logger.info(
-        f"{req.name}: getting build system dependencies for {req} in {sdist_root_dir}"
-    )
+    logger.info(f"getting build system dependencies for {req} in {sdist_root_dir}")
     pbi = ctx.package_build_info(req)
 
     build_system_req_file = sdist_root_dir.parent / BUILD_SYSTEM_REQ_FILE_NAME
     if build_system_req_file.exists():
         logger.info(
-            f"{req.name}: loading build system dependencies from {build_system_req_file.name}"
+            f"loading build system dependencies from {build_system_req_file.name}"
         )
         return _read_requirements_file(build_system_req_file)
 
@@ -73,7 +72,7 @@ def _filter_requirements(
             requires.add(r)
         else:
             logger.debug(
-                f"{req.name}: evaluated {r} in the context of {req} and ignored because the environment marker does not match"
+                f"evaluated {r} in the context of {req} and ignored because the environment marker does not match"
             )
     return requires
 
@@ -98,15 +97,13 @@ def get_build_backend_dependencies(
     req: Requirement,
     sdist_root_dir: pathlib.Path,
 ) -> set[Requirement]:
-    logger.info(
-        f"{req.name}: getting build backend dependencies for {req} in {sdist_root_dir}"
-    )
+    logger.info(f"getting build backend dependencies for {req} in {sdist_root_dir}")
     pbi = ctx.package_build_info(req)
 
     build_backend_req_file = sdist_root_dir.parent / BUILD_BACKEND_REQ_FILE_NAME
     if build_backend_req_file.exists():
         logger.info(
-            f"{req.name}: loading build backend dependencies from {build_backend_req_file.name}"
+            f"loading build backend dependencies from {build_backend_req_file.name}"
         )
         return _read_requirements_file(build_backend_req_file)
 
@@ -157,15 +154,13 @@ def get_build_sdist_dependencies(
     req: Requirement,
     sdist_root_dir: pathlib.Path,
 ) -> set[Requirement]:
-    logger.info(
-        f"{req.name}: getting build sdist dependencies for {req} in {sdist_root_dir}"
-    )
+    logger.info(f"getting build sdist dependencies for {req} in {sdist_root_dir}")
     pbi = ctx.package_build_info(req)
 
     build_sdist_req_file = sdist_root_dir.parent / BUILD_SDIST_REQ_FILE_NAME
     if build_sdist_req_file.exists():
         logger.info(
-            f"{req.name}: loading build sdist dependencies from {build_sdist_req_file.name}"
+            f"loading build sdist dependencies from {build_sdist_req_file.name}"
         )
         return _read_requirements_file(build_sdist_req_file)
 
@@ -223,9 +218,7 @@ def get_install_dependencies_of_sdist(
     """
     pbi = ctx.package_build_info(req)
     build_dir = pbi.build_dir(sdist_root_dir)
-    logger.info(
-        f"{req.name}: getting install requirements for {req} from sdist in {build_dir}"
-    )
+    logger.info(f"getting install requirements for {req} from sdist in {build_dir}")
     extra_environ = pbi.get_extra_environ()
     hook_caller = get_build_backend_hook_caller(
         ctx=ctx,
@@ -259,7 +252,7 @@ def parse_metadata(metadata_file: pathlib.Path, *, validate: bool = True) -> Met
 def get_install_dependencies_of_wheel(
     req: Requirement, wheel_filename: pathlib.Path, requirements_file_dir: pathlib.Path
 ) -> set[Requirement]:
-    logger.info(f"{req.name}: getting installation dependencies from {wheel_filename}")
+    logger.info(f"getting installation dependencies from {wheel_filename}")
     wheel = pkginfo.Wheel(str(wheel_filename))
     deps = _filter_requirements(req, wheel.requires_dist)
     _write_requirements_file(

--- a/src/fromager/dependency_graph.py
+++ b/src/fromager/dependency_graph.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import pathlib
 import typing
 
@@ -7,10 +6,11 @@ from packaging.requirements import Requirement
 from packaging.utils import NormalizedName, canonicalize_name
 from packaging.version import Version
 
+from .log import get_logger
 from .read import open_file_or_url
 from .requirements_file import RequirementType
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 ROOT = ""
 

--- a/src/fromager/external_commands.py
+++ b/src/fromager/external_commands.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import pathlib
 import shlex
@@ -7,7 +6,9 @@ import sys
 import typing
 from io import TextIOWrapper
 
-logger = logging.getLogger(__name__)
+from .log import get_logger
+
+logger = get_logger(__name__)
 
 HERE = pathlib.Path(__file__).absolute().parent
 

--- a/src/fromager/finders.py
+++ b/src/fromager/finders.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import pathlib
 import re
 import typing
@@ -13,7 +12,9 @@ from . import overrides
 if typing.TYPE_CHECKING:
     from . import context
 
-logger = logging.getLogger(__name__)
+from .log import get_logger
+
+logger = get_logger(__name__)
 
 
 def _dist_name_to_filename(dist_name: str) -> str:
@@ -81,7 +82,7 @@ def find_sdist(
         # comparison.
         for base in candidate_bases:
             for ext in [".tar.gz", ".zip"]:
-                logger.debug('%s: looking for sdist as "%s%s"', req.name, base, ext)
+                logger.debug('looking for sdist as "%s%s"', base, ext)
                 for filename in downloads_dir.glob("*" + ext):
                     if str(filename.name).lower()[: -len(ext)] == base.lower():
                         return filename
@@ -122,7 +123,7 @@ def find_wheel(
     # have to run with older versions, too, so do our own name
     # comparison.
     for base in candidate_bases:
-        logger.debug('%s looking for wheel as "%s"', req.name, base)
+        logger.debug('looking for wheel as "%s"', base)
         for filename in downloads_dir.glob("*"):
             if str(filename.name).lower().startswith(base.lower()):
                 return filename
@@ -206,7 +207,7 @@ def find_source_dir(
     # have to run with older versions, too, so do our own name
     # comparison.
     for base in candidate_bases:
-        logger.debug("%s: looking for source directory as %s", req.name, base)
+        logger.debug("looking for source directory as %s", base)
         for dirname in work_dir.glob("*"):
             if str(dirname.name).lower() == base.lower():
                 # We expect the unpack directory and the source

--- a/src/fromager/gitutils.py
+++ b/src/fromager/gitutils.py
@@ -1,4 +1,3 @@
-import logging
 import pathlib
 from urllib.parse import urlparse
 
@@ -6,7 +5,9 @@ from packaging.requirements import Requirement
 
 from fromager import context, external_commands
 
-logger = logging.getLogger(__name__)
+from .log import get_logger
+
+logger = get_logger(__name__)
 
 
 def git_clone(

--- a/src/fromager/hooks.py
+++ b/src/fromager/hooks.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 
-import logging
 import pathlib
 import typing
 
 from packaging.requirements import Requirement
 from stevedore import extension, hook
 
+from .log import get_logger
+
 if typing.TYPE_CHECKING:
     from . import context
 
 _mgrs: dict[str, hook.HookManager] = {}
-logger = logging.getLogger(__name__)
+
+
+logger = get_logger(__name__)
 
 
 def _get_hooks(name: str) -> hook.HookManager:
@@ -47,7 +50,7 @@ def run_post_build_hooks(
 ) -> None:
     hook_mgr = _get_hooks("post_build")
     if hook_mgr.names():
-        logger.info(f"{req.name}: starting post-build hooks")
+        logger.info("starting post-build hooks")
     for ext in hook_mgr:
         # NOTE: Each hook is responsible for doing its own logging for
         # start/stop because we don't have a good name to use here.
@@ -72,7 +75,7 @@ def run_post_bootstrap_hooks(
     hook_mgr = _get_hooks("post_bootstrap")
     if hook_mgr.names():
         logger.info(
-            f"{req.name}: starting post-bootstrap hooks for sdist {sdist_filename} and wheel {wheel_filename}"
+            f"starting post-bootstrap hooks for sdist {sdist_filename} and wheel {wheel_filename}"
         )
     for ext in hook_mgr:
         # NOTE: Each hook is responsible for doing its own logging for
@@ -96,7 +99,7 @@ def run_prebuilt_wheel_hooks(
 ) -> None:
     hook_mgr = _get_hooks("prebuilt_wheel")
     if hook_mgr.names():
-        logger.info(f"{req.name}: starting prebuilt-wheel hooks")
+        logger.info("starting prebuilt-wheel hooks")
     for ext in hook_mgr:
         ext.plugin(
             ctx=ctx,

--- a/src/fromager/log.py
+++ b/src/fromager/log.py
@@ -1,0 +1,45 @@
+import contextvars
+import logging
+import typing
+
+from packaging.requirements import Requirement
+
+requirement_ctxvar: contextvars.ContextVar[Requirement] = contextvars.ContextVar(
+    "requirement"
+)
+
+
+class LogRequirementAdapter(logging.LoggerAdapter):
+    """Logger adapter to add requirement from context var
+
+    The adapter prepends f"req.name: " to every log message if-and-only-if
+    ``requirement_ctxvar`` is set for the current context. The context var
+    must be set at the beginning of a new requirement scope and reset at the
+    end of a scope.
+
+    ::
+        for req in reqs:
+            token = requirement_ctxvar.set(req)
+            do_stuff(req)
+            requirement_ctxvar.reset(token)
+    """
+
+    def process(
+        self, msg: str, kwargs: typing.MutableMapping[str, typing.Any]
+    ) -> tuple[str, typing.MutableMapping[str, typing.Any]]:
+        try:
+            req = requirement_ctxvar.get()
+        except LookupError:
+            pass
+        else:
+            if "extra" in kwargs:
+                kwargs["extra"] = {"req": req, **kwargs["extra"]}
+            else:
+                kwargs["extra"] = {"req": req}
+            msg = f"{req.name}: {msg}"
+        return msg, kwargs
+
+
+def get_logger(name: str) -> logging.LoggerAdapter:
+    """Get a custom logger instance for all Fromager modules"""
+    return LogRequirementAdapter(logging.getLogger(name))

--- a/src/fromager/metrics.py
+++ b/src/fromager/metrics.py
@@ -1,5 +1,4 @@
 import functools
-import logging
 import time
 import typing
 from datetime import timedelta
@@ -8,6 +7,9 @@ from packaging.requirements import Requirement
 from packaging.version import Version
 
 from . import context
+from .log import get_logger
+
+logger = get_logger(__name__)
 
 
 def timeit(description: str) -> typing.Callable:
@@ -25,7 +27,7 @@ def timeit(description: str) -> typing.Callable:
             ret = func(ctx=ctx, req=req, **kwargs)
             end = time.perf_counter()
             # get the logger for the module from which this function was called
-            logger = logging.getLogger(func.__module__)
+            logger = get_logger(func.__module__)
             version = (
                 kwargs.get("version")
                 or kwargs.get("dist_version")
@@ -38,7 +40,7 @@ def timeit(description: str) -> typing.Callable:
 
             if req:
                 logger.debug(
-                    f"{req.name}: {func.__name__} took {timedelta(seconds=runtime)} to {description}"
+                    f"{func.__name__} took {timedelta(seconds=runtime)} to {description}"
                 )
             else:
                 logger.debug(
@@ -60,7 +62,6 @@ def timeit(description: str) -> typing.Callable:
 
 
 def summarize(ctx: context.WorkContext, prefix: str) -> None:
-    logger = logging.getLogger(__name__)
     for req in sorted(ctx.time_store.keys()):
         total_time = sum(ctx.time_store[req].values())
         log = f"{prefix} {req} took {timedelta(seconds=total_time)} total"

--- a/src/fromager/overrides.py
+++ b/src/fromager/overrides.py
@@ -1,5 +1,4 @@
 import inspect
-import logging
 import pathlib
 import typing
 from importlib import metadata
@@ -12,9 +11,9 @@ from stevedore import extension
 # the build process for a particular package - i.e. for a given package
 # and build target, what patches should we apply, what environment variables
 # should we set, etc.
+from .log import get_logger
 
-
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 _mgr = None

--- a/src/fromager/packagesettings.py
+++ b/src/fromager/packagesettings.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import pathlib
 import re
@@ -21,7 +20,9 @@ from . import overrides
 if typing.TYPE_CHECKING:
     from . import build_environment
 
-logger = logging.getLogger(__name__)
+from .log import get_logger
+
+logger = get_logger(__name__)
 
 
 # build directory

--- a/src/fromager/pyproject.py
+++ b/src/fromager/pyproject.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 import pathlib
 import typing
 
@@ -13,7 +12,9 @@ from packaging.utils import NormalizedName, canonicalize_name
 if typing.TYPE_CHECKING:
     from . import context
 
-logger = logging.getLogger(__name__)
+from .log import get_logger
+
+logger = get_logger(__name__)
 
 TomlDict = dict[str, typing.Any]
 
@@ -57,8 +58,7 @@ class PyprojectFix:
         build_system = self._default_build_system(doc)
         self._update_build_requires(build_system)
         logger.debug(
-            "%s: pyproject.toml %s: %s=%r, %s=%r",
-            self.req.name,
+            "pyproject.toml %s: %s=%r, %s=%r",
             BUILD_SYSTEM,
             BUILD_BACKEND,
             build_system.get(BUILD_BACKEND),
@@ -71,9 +71,9 @@ class PyprojectFix:
         """Load pyproject toml or create empty TOML doc"""
         try:
             doc = tomlkit.parse(self.pyproject_toml.read_bytes())
-            logger.debug("%s: loaded pyproject.toml", self.req.name)
+            logger.debug("loaded pyproject.toml")
         except FileNotFoundError:
-            logger.debug("%s: no pyproject.toml, create empty doc", self.req.name)
+            logger.debug(" no pyproject.toml, create empty doc")
             doc = tomlkit.parse(b"")
         return doc
 
@@ -86,7 +86,7 @@ class PyprojectFix:
         """Add / fix basic 'build-system' dict"""
         build_system: TomlDict | None = doc.get(BUILD_SYSTEM)
         if build_system is None:
-            logger.debug("%s: adding %s", self.req.name, BUILD_SYSTEM)
+            logger.debug("adding %s", BUILD_SYSTEM)
             build_system = doc.setdefault(BUILD_SYSTEM, {})
         # ensure `[build-system] requires` exists
         build_system.setdefault(BUILD_REQUIRES, [])
@@ -115,8 +115,7 @@ class PyprojectFix:
             # ignore order of items
             build_system[BUILD_REQUIRES] = new_requires
             logger.info(
-                "%s: changed build-system requires from %r to %r",
-                self.req.name,
+                "changed build-system requires from %r to %r",
                 old_requires,
                 new_requires,
             )
@@ -131,7 +130,7 @@ def apply_project_override(
     remove_build_requires = pbi.project_override.remove_build_requires
     if update_build_requires or remove_build_requires:
         logger.debug(
-            f"{req.name}: applying project_override: "
+            f"applying project_override: "
             f"{update_build_requires=}, {remove_build_requires=}"
         )
         build_dir = pbi.build_dir(sdist_root_dir)
@@ -142,4 +141,4 @@ def apply_project_override(
             remove_build_requires=remove_build_requires,
         ).run()
     else:
-        logger.debug(f"{req.name}: no project_override")
+        logger.debug("no project_override")

--- a/src/fromager/requirements_file.py
+++ b/src/fromager/requirements_file.py
@@ -1,4 +1,3 @@
-import logging
 import pathlib
 import typing
 from enum import StrEnum
@@ -6,9 +5,10 @@ from enum import StrEnum
 from packaging import markers
 from packaging.requirements import Requirement
 
+from .log import get_logger
 from .read import open_file_or_url
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class RequirementType(StrEnum):

--- a/src/fromager/resolver.py
+++ b/src/fromager/resolver.py
@@ -5,7 +5,6 @@
 #
 from __future__ import annotations
 
-import logging
 import os
 import typing
 from collections import defaultdict
@@ -37,7 +36,9 @@ from .requirements_file import RequirementType
 if typing.TYPE_CHECKING:
     from . import context
 
-logger = logging.getLogger(__name__)
+from .log import get_logger
+
+logger = get_logger(__name__)
 
 PYTHON_VERSION = Version(python_version())
 DEBUG_RESOLVER = os.environ.get("DEBUG_RESOLVER", "")
@@ -101,7 +102,7 @@ class LogReporter(resolvelib.BaseReporter):
         super().__init__()
 
     def _report(self, msg: str, *args: typing.Any) -> None:
-        logger.info("%s: %s", self.req.name, msg % args)
+        logger.info(msg, *args)
 
     def starting(self) -> None:
         self._report("looking for candidates for %r", self.req)

--- a/src/fromager/server.py
+++ b/src/fromager/server.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import functools
 import http.server
-import logging
 import os
 import shutil
 import threading
@@ -13,7 +12,9 @@ from . import external_commands
 if typing.TYPE_CHECKING:
     from . import context
 
-logger = logging.getLogger(__name__)
+from .log import get_logger
+
+logger = get_logger(__name__)
 
 
 class LoggingHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import inspect
 import json
-import logging
 import os.path
 import pathlib
 import shutil
@@ -35,7 +34,9 @@ from .requirements_file import RequirementType
 if typing.TYPE_CHECKING:
     from . import build_environment, context
 
-logger = logging.getLogger(__name__)
+from .log import get_logger
+
+logger = get_logger(__name__)
 
 
 def get_source_type(ctx: context.WorkContext, req: Requirement) -> str:
@@ -61,8 +62,7 @@ def download_source(
 ) -> pathlib.Path:
     if req.url:
         logger.info(
-            "%s: downloaded source to %s by cloning %s, ignoring any plugins",
-            req.name,
+            "downloaded source to %s by cloning %s, ignoring any plugins",
             download_url,
             req.url,
         )
@@ -105,12 +105,12 @@ def resolve_source(
         # git clone URLs of some sort. We are given the directory where the
         # cloned repo resides, and return that as the URL for the source code so
         # the next step in the process can find it and operate on it.
-        logger.info("%s: resolving source via URL, ignoring any plugins", req.name)
+        logger.info("resolving source via URL, ignoring any plugins")
         return resolve_version_from_git_url(ctx=ctx, req=req)
 
     constraint = ctx.constraints.get_constraint(req.name)
     logger.debug(
-        f"{req.name}: resolving requirement {req} using {sdist_server_url} with constraint {constraint}"
+        f"resolving requirement {req} using {sdist_server_url} with constraint {constraint}"
     )
 
     try:
@@ -128,7 +128,7 @@ def resolve_source(
         resolvelib.RequirementsConflicted,
         resolvelib.ResolutionImpossible,
     ) as err:
-        logger.debug(f"{req.name}: could not resolve {req} with {constraint}: {err}")
+        logger.debug(f"could not resolve {req} with {constraint}: {err}")
         raise
 
     if len(resolver_results) == 2:
@@ -187,13 +187,12 @@ def resolve_version_from_git_url(
             version = Version(git_ref)
         except ValueError:
             logger.info(
-                "%s: could not parse %r as a version, cloning to get the version",
-                req.name,
+                "could not parse %r as a version, cloning to get the version",
                 git_ref,
             )
             need_to_clone = True
         else:
-            logger.info("%s: URL %s includes version %s", req.name, req.url, version)
+            logger.info("URL %s includes version %s", req.url, version)
             working_src_dir = (
                 ctx.work_dir / f"{req.name}-{version}" / f"{req.name}-{version}"
             )
@@ -201,11 +200,11 @@ def resolve_version_from_git_url(
                 need_to_clone = True
             else:
                 if ctx.cleanup:
-                    logger.debug("%s: cleaning up %s", req.name, working_src_dir)
+                    logger.debug("cleaning up %s", working_src_dir)
                     shutil.rmtree(working_src_dir)
                     need_to_clone = True
                 else:
-                    logger.info("%s: reusing %s", req.name, working_src_dir)
+                    logger.info("reusing %s", working_src_dir)
 
     if need_to_clone:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -221,7 +220,7 @@ def resolve_version_from_git_url(
                 # If we still do not have a version, get it from the package
                 # metadata.
                 version = _get_version_from_package_metadata(ctx, req, clone_dir)
-                logger.info("%s: found version %s", req.name, version)
+                logger.info("found version %s", version)
                 working_src_dir = (
                     ctx.work_dir / f"{req.name}-{version}" / f"{req.name}-{version}"
                 )
@@ -236,11 +235,11 @@ def resolve_version_from_git_url(
                     # version if that version is set with static data in the
                     # repo instead of via a tag or dynamically computed by
                     # something like setuptools-scm.
-                    logger.debug("%s: cleaning up %s", req.name, working_src_dir)
+                    logger.debug("cleaning up %s", working_src_dir)
                     shutil.rmtree(working_src_dir)
                     need_to_clone = True
                 working_src_dir.parent.mkdir(parents=True, exist_ok=True)
-            logger.info("%s: moving cloned repo to %s", req.name, working_src_dir)
+            logger.info("moving cloned repo to %s", working_src_dir)
             shutil.move(clone_dir, working_src_dir)
 
     # We must know the version and we must have a source directory.
@@ -257,7 +256,7 @@ def _get_version_from_package_metadata(
 ) -> Version:
     pbi = ctx.package_build_info(req)
     build_dir = pbi.build_dir(source_dir)
-    logger.info(f"{req.name}: generating metadata to get version")
+    logger.info("generating metadata to get version")
 
     hook_caller = dependencies.get_build_backend_hook_caller(
         ctx=ctx,
@@ -316,9 +315,7 @@ def default_download_source(
         destination_filename=destination_filename,
     )
 
-    logger.debug(
-        f"{req.name}: have source for {req} version {version} in {source_filename}"
-    )
+    logger.debug(f"have source for {req} version {version} in {source_filename}")
     return source_filename
 
 
@@ -365,23 +362,22 @@ def download_url(
     )
     outfile = pathlib.Path(destination_dir) / basename
     logger.debug(
-        "%s: looking for %s %s",
-        req.name,
+        "looking for %s %s",
         outfile,
         "(exists)" if outfile.exists() else "(not there)",
     )
     if outfile.exists():
-        logger.debug("%s: already have %s", req.name, outfile)
+        logger.debug("already have %s", outfile)
         return outfile
     # Open the URL first in case that fails, so we don't end up with an empty file.
     logger.debug(f"reading from {url}")
     with session.get(url, stream=True) as r:
         r.raise_for_status()
         with open(outfile, "wb") as f:
-            logger.debug("%s: writing to %s", req.name, outfile)
+            logger.debug("writing to %s", outfile)
             for chunk in r.iter_content(chunk_size=1024 * 1024):
                 f.write(chunk)
-    logger.info(f"%s: saved {outfile}", req.name)
+    logger.info("saved %s", outfile)
     return outfile
 
 
@@ -463,18 +459,18 @@ def patch_source(
         _apply_patch(req, p, source_root_dir)
         patch_count += 1
 
-    logger.debug("%s: applied %d patches", req.name, patch_count)
+    logger.debug("applied %d patches", patch_count)
     # If no patch has been applied, call warn for old patch
     patchmap = pbi.get_all_patches()
     if not patch_count and patchmap:
         for patchversion in sorted(patchmap):
             logger.warning(
-                f"{req.name}: patch {patchversion} exists but will not be applied for version {version}"
+                f"patch {patchversion} exists but will not be applied for version {version}"
             )
 
 
 def _apply_patch(req: Requirement, patch: pathlib.Path, source_root_dir: pathlib.Path):
-    logger.info("%s: applying patch file %s to %s", req.name, patch, source_root_dir)
+    logger.info("applying patch file %s to %s", patch, source_root_dir)
     with open(patch, "r") as f:
         external_commands.run(["patch", "-p1"], stdin=f, cwd=source_root_dir)
 
@@ -495,7 +491,7 @@ def write_build_meta(
             },
             f,
         )
-    logger.debug("%s: wrote build metadata to %s", req.name, meta_file)
+    logger.debug("wrote build metadata to %s", meta_file)
     return meta_file
 
 
@@ -515,8 +511,7 @@ def prepare_source(
 ) -> pathlib.Path:
     if req.url:
         logger.info(
-            "%s: preparing source cloned from %s, ignoring any plugins",
-            req.name,
+            "preparing source cloned from %s, ignoring any plugins",
             req.url,
         )
         source_root_dir = pathlib.Path(source_filename)
@@ -527,7 +522,7 @@ def prepare_source(
             version=version,
         )
     else:
-        logger.info(f"{req.name}: preparing source for {req} from {source_filename}")
+        logger.info(f"preparing source for {req} from {source_filename}")
         prepare_source_details = overrides.find_and_invoke(
             req.name,
             "prepare_source",
@@ -547,7 +542,7 @@ def prepare_source(
             )
     write_build_meta(source_root_dir.parent, req, source_filename, version)
     if source_root_dir is not None:
-        logger.info(f"{req.name}: prepared source for {req} at {source_root_dir}")
+        logger.info(f"prepared source for {req} at {source_root_dir}")
     return source_root_dir
 
 
@@ -613,7 +608,7 @@ def build_sdist(
     pbi = ctx.package_build_info(req)
     build_dir = pbi.build_dir(sdist_root_dir)
 
-    logger.info(f"{req.name}: building source distribution in {build_dir}")
+    logger.info(f"building source distribution in {build_dir}")
     extra_environ = pbi.get_extra_environ(build_env=build_env)
     if req.url:
         # The default approach to making an sdist is to make a tarball from the
@@ -622,7 +617,7 @@ def build_sdist(
         # get the source tree, we can be very sure that creating a tarball will
         # NOT produce a valid sdist, so we can use the PEP-517 approach
         # instead.
-        logger.info("%s: using PEP-517 sdist build, ignoring any plugins", req.name)
+        logger.info("using PEP-517 sdist build, ignoring any plugins")
         sdist_filename = pep517_build_sdist(
             ctx=ctx,
             extra_environ=extra_environ,
@@ -643,7 +638,7 @@ def build_sdist(
             build_dir=build_dir,
             build_env=build_env,
         )
-    logger.info(f"{req.name}: built source distribution {sdist_filename}")
+    logger.info(f"built source distribution {sdist_filename}")
     return sdist_filename
 
 
@@ -739,7 +734,7 @@ def ensure_pkg_info(
         pkg_info_file = directory / "PKG-INFO"
         if not pkg_info_file.is_file():
             logger.warning(
-                f"{req.name}: PKG-INFO file is missing from {directory}, creating stub file"
+                f"PKG-INFO file is missing from {directory}, creating stub file"
             )
             pkg_info_file.write_text(
                 PKG_INFO_CONTENT.format(

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import collections
-import logging
 import os
 import pathlib
 import shutil
@@ -32,7 +31,9 @@ from . import (
 if typing.TYPE_CHECKING:
     from . import build_environment, context
 
-logger = logging.getLogger(__name__)
+from .log import get_logger
+
+logger = get_logger(__name__)
 
 FROMAGER_BUILD_SETTINGS = "fromager-build-settings"
 FROMAGER_ELF_PROVIDES = "fromager-elf-provides.txt"
@@ -63,7 +64,7 @@ def _extra_metadata_elfdeps(
         else:
             relname = "n/a"
         logger.debug(
-            f"{req.name}: {relname} ({info.soname}) "
+            f"{relname} ({info.soname}) "
             f"requires {sorted(info.requires)}, "
             f"provides {sorted(info.provides)}"
         )
@@ -82,11 +83,10 @@ def _extra_metadata_elfdeps(
         names = sorted(
             name for name in reqmap if not name.startswith(("ld-linux", "rtld"))
         )
-        logger.info("%s: Requires libraries: %s", req.name, ", ".join(names))
+        logger.info("Requires libraries: %s", ", ".join(names))
         for name, versions in sorted(reqmap.items()):
             logger.debug(
-                "%s: Requires %s(%s)",
-                req.name,
+                "Requires %s(%s)",
                 name,
                 ", ".join(v for v in versions if v),
             )
@@ -98,7 +98,7 @@ def _extra_metadata_elfdeps(
 
     if provides:
         names = sorted(p.soname for p in provides)
-        logger.info("%s: Provides libraries: %s", req.name, ", ".join(names))
+        logger.info("Provides libraries: %s", ", ".join(names))
 
         provides_file = dist_info_dir / FROMAGER_ELF_PROVIDES
         with provides_file.open("w", encoding="utf-8") as f:
@@ -120,9 +120,7 @@ def extract_info_from_wheel_file(
     dist_name = wheel_file.name.split("-", 1)[0]
     if dist_name_normalized != canonicalize_name(dist_name):
         # sanity check, should never fail
-        raise ValueError(
-            f"{req.name}: {dist_name_normalized} does not match {dist_name}"
-        )
+        raise ValueError(f"{dist_name_normalized} does not match {dist_name}")
     return (dist_name, dist_version, build_tag, wheel_tags)
 
 
@@ -171,9 +169,7 @@ def add_extra_metadata_to_wheels(
 
         dist_info_dir = wheel_root_dir / f"{dist_filename}.dist-info"
         if not dist_info_dir.is_dir():
-            raise ValueError(
-                f"{req.name}: {wheel_file} does not contain {dist_info_dir.name}"
-            )
+            raise ValueError(f"{wheel_file} does not contain {dist_info_dir.name}")
 
         if extra_data_plugin:
             data_to_add = overrides.invoke(
@@ -187,7 +183,7 @@ def add_extra_metadata_to_wheels(
             )
             if not isinstance(data_to_add, dict):
                 logger.warning(
-                    f"{req.name}: unexpected return type from plugin add_extra_metadata_to_wheels. Expected dictionary. Will ignore"
+                    "unexpected return type from plugin add_extra_metadata_to_wheels. Expected dictionary. Will ignore"
                 )
                 data_to_add = {}
 
@@ -217,12 +213,11 @@ def add_extra_metadata_to_wheels(
                 )
             else:
                 logger.debug(
-                    "%s: shared library dependency analysis not implemented for %s",
-                    req.name,
+                    "shared library dependency analysis not implemented for %s",
                     sys.platform,
                 )
         else:
-            logger.debug("%s: is a purelib wheel", req.name)
+            logger.debug("%s is a purelib wheel", req.name)
 
         build_tag_from_settings = pbi.build_tag(version)
         build_tag = build_tag_from_settings if build_tag_from_settings else (0, "")
@@ -247,7 +242,7 @@ def add_extra_metadata_to_wheels(
     wheels = list(wheel_file.parent.glob(f"{dist_filename}-*.whl"))
     if wheels:
         logger.info(
-            f"{req.name}: added extra metadata and build tag {build_tag}, wheel renamed from {wheel_file.name} to {wheels[0].name}"
+            f"added extra metadata and build tag {build_tag}, wheel renamed from {wheel_file.name} to {wheels[0].name}"
         )
         return wheels[0]
     raise FileNotFoundError("Could not locate new wheels file")
@@ -264,7 +259,7 @@ def build_wheel(
 ) -> pathlib.Path:
     pbi = ctx.package_build_info(req)
     logger.info(
-        f"{req.name}: building wheel for {req} in {sdist_root_dir} writing to {ctx.wheels_build}"
+        f"building wheel for {req} in {sdist_root_dir} writing to {ctx.wheels_build}"
     )
 
     # add package and variant env vars, package's parallel job vars, and
@@ -326,7 +321,7 @@ def default_build_wheel(
     version: Version,
     build_dir: pathlib.Path,
 ) -> None:
-    logger.debug(f"{req.name}: building wheel in {build_dir} with {extra_environ}")
+    logger.debug(f"building wheel in {build_dir} with {extra_environ}")
     pbi = ctx.package_build_info(req)
 
     cmd = [
@@ -370,11 +365,11 @@ def download_wheel(
 ) -> pathlib.Path:
     wheel_filename = output_directory / os.path.basename(urlparse(wheel_url).path)
     if not wheel_filename.exists():
-        logger.info(f"{req.name}: downloading pre-built wheel {wheel_url}")
+        logger.info(f"downloading pre-built wheel {wheel_url}")
         wheel_filename = _download_wheel_check(req, output_directory, wheel_url)
-        logger.info(f"{req.name}: saved wheel to {wheel_filename}")
+        logger.info(f"saved wheel to {wheel_filename}")
     else:
-        logger.info(f"{req.name}: have existing wheel {wheel_filename}")
+        logger.info(f"have existing wheel {wheel_filename}")
 
     return wheel_filename
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -106,7 +106,7 @@ def test_invalid_version(mock_default_resolve_source, tmp_context: context.WorkC
         )
 
 
-@patch("logging.Logger.warning")
+@patch("logging.LoggerAdapter.warning")
 @patch("fromager.sources._apply_patch")
 def test_patch_sources_apply_unversioned_and_versioned(
     apply_patch: Mock,


### PR DESCRIPTION
The new `LogRequirementAdapter` and `fromager.log.get_logger()` helper use a Python `contextvar` to inject the current requirement name into a log message. Context vars are a bit like TLS (thread local storage) vars, but with asyncio and nesting support.

The requirement context variable is set whenenver a new requirement is encountered and reset when the control flow leaves the scope of that requirement. Reset ensures that recursive requirement handling is handled correctly.

See: https://docs.python.org/3/howto/logging-cookbook.html#context-info
See: https://docs.python.org/3/library/contextvars.html