### PR TITLE
do not use bundled setuptools in virtualenvs

### DIFF
--- a/src/fromager/build_environment.py
+++ b/src/fromager/build_environment.py
@@ -163,8 +163,6 @@ class BuildEnvironment:
             return
 
         logger.debug("creating build environment in %s", self.path)
-        # Python 3.12 virtual envs don't have wheel and setuptools by
-        # default. Some packages still assume they are installed.
         external_commands.run(
             [
                 sys.executable,
@@ -173,7 +171,7 @@ class BuildEnvironment:
                 "--python",
                 sys.executable,
                 "--pip=bundle",
-                "--setuptools=bundle",
+                "--setuptools=none",
                 "--no-periodic-update",
                 "--no-download",
                 str(self.path),


### PR DESCRIPTION
Remove the flag that causes us to use a bundled version of setuptools in the build virtualenv. That version is too old to build some packages, especially in the face of recent breaking changes that have been worked around in things that use setuptools.

Instead of using the bundled version, rely on the fact that in src/fromager/dependencies.py we set the default build backend requirements to include setuptools if there is no valid information in the pyproject.toml. This should ensure that we detect setuptools as a dependency of projects that are likely to use it because it is the default backend.