### PR TITLE
virtualenv 20.31.0 has dropped --wheel option

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ setuptools>=73.0.0 # https://github.com/pypa/setuptools/issues/4519
 stevedore
 tomlkit
 tqdm
-virtualenv<20.31.0
+virtualenv
 wheel

--- a/src/fromager/build_environment.py
+++ b/src/fromager/build_environment.py
@@ -174,7 +174,6 @@ class BuildEnvironment:
                 sys.executable,
                 "--pip=bundle",
                 "--setuptools=bundle",
-                "--wheel=bundle",
                 "--no-periodic-update",
                 "--no-download",
                 str(self.path),


### PR DESCRIPTION
Most recent virtualenv version has removed the `--wheel` option and the bundled `wheel` package. Setuptools can now build wheels without the wheels package.

Uncap `virtualenv` package again.