### PR TITLE
cap virtualenv<20.31.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ setuptools>=73.0.0 # https://github.com/pypa/setuptools/issues/4519
 stevedore
 tomlkit
 tqdm
-virtualenv
+virtualenv<20.31.0
 wheel


### PR DESCRIPTION
20.31.0 removes the bundled wheel package that we depend on for building with network isolation. We are going to need to find an alternative solution for that. In the meantime, cap the dependency.

https://virtualenv.pypa.io/en/latest/changelog.html#features-20-31-0