### PR TITLE
switch from virtualenv to venv

### DIFF
--- a/e2e/constraints.txt
+++ b/e2e/constraints.txt
@@ -1,2 +1,3 @@
 # This file is here in case we need to quickly add a constraint to
 # fix CI jobs.
+setuptools<80.3.0

--- a/e2e/test_bootstrap.sh
+++ b/e2e/test_bootstrap.sh
@@ -12,6 +12,7 @@ source "$SCRIPTDIR/common.sh"
 
 # passing settings to bootstrap but should have 0 effect on it
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --log-file="$OUTDIR/bootstrap.log" \
   --error-log-file="$OUTDIR/fromager-errors.log" \
   --sdists-repo="$OUTDIR/sdists-repo" \

--- a/e2e/test_bootstrap_build_tags.sh
+++ b/e2e/test_bootstrap_build_tags.sh
@@ -8,6 +8,7 @@ source "$SCRIPTDIR/common.sh"
 
 # bootstrap stevedore with 1 change log
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --log-file="$OUTDIR/bootstrap1.log" \
   --error-log-file="$OUTDIR/fromager-errors.log" \
   --sdists-repo="$OUTDIR/sdists-repo" \
@@ -47,6 +48,7 @@ start_local_wheel_server
 
 LOGFILE="$OUTDIR/bootstrap2.log"
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --log-file="$LOGFILE" \
   --error-log-file="$OUTDIR/fromager-errors.log" \
   --sdists-repo="$OUTDIR/sdists-repo" \
@@ -69,6 +71,7 @@ find "$OUTDIR/wheels-repo"
 
 LOGFILE="$OUTDIR/bootstrap3.log"
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --log-file="$LOGFILE" \
   --error-log-file="$OUTDIR/fromager-errors.log" \
   --sdists-repo="$OUTDIR/sdists-repo" \
@@ -87,6 +90,7 @@ $pass
 # bootstrap stevedore with 2 changelog. should result in a build instead of being skipped
 LOGFILE="$OUTDIR/bootstrap4.log"
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --log-file="$LOGFILE" \
   --error-log-file="$OUTDIR/fromager-errors.log" \
   --sdists-repo="$OUTDIR/sdists-repo" \

--- a/e2e/test_bootstrap_cache.sh
+++ b/e2e/test_bootstrap_cache.sh
@@ -14,6 +14,7 @@ VER=78.1.0
 # run fromager once to build wheels that can be used by a local wheel server
 
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --debug \
   --log-file="$OUTDIR/bootstrap.log" \
   --error-log-file="$OUTDIR/fromager-errors.log" \
@@ -32,6 +33,7 @@ rm -rf "$OUTDIR/wheels-repo/simple"
 rm "$OUTDIR/bootstrap.log"
 
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --debug \
   --log-file="$OUTDIR/bootstrap.log" \
   --error-log-file="$OUTDIR/fromager-errors.log" \
@@ -78,6 +80,7 @@ rm -rf "$OUTDIR/wheels-repo/download"
 rm "$OUTDIR/bootstrap.log"
 
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --debug \
   --log-file="$OUTDIR/bootstrap.log" \
   --error-log-file="$OUTDIR/fromager-errors.log" \

--- a/e2e/test_bootstrap_conflicting_requirements.sh
+++ b/e2e/test_bootstrap_conflicting_requirements.sh
@@ -12,6 +12,7 @@ source "$SCRIPTDIR/common.sh"
 
 # passing settings to bootstrap but should have 0 effect on it
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --log-file="$OUTDIR/bootstrap.log" \
   --error-log-file="$OUTDIR/fromager-errors.log" \
   --sdists-repo="$OUTDIR/sdists-repo" \

--- a/e2e/test_bootstrap_constraints.sh
+++ b/e2e/test_bootstrap_constraints.sh
@@ -11,7 +11,8 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$SCRIPTDIR/common.sh"
 
 constraints_file=$(mktemp)
-echo "stevedore==4.0.0" > "$constraints_file"
+cp "$SCRIPTDIR/constraints.txt" "$constraints_file"
+echo "stevedore==4.0.0" >> "$constraints_file"
 
 # passing settings to bootstrap but should have 0 effect on it
 fromager \

--- a/e2e/test_bootstrap_extras.sh
+++ b/e2e/test_bootstrap_extras.sh
@@ -7,6 +7,7 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$SCRIPTDIR/common.sh"
 
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --log-file="$OUTDIR/test.log" \
   --sdists-repo="$OUTDIR/sdists-repo" \
   --wheels-repo="$OUTDIR/wheels-repo" \

