### PR TITLE
Implement requirement logging factory

### DIFF
--- a/e2e/fromager_hooks/src/package_plugins/hooks.py
+++ b/e2e/fromager_hooks/src/package_plugins/hooks.py
@@ -17,10 +17,10 @@ def after_build_wheel(
     wheel_filename: pathlib.Path,
 ):
     logger.info(
-        f"{req.name}: running post build hook in {__name__} for {sdist_filename} and {wheel_filename}"
+        f"running post build hook in {__name__} for {sdist_filename} and {wheel_filename}"
     )
     test_file = sdist_filename.parent / "test-output-file.txt"
-    logger.info(f"{req.name}: post-build hook writing to {test_file}")
+    logger.info(f"post-build hook writing to {test_file}")
     test_file.write_text(f"{dist_name}=={dist_version}")
 
 
@@ -33,10 +33,10 @@ def after_bootstrap(
     wheel_filename: pathlib.Path | None,
 ):
     logger.info(
-        f"{req.name}: running post bootstrap hook in {__name__} for {sdist_filename} and {wheel_filename}"
+        f"running post bootstrap hook in {__name__} for {sdist_filename} and {wheel_filename}"
     )
     test_file = ctx.work_dir / "test-output-file.txt"
-    logger.info(f"{req.name}: post-bootstrap hook writing to {test_file}")
+    logger.info(f"post-bootstrap hook writing to {test_file}")
     test_file.write_text(f"{dist_name}=={dist_version}")
 
 
@@ -48,8 +48,8 @@ def after_prebuilt_wheel(
     wheel_filename: pathlib.Path,
 ):
     logger.info(
-        f"{req.name}: running post build hook in {__name__} for {wheel_filename}"
+        f"running post build hook in {__name__} for {wheel_filename}"
     )
     test_file = ctx.work_dir / "test-prebuilt.txt"
-    logger.info(f"{req.name}: prebuilt-wheel hook writing to {test_file}")
+    logger.info(f"prebuilt-wheel hook writing to {test_file}")
     test_file.write_text(f"{dist_name}=={dist_version}")

--- a/src/fromager/__main__.py
+++ b/src/fromager/__main__.py
@@ -11,6 +11,7 @@ from . import (
     commands,
     context,
     external_commands,
+    log,
     overrides,
     packagesettings,
 )
@@ -152,6 +153,8 @@ def main(
     global _DEBUG
     _DEBUG = debug
 
+    # Set custom log factory to prepend requirement name.
+    logging.setLogRecordFactory(log.FromagerLogRecord)
     # Set the overall logger level to debug and allow the handlers to filter
     # messages at their own level.
     logging.getLogger().setLevel(logging.DEBUG)

--- a/src/fromager/build_environment.py
+++ b/src/fromager/build_environment.py
@@ -159,12 +159,10 @@ class BuildEnvironment:
 
     def _createenv(self) -> None:
         if self.path.exists():
-            logger.info(
-                "%s: reusing build environment in %s", self._req.name, self.path
-            )
+            logger.info("reusing build environment in %s", self.path)
             return
 
-        logger.debug("%s: creating build environment in %s", self._req.name, self.path)
+        logger.debug("creating build environment in %s", self.path)
         # Python 3.12 virtual envs don't have wheel and setuptools by
         # default. Some packages still assume they are installed.
         external_commands.run(
@@ -183,7 +181,7 @@ class BuildEnvironment:
             ],
             network_isolation=self._ctx.network_isolation,
         )
-        logger.info("%s: created build environment in %s", self._req.name, self.path)
+        logger.info("created build environment in %s", self.path)
 
         req_filename = self.path / "requirements.txt"
         # FIXME: Ensure each requirement is pinned to a specific version.
@@ -213,8 +211,7 @@ class BuildEnvironment:
             network_isolation=False,
         )
         logger.info(
-            "%s: installed dependencies into build environment in %s",
-            self._req.name,
+            "installed dependencies into build environment in %s",
             self.path,
         )
 
@@ -226,7 +223,7 @@ def prepare_build_environment(
     req: Requirement,
     sdist_root_dir: pathlib.Path,
 ) -> BuildEnvironment:
