### PR TITLE
require review from maintainer

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -112,8 +112,10 @@ pull_request_rules:
           - check-success=e2e (3.12, 1.75, rust_vendor, macos-latest)
           - check-success=e2e (3.12, 1.75, rust_vendor, ubuntu-latest)
 
-          # At least 1 reviewer
-          - "#approved-reviews-by>=1"
+          # At least 1 reviewer from maintainers
+          - and:
+            - author=@python-wheel-build/fromager-maintainers
+            - "#approved-reviews-by>=1"
 
     actions:
       merge:


### PR DESCRIPTION
We have many members of the org who are not active maintainers of fromager. This change limits the auto-merge rule for mergify to look for reviews with approvals from maintainers.