--- a/e2e/test_bootstrap_git_url.sh
+++ b/e2e/test_bootstrap_git_url.sh
@@ -9,6 +9,7 @@ source "$SCRIPTDIR/common.sh"
 GIT_REPO_URL="https://opendev.org/openstack/stevedore.git"
 
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --debug \
   --log-file="$OUTDIR/bootstrap.log" \
   --error-log-file="$OUTDIR/fromager-errors.log" \

--- a/e2e/test_bootstrap_git_url_tag.sh
+++ b/e2e/test_bootstrap_git_url_tag.sh
@@ -9,6 +9,7 @@ source "$SCRIPTDIR/common.sh"
 GIT_REPO_URL="https://opendev.org/openstack/stevedore.git"
 
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --debug \
   --log-file="$OUTDIR/bootstrap.log" \
   --error-log-file="$OUTDIR/fromager-errors.log" \

--- a/e2e/test_bootstrap_prerelease.sh
+++ b/e2e/test_bootstrap_prerelease.sh
@@ -10,6 +10,7 @@ DIST="flit_core<2.0.1"
 
 # building flit_core 2.0 is not possible because it requires pytoml. we just care about resolution anyways
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --verbose \
   --log-file="$OUTDIR/bootstrap.log" \
   --sdists-repo="$OUTDIR/sdists-repo" \

--- a/e2e/test_bootstrap_sdist_only.sh
+++ b/e2e/test_bootstrap_sdist_only.sh
@@ -12,6 +12,7 @@ source "$SCRIPTDIR/common.sh"
 
 # passing settings to bootstrap but should have 0 effect on it
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --log-file="$OUTDIR/bootstrap.log" \
   --error-log-file="$OUTDIR/fromager-errors.log" \
   --sdists-repo="$OUTDIR/sdists-repo" \

--- a/e2e/test_build.sh
+++ b/e2e/test_build.sh
@@ -23,6 +23,7 @@ fi
 
 # Bootstrap the test project
 fromager \
+    --constraints-file="$SCRIPTDIR/constraints.txt" \
     $NETWORK_ISOLATION \
     --sdists-repo="$OUTDIR/sdists-repo" \
     --wheels-repo="$OUTDIR/wheels-repo" \
@@ -39,6 +40,7 @@ rm -r "$OUTDIR/wheels-repo/simple/stevedore"
 
 # Rebuild the wheel
 fromager \
+    --constraints-file="$SCRIPTDIR/constraints.txt" \
     --log-file="$OUTDIR/build.log" \
     --sdists-repo="$OUTDIR/sdists-repo" \
     --wheels-repo="$OUTDIR/wheels-repo" \

--- a/e2e/test_build_order.sh
+++ b/e2e/test_build_order.sh
@@ -12,6 +12,7 @@ VERSION="5.2.0"
 
 # Bootstrap the test project
 fromager \
+    --constraints-file="$SCRIPTDIR/constraints.txt" \
     --sdists-repo="$OUTDIR/sdists-repo" \
     --wheels-repo="$OUTDIR/wheels-repo" \
     --work-dir="$OUTDIR/work-dir" \
@@ -24,6 +25,7 @@ cp "$OUTDIR/work-dir/build-order.json" "$OUTDIR/"
 # Rebuild everything even if it already exists
 log="$OUTDIR/build-logs/${DIST}-build.log"
 fromager \
+    --constraints-file="$SCRIPTDIR/constraints.txt" \
     --log-file "$log" \
     --work-dir "$OUTDIR/work-dir" \
     --sdists-repo "$OUTDIR/sdists-repo" \

--- a/e2e/test_build_settings.sh
+++ b/e2e/test_build_settings.sh
@@ -16,6 +16,7 @@ pip install e2e/fromager_hooks
 
 # Bootstrap the test project
 fromager \
+    --constraints-file="$SCRIPTDIR/constraints.txt" \
     --sdists-repo="$OUTDIR/sdists-repo" \
     --wheels-repo="$OUTDIR/wheels-repo" \
     --work-dir="$OUTDIR/work-dir" \
@@ -31,6 +32,7 @@ rm -r "$OUTDIR/wheels-repo/simple/stevedore/"
 
 # Rebuild the wheel
 fromager \