-    logger.info(f"{req.name}: preparing build environment")
+    logger.info("preparing build environment")
 
     next_req_type = RequirementType.BUILD_SYSTEM
     build_system_dependencies = dependencies.get_build_system_dependencies(
@@ -244,9 +241,7 @@ def prepare_build_environment(
                 ctx=ctx, req=req, dep=dep, dep_version=None, dep_req_type=next_req_type
             )
         except Exception as err:
-            logger.error(
-                f"{req.name}: failed to install {next_req_type} dependency {dep}: {err}"
-            )
+            logger.error(f"failed to install {next_req_type} dependency {dep}: {err}")
             raise MissingDependency(
                 ctx,
                 next_req_type,
@@ -270,9 +265,7 @@ def prepare_build_environment(
                 ctx=ctx, req=req, dep=dep, dep_version=None, dep_req_type=next_req_type
             )
         except Exception as err:
-            logger.error(
-                f"{req.name}: failed to install {next_req_type} dependency {dep}: {err}"
-            )
+            logger.error(f"failed to install {next_req_type} dependency {dep}: {err}")
             raise MissingDependency(
                 ctx,
                 next_req_type,
@@ -293,9 +286,7 @@ def prepare_build_environment(
                 ctx=ctx, req=req, dep=dep, dep_version=None, dep_req_type=next_req_type
             )
         except Exception as err:
-            logger.error(
-                f"{req.name}: failed to install {next_req_type} dependency {dep}: {err}"
-            )
+            logger.error(f"failed to install {next_req_type} dependency {dep}: {err}")
             raise MissingDependency(
                 ctx,
                 next_req_type,
@@ -318,7 +309,7 @@ def prepare_build_environment(
         # Pip has no API, so parse its output looking for what it
         # couldn't install. If we don't find something, just re-raise
         # the exception we already have.
-        logger.error(f"{req.name}: failed to create build environment for {dep}: {err}")
+        logger.error(f"failed to create build environment for {dep}: {err}")
         logger.info(f"looking for pattern in {err.output!r}")
         match = _pip_missing_dependency_pattern.search(err.output)
         if match:
@@ -346,12 +337,10 @@ def maybe_install(
         try:
             actual_version = importlib.metadata.version(dep.name)
             if str(dep_version) == actual_version:
-                logger.debug(
-                    f"{req.name}: already have {dep.name} version {dep_version} installed"
-                )
+                logger.debug(f"already have {dep.name} version {dep_version} installed")
                 return
             logger.info(
-                f"{req.name}: found {dep.name} {actual_version} installed, updating to {dep_version}"
+                f"found {dep.name} {actual_version} installed, updating to {dep_version}"
             )
             _safe_install(
                 ctx, req, Requirement(f"{dep.name}=={dep_version}"), dep_req_type
@@ -370,7 +359,7 @@ def _safe_install(
     dep: Requirement,
     dep_req_type: RequirementType,
 ):
-    logger.debug("%s: installing %s %s", req.name, dep_req_type, dep)
+    logger.debug("installing %s %s", dep_req_type, dep)
     external_commands.run(
         [
             sys.executable,
@@ -390,4 +379,4 @@ def _safe_install(
         ],
         network_isolation=False,
     )
-    logger.info("%s: installed %s requirement %s", req.name, dep_req_type, dep)
+    logger.info("installed %s requirement %s", dep_req_type, dep)

--- a/src/fromager/commands/download_sequence.py
+++ b/src/fromager/commands/download_sequence.py
@@ -9,6 +9,7 @@ from packaging.requirements import Requirement
 from packaging.version import Version
 
 from .. import context, progress, read, sources, wheels
+from ..log import requirement_ctxvar
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +63,7 @@ def download_sequence(
 
     def download_one(entry: dict[str, typing.Any]):
         req = Requirement(f"{entry['dist']}=={entry['version']}")
+        token = requirement_ctxvar.set(req)
 
         if entry["prebuilt"]:
             if include_wheels:
@@ -99,6 +101,7 @@ def download_sequence(
                 )
             except Exception as err:
                 logger.error(f"failed to download wheel for {req}: {err}")
+        requirement_ctxvar.reset(token)
 
     num_items = len(build_order)
     logger.debug(

--- a/src/fromager/commands/step.py
+++ b/src/fromager/commands/step.py
@@ -14,6 +14,7 @@ from .. import (
     sources,
     wheels,
 )
+from ..log import requirement_ctxvar
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +46,7 @@ def download_source_archive(
 
     """
     req = Requirement(f"{dist_name}=={dist_version}")
+    token = requirement_ctxvar.set(req)
     source_url, version = sources.resolve_source(
         ctx=wkctx, req=req, sdist_server_url=sdist_server_url
     )
@@ -54,6 +56,7 @@ def download_source_archive(
         version=version,
         download_url=source_url,
     )
+    requirement_ctxvar.reset(token)
     print(filename)
 
 
@@ -74,6 +77,7 @@ def prepare_source(
 
     """
     req = Requirement(f"{dist_name}=={dist_version}")
+    token = requirement_ctxvar.set(req)
     sdists_downloads = pathlib.Path(wkctx.sdists_repo) / "downloads"
     source_filename = finders.find_sdist(
         wkctx, wkctx.sdists_downloads, req, str(dist_version)
@@ -91,6 +95,7 @@ def prepare_source(
         source_filename=source_filename,
         version=dist_version,
     )
+    requirement_ctxvar.reset(token)
     print(source_root_dir)
 
 
@@ -114,6 +119,7 @@ def build_sdist(
 
     """
     req = Requirement(f"{dist_name}=={dist_version}")
+    token = requirement_ctxvar.set(req)
     source_root_dir = _find_source_root_dir(wkctx, wkctx.work_dir, req, dist_version)
     build_env = build_environment.BuildEnvironment(
         ctx=wkctx, parent_dir=source_root_dir.parent, build_requirements=None, req=req
@@ -125,6 +131,7 @@ def build_sdist(
         sdist_root_dir=source_root_dir,
         build_env=build_env,
     )
+    requirement_ctxvar.reset(token)
     print(sdist_filename)
 
 
@@ -169,10 +176,12 @@ def prepare_build(
     wkctx.wheel_server_url = wheel_server_url
     server.start_wheel_server(wkctx)
     req = Requirement(f"{dist_name}=={dist_version}")
+    token = requirement_ctxvar.set(req)
     source_root_dir = _find_source_root_dir(wkctx, wkctx.work_dir, req, dist_version)
     build_environment.prepare_build_environment(
         ctx=wkctx, req=req, sdist_root_dir=source_root_dir
     )
+    requirement_ctxvar.reset(token)
 
 
 @step.command()
@@ -200,6 +209,7 @@ def build_wheel(
     """
     wkctx.wheel_server_url = wheel_server_url
     req = Requirement(f"{dist_name}=={dist_version}")
+    token = requirement_ctxvar.set(req)
     source_root_dir = _find_source_root_dir(wkctx, wkctx.work_dir, req, dist_version)
     server.start_wheel_server(wkctx)
     build_env = build_environment.BuildEnvironment(
@@ -212,4 +222,5 @@ def build_wheel(
         version=dist_version,
         build_env=build_env,
     )
+    requirement_ctxvar.reset(token)
     print(wheel_filename)

--- a/src/fromager/dependencies.py
+++ b/src/fromager/dependencies.py
@@ -31,15 +31,13 @@ def get_build_system_dependencies(
     req: Requirement,
     sdist_root_dir: pathlib.Path,
 ) -> set[Requirement]:
-    logger.info(
-        f"{req.name}: getting build system dependencies for {req} in {sdist_root_dir}"
-    )
+    logger.info(f"getting build system dependencies for {req} in {sdist_root_dir}")
     pbi = ctx.package_build_info(req)
 
     build_system_req_file = sdist_root_dir.parent / BUILD_SYSTEM_REQ_FILE_NAME
     if build_system_req_file.exists():
         logger.info(
-            f"{req.name}: loading build system dependencies from {build_system_req_file.name}"
+            f"loading build system dependencies from {build_system_req_file.name}"
         )
         return _read_requirements_file(build_system_req_file)
 
@@ -73,7 +71,7 @@ def _filter_requirements(
             requires.add(r)
         else:
             logger.debug(
-                f"{req.name}: evaluated {r} in the context of {req} and ignored because the environment marker does not match"
+                f"evaluated {r} in the context of {req} and ignored because the environment marker does not match"
             )
     return requires
 
@@ -98,15 +96,13 @@ def get_build_backend_dependencies(
     req: Requirement,
     sdist_root_dir: pathlib.Path,
 ) -> set[Requirement]:
-    logger.info(
-        f"{req.name}: getting build backend dependencies for {req} in {sdist_root_dir}"
-    )
+    logger.info(f"getting build backend dependencies for {req} in {sdist_root_dir}")
     pbi = ctx.package_build_info(req)
 
     build_backend_req_file = sdist_root_dir.parent / BUILD_BACKEND_REQ_FILE_NAME
     if build_backend_req_file.exists():
         logger.info(
-            f"{req.name}: loading build backend dependencies from {build_backend_req_file.name}"
+            f"loading build backend dependencies from {build_backend_req_file.name}"
         )
         return _read_requirements_file(build_backend_req_file)
 
@@ -157,15 +153,13 @@ def get_build_sdist_dependencies(
     req: Requirement,
     sdist_root_dir: pathlib.Path,
 ) -> set[Requirement]:
-    logger.info(
-        f"{req.name}: getting build sdist dependencies for {req} in {sdist_root_dir}"
-    )
+    logger.info(f"getting build sdist dependencies for {req} in {sdist_root_dir}")
     pbi = ctx.package_build_info(req)
 
     build_sdist_req_file = sdist_root_dir.parent / BUILD_SDIST_REQ_FILE_NAME
     if build_sdist_req_file.exists():
         logger.info(
-            f"{req.name}: loading build sdist dependencies from {build_sdist_req_file.name}"
+            f"loading build sdist dependencies from {build_sdist_req_file.name}"
         )
         return _read_requirements_file(build_sdist_req_file)
 
@@ -223,9 +217,7 @@ def get_install_dependencies_of_sdist(
     """
     pbi = ctx.package_build_info(req)
     build_dir = pbi.build_dir(sdist_root_dir)
-    logger.info(
-        f"{req.name}: getting install requirements for {req} from sdist in {build_dir}"
-    )
+    logger.info(f"getting install requirements for {req} from sdist in {build_dir}")
     extra_environ = pbi.get_extra_environ()
     hook_caller = get_build_backend_hook_caller(
         ctx=ctx,
@@ -259,7 +251,7 @@ def parse_metadata(metadata_file: pathlib.Path, *, validate: bool = True) -> Met
 def get_install_dependencies_of_wheel(
     req: Requirement, wheel_filename: pathlib.Path, requirements_file_dir: pathlib.Path
 ) -> set[Requirement]:
-    logger.info(f"{req.name}: getting installation dependencies from {wheel_filename}")
+    logger.info(f"getting installation dependencies from {wheel_filename}")
     wheel = pkginfo.Wheel(str(wheel_filename))
     deps = _filter_requirements(req, wheel.requires_dist)
     _write_requirements_file(

--- a/src/fromager/finders.py
+++ b/src/fromager/finders.py
@@ -81,7 +81,7 @@ def find_sdist(
         # comparison.
         for base in candidate_bases:
             for ext in [".tar.gz", ".zip"]:
-                logger.debug('%s: looking for sdist as "%s%s"', req.name, base, ext)
+                logger.debug('looking for sdist as "%s%s"', base, ext)
                 for filename in downloads_dir.glob("*" + ext):
                     if str(filename.name).lower()[: -len(ext)] == base.lower():
                         return filename
@@ -122,7 +122,7 @@ def find_wheel(
     # have to run with older versions, too, so do our own name
     # comparison.
     for base in candidate_bases:
-        logger.debug('%s looking for wheel as "%s"', req.name, base)
+        logger.debug('looking for wheel as "%s"', base)
         for filename in downloads_dir.glob("*"):
             if str(filename.name).lower().startswith(base.lower()):
                 return filename
@@ -206,7 +206,7 @@ def find_source_dir(
     # have to run with older versions, too, so do our own name
     # comparison.
     for base in candidate_bases:
-        logger.debug("%s: looking for source directory as %s", req.name, base)
+        logger.debug("looking for source directory as %s", base)
         for dirname in work_dir.glob("*"):
             if str(dirname.name).lower() == base.lower():
                 # We expect the unpack directory and the source

--- a/src/fromager/hooks.py
+++ b/src/fromager/hooks.py
@@ -11,6 +11,7 @@ if typing.TYPE_CHECKING:
     from . import context
 
 _mgrs: dict[str, hook.HookManager] = {}
+
 logger = logging.getLogger(__name__)
 
 
@@ -47,7 +48,7 @@ def run_post_build_hooks(
 ) -> None:
     hook_mgr = _get_hooks("post_build")
     if hook_mgr.names():
-        logger.info(f"{req.name}: starting post-build hooks")
+        logger.info("starting post-build hooks")
     for ext in hook_mgr:
         # NOTE: Each hook is responsible for doing its own logging for
         # start/stop because we don't have a good name to use here.
@@ -72,7 +73,7 @@ def run_post_bootstrap_hooks(
     hook_mgr = _get_hooks("post_bootstrap")
     if hook_mgr.names():
         logger.info(
-            f"{req.name}: starting post-bootstrap hooks for sdist {sdist_filename} and wheel {wheel_filename}"
+            f"starting post-bootstrap hooks for sdist {sdist_filename} and wheel {wheel_filename}"
         )
     for ext in hook_mgr:
         # NOTE: Each hook is responsible for doing its own logging for
@@ -96,7 +97,7 @@ def run_prebuilt_wheel_hooks(
 ) -> None:
     hook_mgr = _get_hooks("prebuilt_wheel")
     if hook_mgr.names():
-        logger.info(f"{req.name}: starting prebuilt-wheel hooks")
+        logger.info("starting prebuilt-wheel hooks")
     for ext in hook_mgr:
         ext.plugin(
             ctx=ctx,

--- a/src/fromager/log.py
+++ b/src/fromager/log.py
@@ -1,0 +1,34 @@
+import contextvars
+import logging
+
+from packaging.requirements import Requirement
+
+requirement_ctxvar: contextvars.ContextVar[Requirement] = contextvars.ContextVar(
+    "requirement"
+)
+
+
+class FromagerLogRecord(logging.LogRecord):
+    """Logger record factory to add requirement from context var
+
+    The class prepends f"req.name: " to every log message if-and-only-if
+    ``requirement_ctxvar`` is set for the current context. The context var
+    must be set at the beginning of a new requirement scope and reset at the
+    end of a scope.
+
+    ::
+        for req in reqs:
+            token = requirement_ctxvar.set(req)
+            do_stuff(req)
+            requirement_ctxvar.reset(token)
+    """
+
+    def getMessage(self) -> str:  # noqa: N802
+        msg = super().getMessage()
+        try:
+            req = requirement_ctxvar.get()
+        except LookupError:
+            pass
+        else:
+            msg = f"{req.name}: {msg}"
+        return msg

--- a/src/fromager/metrics.py
+++ b/src/fromager/metrics.py
@@ -38,7 +38,7 @@ def timeit(description: str) -> typing.Callable:
 
             if req:
                 logger.debug(
-                    f"{req.name}: {func.__name__} took {timedelta(seconds=runtime)} to {description}"
+                    f"{func.__name__} took {timedelta(seconds=runtime)} to {description}"
                 )
             else:
                 logger.debug(

--- a/src/fromager/overrides.py
+++ b/src/fromager/overrides.py
@@ -12,8 +12,6 @@ from stevedore import extension
 # the build process for a particular package - i.e. for a given package
 # and build target, what patches should we apply, what environment variables
 # should we set, etc.
-
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/fromager/pyproject.py
+++ b/src/fromager/pyproject.py
@@ -57,8 +57,7 @@ class PyprojectFix:
         build_system = self._default_build_system(doc)
         self._update_build_requires(build_system)
         logger.debug(
-            "%s: pyproject.toml %s: %s=%r, %s=%r",
-            self.req.name,
+            "pyproject.toml %s: %s=%r, %s=%r",
             BUILD_SYSTEM,
             BUILD_BACKEND,
             build_system.get(BUILD_BACKEND),
@@ -71,9 +70,9 @@ class PyprojectFix:
         """Load pyproject toml or create empty TOML doc"""
         try:
             doc = tomlkit.parse(self.pyproject_toml.read_bytes())
-            logger.debug("%s: loaded pyproject.toml", self.req.name)
+            logger.debug("loaded pyproject.toml")
         except FileNotFoundError:
-            logger.debug("%s: no pyproject.toml, create empty doc", self.req.name)
+            logger.debug(" no pyproject.toml, create empty doc")
             doc = tomlkit.parse(b"")
         return doc
 
@@ -86,7 +85,7 @@ class PyprojectFix:
         """Add / fix basic 'build-system' dict"""
         build_system: TomlDict | None = doc.get(BUILD_SYSTEM)
         if build_system is None:
-            logger.debug("%s: adding %s", self.req.name, BUILD_SYSTEM)
+            logger.debug("adding %s", BUILD_SYSTEM)
             build_system = doc.setdefault(BUILD_SYSTEM, {})
         # ensure `[build-system] requires` exists
         build_system.setdefault(BUILD_REQUIRES, [])
@@ -115,8 +114,7 @@ class PyprojectFix:
             # ignore order of items
             build_system[BUILD_REQUIRES] = new_requires
             logger.info(
-                "%s: changed build-system requires from %r to %r",
-                self.req.name,
+                "changed build-system requires from %r to %r",
                 old_requires,
                 new_requires,
             )
@@ -131,7 +129,7 @@ def apply_project_override(
     remove_build_requires = pbi.project_override.remove_build_requires
     if update_build_requires or remove_build_requires:
         logger.debug(
-            f"{req.name}: applying project_override: "
+            f"applying project_override: "
             f"{update_build_requires=}, {remove_build_requires=}"
         )
         build_dir = pbi.build_dir(sdist_root_dir)
@@ -142,4 +140,4 @@ def apply_project_override(
             remove_build_requires=remove_build_requires,
         ).run()
     else:
-        logger.debug(f"{req.name}: no project_override")
+        logger.debug("no project_override")

--- a/src/fromager/resolver.py
+++ b/src/fromager/resolver.py
@@ -101,7 +101,7 @@ class LogReporter(resolvelib.BaseReporter):
         super().__init__()
 
     def _report(self, msg: str, *args: typing.Any) -> None:
-        logger.info("%s: %s", self.req.name, msg % args)
+        logger.info(msg, *args)
 
     def starting(self) -> None:
         self._report("looking for candidates for %r", self.req)

--- a/src/fromager/vendor_rust.py
+++ b/src/fromager/vendor_rust.py
@@ -35,7 +35,7 @@ def _cargo_vendor(
     project_dir: pathlib.Path,
 ) -> typing.Iterable[pathlib.Path]:
     """Run cargo vendor"""
-    logger.info(f"{req.name}: updating vendored rust dependencies in {project_dir}")
+    logger.info(f"updating vendored rust dependencies in {project_dir}")
     args = ["cargo", "vendor", f"--manifest-path={manifests[0]}"]
     for manifest in manifests[1:]:
         args.append(f"--sync={manifest}")
@@ -108,12 +108,10 @@ def _detect_rust_build_backend(
         except ValueError:
             pass
         else:
-            logger.debug(
-                f"{req.name}: build-system requires '{req.name}', vendoring crates"
-            )
+            logger.debug(f"build-system requires '{req.name}', vendoring crates")
             return rbs
 
-    logger.debug(f"{req.name}: no Rust build plugin detected")
+    logger.debug("no Rust build plugin detected")
     return None
 
 
@@ -130,7 +128,7 @@ def vendor_generic_rust_package(
         manifests = [root_dir / "Cargo.toml"]
     # fetch and vendor Rust crates
     vendored = _cargo_vendor(req, manifests, root_dir)
-    logger.debug(f"{req.name}: vendored crates: {sorted(d.name for d in vendored)}")
+    logger.debug(f"vendored crates: {sorted(d.name for d in vendored)}")
 
     # remove unnecessary pre-compiled files for Windows, macOS, and iOS.
     if shrink_vendored:
@@ -153,7 +151,7 @@ def vendor_rust(
     """
     pyproject_toml = dependencies.get_pyproject_contents(project_dir)
     if not pyproject_toml:
-        logger.debug(f"{req.name}: has no pyproject.toml")
+        logger.debug("has no pyproject.toml")
         return False
 
     backend = _detect_rust_build_backend(req, pyproject_toml)
@@ -166,7 +164,7 @@ def vendor_rust(
             try:
                 tool_maturin: dict[str, typing.Any] = pyproject_toml["tool"]["maturin"]
             except KeyError as e:
-                logger.debug(f"{req.name}: No additional maturin settings: {e}")
+                logger.debug(f"No additional maturin settings: {e}")
             else:
                 if "manifest-path" in tool_maturin:
                     manifests.append(project_dir / tool_maturin["manifest-path"])
@@ -175,13 +173,13 @@ def vendor_rust(
             try:
                 ext_modules = pyproject_toml["tool"]["setuptools-rust"]["ext-modules"]
             except KeyError as e:
-                logger.debug(f"{req.name}: No additional setuptools-rust settings: {e}")
+                logger.debug(f"No additional setuptools-rust settings: {e}")
             else:
                 for ext_module in ext_modules:
                     if "path" in ext_module:
                         manifests.append(project_dir / ext_module["path"])
         case None:
-            logger.debug(f"{req.name}: no Rust build system detected")
+            logger.debug("no Rust build system detected")
             return False
         case _ as unreachable:
             typing.assert_never(unreachable)
@@ -193,13 +191,12 @@ def vendor_rust(
             manifests.append(root_cargo_toml)
         else:
             logger.warning(
-                f"{req.name}: Rust build backend {backend} detected, but "
-                "no Cargo.toml files found."
+                f"Rust build backend {backend} detected, but no Cargo.toml files found."
             )
             return False
 
     the_manifests = sorted(str(d.relative_to(project_dir)) for d in manifests)
-    logger.debug(f"{req.name}: {project_dir} has cargo manifests: {the_manifests}")
+    logger.debug(f"{project_dir} has cargo manifests: {the_manifests}")
 
     vendor_generic_rust_package(
         req, manifests, project_dir, shrink_vendored=shrink_vendored

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -63,7 +63,7 @@ def _extra_metadata_elfdeps(
         else:
             relname = "n/a"
         logger.debug(
-            f"{req.name}: {relname} ({info.soname}) "
+            f"{relname} ({info.soname}) "
             f"requires {sorted(info.requires)}, "
             f"provides {sorted(info.provides)}"
         )
@@ -82,11 +82,10 @@ def _extra_metadata_elfdeps(
         names = sorted(
             name for name in reqmap if not name.startswith(("ld-linux", "rtld"))
         )
-        logger.info("%s: Requires libraries: %s", req.name, ", ".join(names))
+        logger.info("Requires libraries: %s", ", ".join(names))
         for name, versions in sorted(reqmap.items()):
             logger.debug(
-                "%s: Requires %s(%s)",
-                req.name,
+                "Requires %s(%s)",
                 name,
                 ", ".join(v for v in versions if v),
             )
@@ -98,7 +97,7 @@ def _extra_metadata_elfdeps(
 
     if provides:
         names = sorted(p.soname for p in provides)
-        logger.info("%s: Provides libraries: %s", req.name, ", ".join(names))
+        logger.info("Provides libraries: %s", ", ".join(names))
 
         provides_file = dist_info_dir / FROMAGER_ELF_PROVIDES
         with provides_file.open("w", encoding="utf-8") as f:
@@ -120,9 +119,7 @@ def extract_info_from_wheel_file(
     dist_name = wheel_file.name.split("-", 1)[0]
     if dist_name_normalized != canonicalize_name(dist_name):
         # sanity check, should never fail
-        raise ValueError(
-            f"{req.name}: {dist_name_normalized} does not match {dist_name}"
-        )
+        raise ValueError(f"{dist_name_normalized} does not match {dist_name}")
     return (dist_name, dist_version, build_tag, wheel_tags)
 
 
@@ -171,9 +168,7 @@ def add_extra_metadata_to_wheels(
 
         dist_info_dir = wheel_root_dir / f"{dist_filename}.dist-info"
         if not dist_info_dir.is_dir():
-            raise ValueError(
-                f"{req.name}: {wheel_file} does not contain {dist_info_dir.name}"
-            )
+            raise ValueError(f"{wheel_file} does not contain {dist_info_dir.name}")
 
         if extra_data_plugin:
             data_to_add = overrides.invoke(
@@ -187,7 +182,7 @@ def add_extra_metadata_to_wheels(
             )
             if not isinstance(data_to_add, dict):
                 logger.warning(
-                    f"{req.name}: unexpected return type from plugin add_extra_metadata_to_wheels. Expected dictionary. Will ignore"
+                    "unexpected return type from plugin add_extra_metadata_to_wheels. Expected dictionary. Will ignore"
                 )
                 data_to_add = {}
 
@@ -217,12 +212,11 @@ def add_extra_metadata_to_wheels(
                 )
             else:
                 logger.debug(
-                    "%s: shared library dependency analysis not implemented for %s",
-                    req.name,
+                    "shared library dependency analysis not implemented for %s",
                     sys.platform,
                 )
         else:
-            logger.debug("%s: is a purelib wheel", req.name)
+            logger.debug("%s is a purelib wheel", req.name)
 
         build_tag_from_settings = pbi.build_tag(version)
         build_tag = build_tag_from_settings if build_tag_from_settings else (0, "")
@@ -247,7 +241,7 @@ def add_extra_metadata_to_wheels(
     wheels = list(wheel_file.parent.glob(f"{dist_filename}-*.whl"))
     if wheels:
         logger.info(
-            f"{req.name}: added extra metadata and build tag {build_tag}, wheel renamed from {wheel_file.name} to {wheels[0].name}"
+            f"added extra metadata and build tag {build_tag}, wheel renamed from {wheel_file.name} to {wheels[0].name}"
         )
         return wheels[0]
     raise FileNotFoundError("Could not locate new wheels file")
@@ -264,7 +258,7 @@ def build_wheel(
 ) -> pathlib.Path:
     pbi = ctx.package_build_info(req)
     logger.info(
-        f"{req.name}: building wheel for {req} in {sdist_root_dir} writing to {ctx.wheels_build}"
+        f"building wheel for {req} in {sdist_root_dir} writing to {ctx.wheels_build}"
     )
 
     # add package and variant env vars, package's parallel job vars, and
@@ -326,7 +320,7 @@ def default_build_wheel(
     version: Version,
     build_dir: pathlib.Path,
 ) -> None:
-    logger.debug(f"{req.name}: building wheel in {build_dir} with {extra_environ}")
+    logger.debug(f"building wheel in {build_dir} with {extra_environ}")
     pbi = ctx.package_build_info(req)
 
     cmd = [
@@ -370,11 +364,11 @@ def download_wheel(
 ) -> pathlib.Path:
     wheel_filename = output_directory / os.path.basename(urlparse(wheel_url).path)
     if not wheel_filename.exists():
-        logger.info(f"{req.name}: downloading pre-built wheel {wheel_url}")
+        logger.info(f"downloading pre-built wheel {wheel_url}")
         wheel_filename = _download_wheel_check(req, output_directory, wheel_url)
-        logger.info(f"{req.name}: saved wheel to {wheel_filename}")
+        logger.info(f"saved wheel to {wheel_filename}")
     else:
-        logger.info(f"{req.name}: have existing wheel {wheel_filename}")
+        logger.info(f"have existing wheel {wheel_filename}")
 
     return wheel_filename
 


### PR DESCRIPTION
The new `FromagerLogRecord` replaces logging's default LogRecord class. It uses a Python `contextvar` to inject the current requirement name into a log message. Context vars are a bit like TLS (thread local storage) vars, but with asyncio and nesting support.

The requirement context variable is set whenenver a new requirement is encountered and reset when the control flow leaves the scope of that requirement. Reset ensures that recursive requirement handling is handled correctly.

See: https://docs.python.org/3/library/contextvars.html