### PR TITLE
Replaceing the metadata parser from packaging.metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "elfdeps>=0.2.0",
     "license-expression",
     "packaging",
-    "pkginfo",
     "psutil",
     "pydantic",
     "pypi_simple",
@@ -204,7 +203,7 @@ exclude = [
 
 [[tool.mypy.overrides]]
 # packages without typing annotations and stubs
-module = ["license_expression", "pyproject_hooks", "requests_mock", "resolver", "stevedore"]
+module = ["hatchling", "hatchling.build", "license_expression", "pyproject_hooks", "requests_mock", "resolver", "stevedore"]
 ignore_missing_imports = true
 
 [tool.basedpyright]

--- a/src/fromager/bootstrapper.py
+++ b/src/fromager/bootstrapper.py
@@ -12,7 +12,6 @@ import shutil
 import tempfile
 import typing
 import zipfile
-from email.parser import BytesParser
 from urllib.parse import urlparse
 
 from packaging.requirements import Requirement
@@ -1234,10 +1233,10 @@ class Bootstrapper:
             config_settings=pbi.config_settings,
         )
         metadata_filename = source_dir.parent / metadata_dir_base / "METADATA"
-        with open(metadata_filename, "rb") as f:
-            p = BytesParser()
-            metadata = p.parse(f, headersonly=True)
-        return Version(metadata["Version"])
+        # Disable validation because some packages have metadata version mismatches
+        # (e.g., declaring Metadata-Version: 2.2 but using fields from 2.4).
+        metadata = dependencies.parse_metadata(metadata_filename, validate=False)
+        return metadata.version
 
     def _create_unpack_dir(
         self, req: Requirement, resolved_version: Version

--- a/tests/test_pep658_support.py
+++ b/tests/test_pep658_support.py
@@ -57,10 +57,11 @@ Requires-Dist: requests >= 2.0.0
         metadata = get_metadata_for_wheel(wheel_url, metadata_url)
 
         # Verify the metadata was parsed correctly
-        assert metadata["Name"] == "test-package"
-        assert metadata["Version"] == "1.0.0"
-        assert metadata["Summary"] == "A test package"
-        assert "requests >= 2.0.0" in metadata.get_all("Requires-Dist", [])
+        assert metadata.name == "test-package"
+        assert str(metadata.version) == "1.0.0"
+        assert metadata.summary == "A test package"
+        assert metadata.requires_dist is not None
+        assert any(str(req) == "requests>=2.0.0" for req in metadata.requires_dist)
 
         # Verify only the metadata URL was called, not the wheel URL
         mock_session.get.assert_called_once_with(metadata_url)


### PR DESCRIPTION
 Replaces the Python email library parser with packaging.metadata.Metadata for parsing wheel/package metadata.


Fixes https://github.com/python-wheel-build/fromager/issues/561