### PR TITLE
Don't compile bytecode of dependencies

### DIFF
--- a/src/fromager/build_environment.py
+++ b/src/fromager/build_environment.py
@@ -198,6 +198,7 @@ class BuildEnvironment:
                 "pip",
                 "install",
                 "--disable-pip-version-check",
+                "--no-compile",  # don't compile byte code
                 "--only-binary",
                 ":all:",
             ]
@@ -368,6 +369,7 @@ def _safe_install(
             "-vvv",
             "install",
             "--disable-pip-version-check",
+            "--no-compile",  # don't compile byte code
             "--upgrade",
             "--only-binary",
             ":all:",


### PR DESCRIPTION
By default, `pip install` also compiles byte code of all Python files. The step takes a while, especially for large packages like PyTorch. Disable byte code compilation to speed up installation of build dependencies. Byte code is now compiled on demand.