+    --constraints-file="$SCRIPTDIR/constraints.txt" \
     --log-file="$OUTDIR/build.log" \
     --sdists-repo="$OUTDIR/sdists-repo" \
     --wheels-repo="$OUTDIR/wheels-repo" \

--- a/e2e/test_build_steps.sh
+++ b/e2e/test_build_steps.sh
@@ -13,6 +13,7 @@ VERSION="5.2.0"
 
 # Bootstrap the test project
 fromager \
+    --constraints-file="$SCRIPTDIR/constraints.txt" \
     --sdists-repo="$OUTDIR/sdists-repo" \
     --wheels-repo="$OUTDIR/wheels-repo" \
     --work-dir="$OUTDIR/work-dir" \
@@ -35,6 +36,7 @@ build_wheel() {
 
     # Download the source archive
     fromager \
+        --constraints-file="$SCRIPTDIR/constraints.txt" \
         --log-file "$OUTDIR/build-logs/${dist}-download-source-archive.log" \
         --work-dir "$OUTDIR/work-dir" \
         --sdists-repo "$OUTDIR/sdists-repo" \
@@ -43,6 +45,7 @@ build_wheel() {
 
     # Prepare the source dir for building
     fromager \
+        --constraints-file="$SCRIPTDIR/constraints.txt" \
         --log-file "$OUTDIR/build-logs/${dist}-prepare-source.log" \
         --work-dir "$OUTDIR/work-dir" \
         --sdists-repo "$OUTDIR/sdists-repo" \
@@ -51,6 +54,7 @@ build_wheel() {
 
     # Prepare the build environment
     fromager \
+        --constraints-file="$SCRIPTDIR/constraints.txt" \
         --log-file "$OUTDIR/build-logs/${dist}-prepare-build.log" \
         --work-dir "$OUTDIR/work-dir" \
         --sdists-repo "$OUTDIR/sdists-repo" \
@@ -59,6 +63,7 @@ build_wheel() {
 
     # Build an updated sdist
     fromager \
+        --constraints-file="$SCRIPTDIR/constraints.txt" \
         --log-file "$OUTDIR/build-logs/${dist}-build-sdist.log" \
         --work-dir "$OUTDIR/work-dir" \
         --sdists-repo "$OUTDIR/sdists-repo" \
@@ -67,6 +72,7 @@ build_wheel() {
 
     # Build the wheel
     fromager \
+        --constraints-file="$SCRIPTDIR/constraints.txt" \
         --log-file "$OUTDIR/build-logs/${dist}-prepare-build.log" \
         --work-dir "$OUTDIR/work-dir" \
         --sdists-repo "$OUTDIR/sdists-repo" \

--- a/e2e/test_download_sequence.sh
+++ b/e2e/test_download_sequence.sh
@@ -9,6 +9,7 @@ source "$SCRIPTDIR/common.sh"
 
 # Bootstrap the test project
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   -v \
   --sdists-repo="$OUTDIR/sdists-repo" \
   --wheels-repo="$OUTDIR/wheels-repo" \

--- a/e2e/test_elfdeps.sh
+++ b/e2e/test_elfdeps.sh
@@ -13,6 +13,7 @@ VERSION="2.1.5"
 
 # Bootstrap the test project
 fromager \
+    --constraints-file="$SCRIPTDIR/constraints.txt" \
     $NETWORK_ISOLATION \
     --verbose \
     --sdists-repo="$OUTDIR/sdists-repo" \

--- a/e2e/test_extra_metadata.sh
+++ b/e2e/test_extra_metadata.sh
@@ -7,6 +7,7 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$SCRIPTDIR/common.sh"
 
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --log-file="$OUTDIR/bootstrap.log" \
   --error-log-file="$OUTDIR/fromager-errors.log" \
   --sdists-repo="$OUTDIR/sdists-repo" \

--- a/e2e/test_meson.sh
+++ b/e2e/test_meson.sh
@@ -12,6 +12,7 @@ VERSION="1.5.0"
 
 # Bootstrap the test project
 fromager \
+    --constraints-file="$SCRIPTDIR/constraints.txt" \
     --sdists-repo="$OUTDIR/sdists-repo" \
     --wheels-repo="$OUTDIR/wheels-repo" \
     --work-dir="$OUTDIR/work-dir" \

--- a/e2e/test_optimize_build.sh
+++ b/e2e/test_optimize_build.sh
@@ -5,6 +5,7 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$SCRIPTDIR/common.sh"
 
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --sdists-repo="$OUTDIR/sdists-repo" \
   --wheels-repo="$OUTDIR/wheels-repo" \
   --work-dir="$OUTDIR/work-dir" \
@@ -22,6 +23,7 @@ rm -rf "$OUTDIR/wheels-repo/downloads"
 rm -rf "$OUTDIR/logfile.txt"
 
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --sdists-repo="$OUTDIR/sdists-repo" \
   --wheels-repo="$OUTDIR/wheels-repo" \
   --work-dir="$OUTDIR/work-dir" \
@@ -38,6 +40,7 @@ rm -rf "$OUTDIR/wheels-repo/downloads"
 rm -rf "$OUTDIR/logfile.txt"
 
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --sdists-repo="$OUTDIR/sdists-repo" \
   --wheels-repo="$OUTDIR/wheels-repo" \
   --work-dir="$OUTDIR/work-dir" \

--- a/e2e/test_override.sh
+++ b/e2e/test_override.sh
@@ -13,6 +13,7 @@ source "$SCRIPTDIR/common.sh"
 pip install e2e/flit_core_override
 
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --verbose \
   --log-file="$OUTDIR/bootstrap.log" \
   --sdists-repo="$OUTDIR/sdists-repo" \

--- a/e2e/test_pep517_build_sdist.sh
+++ b/e2e/test_pep517_build_sdist.sh
@@ -15,6 +15,7 @@ pip install e2e/stevedore_override
 
 # Download the source archive
 fromager \
+    --constraints-file="$SCRIPTDIR/constraints.txt" \
     --log-file "$OUTDIR/build-logs/${DIST}-download-source-archive.log" \
     --work-dir "$OUTDIR/work-dir" \
     --sdists-repo "$OUTDIR/sdists-repo" \
@@ -24,6 +25,7 @@ fromager \
 # Prepare the source dir for building
 rm -rf "$OUTDIR/work-dir/${DIST}*"
 fromager \
+    --constraints-file="$SCRIPTDIR/constraints.txt" \
     --log-file "$OUTDIR/build-logs/${DIST}-prepare-source.log" \
     --work-dir "$OUTDIR/work-dir" \
     --sdists-repo "$OUTDIR/sdists-repo" \
@@ -32,6 +34,7 @@ fromager \
 
 # Prepare the build environment
 fromager \
+    --constraints-file="$SCRIPTDIR/constraints.txt" \
     --log-file "$OUTDIR/build-logs/${DIST}-prepare-build.log" \
     --work-dir "$OUTDIR/work-dir" \
     --sdists-repo "$OUTDIR/sdists-repo" \
@@ -41,6 +44,7 @@ fromager \
 # Build an updated sdist
 rm -rf "$OUTDIR/sdists-repo/builds"
 fromager \
+    --constraints-file="$SCRIPTDIR/constraints.txt" \
     --log-file "$OUTDIR/build-logs/${DIST}-build-sdist.log" \
     --work-dir "$OUTDIR/work-dir" \
     --sdists-repo "$OUTDIR/sdists-repo" \

--- a/e2e/test_post_bootstrap_hook.sh
+++ b/e2e/test_post_bootstrap_hook.sh
@@ -15,7 +15,8 @@ pip install e2e/fromager_hooks
 
 # Bootstrap the project
 fromager \
-  --debug \
+    --constraints-file="$SCRIPTDIR/constraints.txt" \
+    --debug \
     --sdists-repo="$OUTDIR/sdists-repo" \
     --wheels-repo="$OUTDIR/wheels-repo" \
     --work-dir="$OUTDIR/work-dir" \

--- a/e2e/test_prebuilt_wheel_hook.sh
+++ b/e2e/test_prebuilt_wheel_hook.sh
@@ -15,6 +15,7 @@ pip install e2e/fromager_hooks
 
 # Bootstrap the test project
 fromager \
+    --constraints-file="$SCRIPTDIR/constraints.txt" \
     --sdists-repo="$OUTDIR/sdists-repo" \
     --wheels-repo="$OUTDIR/wheels-repo" \
     --work-dir="$OUTDIR/work-dir" \
@@ -29,6 +30,7 @@ rm -rf "$OUTDIR/wheels-repo"
 
 log="$OUTDIR/build-logs/${DIST}-build.log"
 fromager \
+    --constraints-file="$SCRIPTDIR/constraints.txt" \
     --log-file "$log" \
     --work-dir "$OUTDIR/work-dir" \
     --sdists-repo "$OUTDIR/sdists-repo" \

--- a/e2e/test_prebuilt_wheels_alt_server.sh
+++ b/e2e/test_prebuilt_wheels_alt_server.sh
@@ -16,6 +16,7 @@ VERSION="3.9.0"
 
 # Get the wheel we need from PyPI
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --sdists-repo="$INIT/sdists-repo" \
   --wheels-repo="$INIT/wheels-repo" \
   --work-dir="$INIT/work-dir" \
@@ -48,6 +49,7 @@ EOF
 # Bootstrap the package we modified, and another that we don't have on
 # the local server.
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   -v \
   --settings-dir="$TESTDIR/overrides/settings" \
   --sdists-repo="$INIT/sdists-repo" \

--- a/e2e/test_report_missing_dependency.sh
+++ b/e2e/test_report_missing_dependency.sh
@@ -12,6 +12,7 @@ DIST="stevedore"
 VERSION="5.2.0"
 
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --sdists-repo="$OUTDIR/sdists-repo" \
   --wheels-repo="$OUTDIR/wheels-repo" \
   --work-dir="$OUTDIR/work-dir" \
@@ -36,6 +37,7 @@ version=$(jq -r '.[] | select ( .dist == "'$DIST'" ) | .version' "$OUTDIR/work-d
 
 # Download the source archive
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --log-file "$OUTDIR/build-logs/download-source-archive.log" \
   --work-dir "$OUTDIR/work-dir" \
   --sdists-repo "$OUTDIR/sdists-repo" \
@@ -44,6 +46,7 @@ fromager \
 
 # Prepare the source dir for building
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --log-file "$OUTDIR/build-logs/prepare-source.log" \
   --work-dir "$OUTDIR/work-dir" \
   --sdists-repo "$OUTDIR/sdists-repo" \
@@ -53,6 +56,7 @@ fromager \
 # Prepare the build environment
 build_log="$OUTDIR/build-logs/prepare-build.log"
 fromager \
+  --constraints-file="$SCRIPTDIR/constraints.txt" \
   --log-file "$build_log" \
   --work-dir "$OUTDIR/work-dir" \
   --sdists-repo "$OUTDIR/sdists-repo" \

--- a/e2e/test_rust_vendor.sh
+++ b/e2e/test_rust_vendor.sh
@@ -14,6 +14,7 @@ VERSION="1.6.0"
 
 # Bootstrap the test project
 fromager \
+    --constraints-file="$SCRIPTDIR/constraints.txt" \
     $NETWORK_ISOLATION \
     --sdists-repo="$OUTDIR/sdists-repo" \
     --wheels-repo="$OUTDIR/wheels-repo" \

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ PyYAML
 rich
 requests
 resolvelib
-setuptools>=73.0.0 # https://github.com/pypa/setuptools/issues/4519
+setuptools>=73.0.0,<80.3.0 # https://github.com/pypa/setuptools/issues/4519
 stevedore
 tomlkit
 tqdm

--- a/src/fromager/build_environment.py
+++ b/src/fromager/build_environment.py
@@ -163,20 +163,13 @@ class BuildEnvironment:
             return
 
         logger.debug("creating build environment in %s", self.path)
-        # Python 3.12 virtual envs don't have wheel and setuptools by
-        # default. Some packages still assume they are installed.
+        # Use venv instead of virtualenv because virtualenv 20.31.0 broke
+        # compatibility by removing the --wheel commandline option.
         external_commands.run(
             [
                 sys.executable,
                 "-m",
-                "virtualenv",
-                "--python",
-                sys.executable,
-                "--pip=bundle",
-                "--setuptools=bundle",
-                "--wheel=bundle",
-                "--no-periodic-update",
-                "--no-download",
+                "venv",
                 str(self.path),
             ],
             network_isolation=self._ctx.network_isolation,

--- a/src/fromager/build_environment.py
+++ b/src/fromager/build_environment.py
@@ -194,6 +194,7 @@ class BuildEnvironment:
                 "--no-compile",  # don't compile byte code
                 "--only-binary",
                 ":all:",
+                "--no-cache-dir",
             ]
             + self._ctx.pip_wheel_server_args
             + self._ctx.pip_constraint_args


### PR DESCRIPTION
virtualenv 20.31.0 dropped the bundled wheel and broke backwards compatibility by removing the `--wheel` command line option. There's no particular reason for us to use virtualenv, so switch to the standard library module instead.