### PR TITLE
Log variant name in a few places

### DIFF
--- a/src/fromager/bootstrapper.py
+++ b/src/fromager/bootstrapper.py
@@ -337,7 +337,7 @@ class Bootstrapper:
             req, resolved_version, sdist_root_dir, build_dependencies
         )
 
-        logger.info(f"starting build of {self._explain}")
+        logger.info(f"starting build of {self._explain} for {self.ctx.variant}")
         built_filename = wheels.build_wheel(
             ctx=self.ctx,
             req=req,

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -607,7 +607,7 @@ def build_sdist(
     pbi = ctx.package_build_info(req)
     build_dir = pbi.build_dir(sdist_root_dir)
 
-    logger.info(f"building source distribution in {build_dir}")
+    logger.info(f"building {ctx.variant} source distribution for {req} in {build_dir}")
     extra_environ = pbi.get_extra_environ(build_env=build_env)
     if req.url:
         # The default approach to making an sdist is to make a tarball from the

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -258,7 +258,8 @@ def build_wheel(
 ) -> pathlib.Path:
     pbi = ctx.package_build_info(req)
     logger.info(
-        f"building wheel for {req} in {sdist_root_dir} writing to {ctx.wheels_build}"
+        f"building {ctx.variant} wheel for {req} in {sdist_root_dir} "
+        f"writing to {ctx.wheels_build}"
     )
 
     # add package and variant env vars, package's parallel job vars, and


### PR DESCRIPTION
Include the variant name in log lines of a few steps like sdist and wheel builds. This is useful when running multiple builds in parallel. In downstream we currently rely on the fact that builds have the variant name in some paths. This causes problems with caching and will go away.