### PR TITLE
Detect requirement conflict

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -94,6 +94,7 @@ jobs:
           - build_order
           - build_steps
           - build_settings
+          - graph_to_constraints
           - meson
           - migrate_graph
           - override

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,6 +27,7 @@ pull_request_rules:
     conditions:
       - and:
           - "-draft"
+
           - check-success=e2e (3.11, 1.75, bootstrap, ubuntu-latest)
           - check-success=e2e (3.11, 1.75, bootstrap_build_tags, ubuntu-latest)
           - check-success=e2e (3.11, 1.75, bootstrap_cache, ubuntu-latest)
@@ -45,6 +46,7 @@ pull_request_rules:
           - check-success=e2e (3.11, 1.75, download_sequence, ubuntu-latest)
           - check-success=e2e (3.11, 1.75, elfdeps, ubuntu-latest)
           - check-success=e2e (3.11, 1.75, extra_metadata, ubuntu-latest)
+          - check-success=e2e (3.11, 1.75, graph_to_constraints, ubuntu-latest)
           - check-success=e2e (3.11, 1.75, lint_requirements, ubuntu-latest)
           - check-success=e2e (3.11, 1.75, meson, ubuntu-latest)
           - check-success=e2e (3.11, 1.75, migrate_graph, ubuntu-latest)
@@ -92,6 +94,8 @@ pull_request_rules:
           - check-success=e2e (3.12, 1.75, elfdeps, ubuntu-latest)
           - check-success=e2e (3.12, 1.75, extra_metadata, macos-latest)
           - check-success=e2e (3.12, 1.75, extra_metadata, ubuntu-latest)
+          - check-success=e2e (3.12, 1.75, graph_to_constraints, macos-latest)
+          - check-success=e2e (3.12, 1.75, graph_to_constraints, ubuntu-latest)
           - check-success=e2e (3.12, 1.75, lint_requirements, macos-latest)
           - check-success=e2e (3.12, 1.75, lint_requirements, ubuntu-latest)
           - check-success=e2e (3.12, 1.75, meson, macos-latest)

--- a/e2e/graph-with-dependency-conflict.json
+++ b/e2e/graph-with-dependency-conflict.json
@@ -1,0 +1,9116 @@
+{
+  "": {
+    "download_url": "",
+    "pre_built": false,
+    "version": "0",
+    "canonicalized_name": "",
+    "edges": [
+      {
+        "key": "vllm==0.6.4.post1",
+        "req_type": "toplevel",
+        "req": "vllm[cuda]==0.6.4.post1"
+      },
+      {
+        "key": "huggingface-hub==0.30.1",
+        "req_type": "toplevel",
+        "req": "huggingface-hub[hf-transfer]"
+      },
+      {
+        "key": "instructlab==0.23.5",
+        "req_type": "toplevel",
+        "req": "instructlab[cuda]==0.23.5"
+      },
+      {
+        "key": "instructlab-sdg==0.7.2",
+        "req_type": "toplevel",
+        "req": "instructlab-sdg==0.7.2"
+      },
+      {
+        "key": "kfp==2.11.0",
+        "req_type": "toplevel",
+        "req": "kfp==2.11.0"
+      },
+      {
+        "key": "docling==2.28.4",
+        "req_type": "toplevel",
+        "req": "docling==2.28.4"
+      },
+      {
+        "key": "docling-parse==4.0.0",
+        "req_type": "toplevel",
+        "req": "docling-parse==4.0.0"
+      }
+    ]
+  },
+  "docling-parse==4.0.0": {
+    "download_url": "https://files.pythonhosted.org/packages/1c/49/c722b719882442f909d254c33ed8d0ff87e72bee6dc50e0dc3ba9a9a7519/docling_parse-4.0.0.tar.gz#sha256=5be0ba4e0098524f116743e6b709f29fe273e441e61923c3a262e054643c5ee6",
+    "pre_built": false,
+    "version": "4.0.0",
+    "canonicalized_name": "docling-parse",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core"
+      },
+      {
+        "key": "pybind11==2.13.6",
+        "req_type": "build-system",
+        "req": "pybind11>=2.13.1"
+      },
+      {
+        "key": "docling-core==2.25.0",
+        "req_type": "install",
+        "req": "docling-core<3.0.0,>=2.23.0"
+      },
+      {
+        "key": "pillow==11.1.0",
+        "req_type": "install",
+        "req": "pillow<12.0.0,>=10.0.0"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic<3.0.0,>=2.0.0"
+      },
+      {
+        "key": "tabulate==0.9.0",
+        "req_type": "install",
+        "req": "tabulate<1.0.0,>=0.9.0"
+      }
+    ]
+  },
+  "tabulate==0.9.0": {
+    "download_url": "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz#sha256=0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c",
+    "pre_built": false,
+    "version": "0.9.0",
+    "canonicalized_name": "tabulate",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=61.2.0"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm[toml]>=3.4.3"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      }
+    ]
+  },
+  "wheel==0.45.1": {
+    "download_url": "https://files.pythonhosted.org/packages/8a/98/2d9906746cdc6a6ef809ae6338005b3f21bb568bea3165cfc6a243fdc25c/wheel-0.45.1.tar.gz#sha256=661e1abd9198507b1409a20c02106d9670b2576e916d58f520316666abca6729",
+    "pre_built": false,
+    "version": "0.45.1",
+    "canonicalized_name": "wheel",
+    "edges": [
+      {
+        "key": "flit-core==3.10.1",
+        "req_type": "build-system",
+        "req": "flit_core<4,>=3.8"
+      }
+    ]
+  },
+  "flit-core==3.10.1": {
+    "download_url": "https://files.pythonhosted.org/packages/d5/ae/09427bea9227a33ec834ed5461432752fd5d02b14f93dd68406c91684622/flit_core-3.10.1.tar.gz#sha256=66e5b87874a0d6e39691f0e22f09306736b633548670ad3c09ec9db03c5662f7",
+    "pre_built": false,
+    "version": "3.10.1",
+    "canonicalized_name": "flit-core",
+    "edges": []
+  },
+  "setuptools-scm==8.1.0": {
+    "download_url": "https://files.pythonhosted.org/packages/4f/a4/00a9ac1b555294710d4a68d2ce8dfdf39d72aa4d769a7395d05218d88a42/setuptools_scm-8.1.0.tar.gz#sha256=42dea1b65771cba93b7a515d65a65d8246e560768a66b9106a592c8e7f26c8a7",
+    "pre_built": false,
+    "version": "8.1.0",
+    "canonicalized_name": "setuptools-scm",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=61"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging>=20"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "install",
+        "req": "setuptools"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=61"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging>=20"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "install",
+        "req": "setuptools"
+      }
+    ]
+  },
+  "setuptools==75.8.0": {
+    "download_url": "https://files.pythonhosted.org/packages/92/ec/089608b791d210aec4e7f97488e67ab0d33add3efccb83a056cbafe3a2a6/setuptools-75.8.0.tar.gz#sha256=c5afc8f407c626b8313a86e10311dd3f661c6cd9c09d4bf8c15c0e11f9f2b0e6",
+    "pre_built": false,
+    "version": "75.8.0",
+    "canonicalized_name": "setuptools",
+    "edges": []
+  },
+  "packaging==24.2": {
+    "download_url": "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz#sha256=c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f",
+    "pre_built": false,
+    "version": "24.2",
+    "canonicalized_name": "packaging",
+    "edges": [
+      {
+        "key": "flit-core==3.10.1",
+        "req_type": "build-system",
+        "req": "flit_core>=3.3"
+      }
+    ]
+  },
+  "pydantic==2.9.2": {
+    "download_url": "https://files.pythonhosted.org/packages/a9/b7/d9e3f12af310e1120c21603644a1cd86f59060e040ec5c3a80b8f05fae30/pydantic-2.9.2.tar.gz#sha256=d155cef71265d1e9807ed1c32b4c8deec042a44a50a4188b25ac67ecd81a9c0f",
+    "pre_built": false,
+    "version": "2.9.2",
+    "canonicalized_name": "pydantic",
+    "edges": [
+      {
+        "key": "hatch-fancy-pypi-readme==24.1.0",
+        "req_type": "build-system",
+        "req": "hatch-fancy-pypi-readme>=22.5.0"
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      },
+      {
+        "key": "annotated-types==0.7.0",
+        "req_type": "install",
+        "req": "annotated-types>=0.6.0"
+      },
+      {
+        "key": "pydantic-core==2.23.4",
+        "req_type": "install",
+        "req": "pydantic-core==2.23.4"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions>=4.6.1; python_version < \"3.13\""
+      }
+    ]
+  },
+  "typing-extensions==4.12.2": {
+    "download_url": "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz#sha256=1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8",
+    "pre_built": false,
+    "version": "4.12.2",
+    "canonicalized_name": "typing-extensions",
+    "edges": [
+      {
+        "key": "flit-core==3.10.1",
+        "req_type": "build-system",
+        "req": "flit_core<4,>=3.4"
+      }
+    ]
+  },
+  "pydantic-core==2.23.4": {
+    "download_url": "https://files.pythonhosted.org/packages/e2/aa/6b6a9b9f8537b872f552ddd46dd3da230367754b6f707b8e1e963f515ea3/pydantic_core-2.23.4.tar.gz#sha256=2584f7cf844ac4d970fba483a717dbe10c1c1c96a969bf65d61ffe94df1b2863",
+    "pre_built": false,
+    "version": "2.23.4",
+    "canonicalized_name": "pydantic-core",
+    "edges": [
+      {
+        "key": "maturin==1.8.1",
+        "req_type": "build-system",
+        "req": "maturin<2,>=1"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "build-system",
+        "req": "typing-extensions!=4.7.0,>=4.6.0"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions!=4.7.0,>=4.6.0"
+      }
+    ]
+  },
+  "maturin==1.8.1": {
+    "download_url": "https://files.pythonhosted.org/packages/9a/08/ccb0f917722a35ab0d758be9bb5edaf645c3a3d6170061f10d396ecd273f/maturin-1.8.1.tar.gz#sha256=49cd964aabf59f8b0a6969f9860d2cdf194ac331529caae14c884f5659568857",
+    "pre_built": false,
+    "version": "1.8.1",
+    "canonicalized_name": "maturin",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      },
+      {
+        "key": "setuptools-rust==1.10.2",
+        "req_type": "build-system",
+        "req": "setuptools-rust>=1.4.0"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel>=0.36.2"
+      }
+    ]
+  },
+  "setuptools-rust==1.10.2": {
+    "download_url": "https://files.pythonhosted.org/packages/d3/6b/99a1588d826ceb108694ba00f78bc6afda10ed5d72d550ae8f256af1f7b4/setuptools_rust-1.10.2.tar.gz#sha256=5d73e7eee5f87a6417285b617c97088a7c20d1a70fcea60e3bdc94ff567c29dc",
+    "pre_built": false,
+    "version": "1.10.2",
+    "canonicalized_name": "setuptools-rust",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=62.4"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm"
+      },
+      {
+        "key": "semantic-version==2.10.0",
+        "req_type": "install",
+        "req": "semantic-version<3,>=2.8.2"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "install",
+        "req": "setuptools>=62.4"
+      }
+    ]
+  },
+  "semantic-version==2.10.0": {
+    "download_url": "https://files.pythonhosted.org/packages/7d/31/f2289ce78b9b473d582568c234e104d2a342fd658cc288a7553d83bb8595/semantic_version-2.10.0.tar.gz#sha256=bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c",
+    "pre_built": false,
+    "version": "2.10.0",
+    "canonicalized_name": "semantic-version",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "annotated-types==0.7.0": {
+    "download_url": "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz#sha256=aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89",
+    "pre_built": false,
+    "version": "0.7.0",
+    "canonicalized_name": "annotated-types",
+    "edges": [
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      }
+    ]
+  },
+  "hatchling==1.27.0": {
+    "download_url": "https://files.pythonhosted.org/packages/8f/8a/cc1debe3514da292094f1c3a700e4ca25442489731ef7c0814358816bb03/hatchling-1.27.0.tar.gz#sha256=971c296d9819abb3811112fc52c7a9751c8d381898f36533bb16f9791e941fd6",
+    "pre_built": false,
+    "version": "1.27.0",
+    "canonicalized_name": "hatchling",
+    "edges": [
+      {
+        "key": "packaging==24.2",
+        "req_type": "build-backend",
+        "req": "packaging>=24.2"
+      },
+      {
+        "key": "pathspec==0.12.1",
+        "req_type": "build-backend",
+        "req": "pathspec>=0.10.1"
+      },
+      {
+        "key": "pluggy==1.5.0",
+        "req_type": "build-backend",
+        "req": "pluggy>=1.0.0"
+      },
+      {
+        "key": "trove-classifiers==2025.1.15.22",
+        "req_type": "build-backend",
+        "req": "trove-classifiers"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "build-sdist",
+        "req": "packaging>=24.2"
+      },
+      {
+        "key": "pathspec==0.12.1",
+        "req_type": "build-sdist",
+        "req": "pathspec>=0.10.1"
+      },
+      {
+        "key": "pluggy==1.5.0",
+        "req_type": "build-sdist",
+        "req": "pluggy>=1.0.0"
+      },
+      {
+        "key": "trove-classifiers==2025.1.15.22",
+        "req_type": "build-sdist",
+        "req": "trove-classifiers"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging>=24.2"
+      },
+      {
+        "key": "pathspec==0.12.1",
+        "req_type": "install",
+        "req": "pathspec>=0.10.1"
+      },
+      {
+        "key": "pluggy==1.5.0",
+        "req_type": "install",
+        "req": "pluggy>=1.0.0"
+      },
+      {
+        "key": "trove-classifiers==2025.1.15.22",
+        "req_type": "install",
+        "req": "trove-classifiers"
+      }
+    ]
+  },
+  "trove-classifiers==2025.1.15.22": {
+    "download_url": "https://files.pythonhosted.org/packages/f3/cb/8f6a91c74049180e395590901834d68bef5d6a2ce4c9ca9792cfadc1b9b4/trove_classifiers-2025.1.15.22.tar.gz#sha256=90af74358d3a01b3532bc7b3c88d8c6a094c2fd50a563d13d9576179326d7ed9",
+    "pre_built": false,
+    "version": "2025.1.15.22",
+    "canonicalized_name": "trove-classifiers",
+    "edges": [
+      {
+        "key": "calver==2022.6.26",
+        "req_type": "build-system",
+        "req": "calver"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      },
+      {
+        "key": "calver==2022.6.26",
+        "req_type": "build-backend",
+        "req": "calver"
+      },
+      {
+        "key": "calver==2022.6.26",
+        "req_type": "build-sdist",
+        "req": "calver"
+      }
+    ]
+  },
+  "calver==2022.6.26": {
+    "download_url": "https://files.pythonhosted.org/packages/b5/00/96cbed7c019c49ee04b8a08357a981983db7698ae6de402e57097cefc9ad/calver-2022.6.26.tar.gz#sha256=e05493a3b17517ef1748fbe610da11f10485faa7c416b9d33fd4a52d74894f8b",
+    "pre_built": false,
+    "version": "2022.6.26",
+    "canonicalized_name": "calver",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      }
+    ]
+  },
+  "pluggy==1.5.0": {
+    "download_url": "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz#sha256=2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1",
+    "pre_built": false,
+    "version": "1.5.0",
+    "canonicalized_name": "pluggy",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=45.0"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools-scm[toml]>=6.2.3"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-backend",
+        "req": "setuptools-scm"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-sdist",
+        "req": "setuptools-scm"
+      }
+    ]
+  },
+  "pathspec==0.12.1": {
+    "download_url": "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz#sha256=a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712",
+    "pre_built": false,
+    "version": "0.12.1",
+    "canonicalized_name": "pathspec",
+    "edges": [
+      {
+        "key": "flit-core==3.10.1",
+        "req_type": "build-system",
+        "req": "flit_core<4,>=3.2"
+      }
+    ]
+  },
+  "hatch-fancy-pypi-readme==24.1.0": {
+    "download_url": "https://files.pythonhosted.org/packages/b4/c2/c9094283a07dd96c5a8f7a5f1910259d40d2e29223b95dd875a6ca13b58f/hatch_fancy_pypi_readme-24.1.0.tar.gz#sha256=44dd239f1a779b9dcf8ebc9401a611fd7f7e3e14578dcf22c265dfaf7c1514b8",
+    "pre_built": false,
+    "version": "24.1.0",
+    "canonicalized_name": "hatch-fancy-pypi-readme",
+    "edges": [
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "install",
+        "req": "hatchling"
+      }
+    ]
+  },
+  "pillow==11.1.0": {
+    "download_url": "https://files.pythonhosted.org/packages/f3/af/c097e544e7bd278333db77933e535098c259609c4eb3b85381109602fb5b/pillow-11.1.0.tar.gz#sha256=368da70808b36d73b4b390a8ffac11069f8a5c85f29eff1f1b01bcf3ef5b2a20",
+    "pre_built": false,
+    "version": "11.1.0",
+    "canonicalized_name": "pillow",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=67.8"
+      }
+    ]
+  },
+  "docling-core==2.25.0": {
+    "download_url": "https://files.pythonhosted.org/packages/cb/2a/648888b26d8382ad604ed346773b3e8b5a79c98885f7cc027384ecc98bac/docling_core-2.25.0.tar.gz#sha256=a2019392592840b2829082ef0c1d1a9096fb3512ae44c3a93dc04a5eaef81b2f",
+    "pre_built": false,
+    "version": "2.25.0",
+    "canonicalized_name": "docling-core",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0"
+      },
+      {
+        "key": "jsonref==1.1.0",
+        "req_type": "install",
+        "req": "jsonref<2.0.0,>=1.1.0"
+      },
+      {
+        "key": "jsonschema==4.23.0",
+        "req_type": "install",
+        "req": "jsonschema<5.0.0,>=4.16.0"
+      },
+      {
+        "key": "latex2mathml==3.77.0",
+        "req_type": "install",
+        "req": "latex2mathml<4.0.0,>=3.77.0"
+      },
+      {
+        "key": "pandas==2.2.3",
+        "req_type": "install",
+        "req": "pandas<3.0.0,>=2.1.4"
+      },
+      {
+        "key": "pillow==10.4.0",
+        "req_type": "install",
+        "req": "pillow<12.0.0,>=10.0.0"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic!=2.10.0,!=2.10.1,!=2.10.2,<3.0.0,>=2.6.0"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml<7.0.0,>=5.1"
+      },
+      {
+        "key": "semchunk==2.2.2",
+        "req_type": "install",
+        "req": "semchunk<3.0.0,>=2.2.0; extra == \"chunking\""
+      },
+      {
+        "key": "tabulate==0.9.0",
+        "req_type": "install",
+        "req": "tabulate<0.10.0,>=0.9.0"
+      },
+      {
+        "key": "transformers==4.48.1",
+        "req_type": "install",
+        "req": "transformers<5.0.0,>=4.34.0; extra == \"chunking\""
+      },
+      {
+        "key": "typer==0.12.5",
+        "req_type": "install",
+        "req": "typer<0.13.0,>=0.12.5"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions<5.0.0,>=4.12.2"
+      },
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0"
+      },
+      {
+        "key": "jsonref==1.1.0",
+        "req_type": "install",
+        "req": "jsonref<2.0.0,>=1.1.0"
+      },
+      {
+        "key": "jsonschema==4.23.0",
+        "req_type": "install",
+        "req": "jsonschema<5.0.0,>=4.16.0"
+      },
+      {
+        "key": "latex2mathml==3.77.0",
+        "req_type": "install",
+        "req": "latex2mathml<4.0.0,>=3.77.0"
+      },
+      {
+        "key": "pandas==2.2.3",
+        "req_type": "install",
+        "req": "pandas<3.0.0,>=2.1.4"
+      },
+      {
+        "key": "pillow==10.4.0",
+        "req_type": "install",
+        "req": "pillow<12.0.0,>=10.0.0"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic!=2.10.0,!=2.10.1,!=2.10.2,<3.0.0,>=2.6.0"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml<7.0.0,>=5.1"
+      },
+      {
+        "key": "tabulate==0.9.0",
+        "req_type": "install",
+        "req": "tabulate<0.10.0,>=0.9.0"
+      },
+      {
+        "key": "typer==0.12.5",
+        "req_type": "install",
+        "req": "typer<0.13.0,>=0.12.5"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions<5.0.0,>=4.12.2"
+      }
+    ]
+  },
+  "typer==0.12.5": {
+    "download_url": "https://files.pythonhosted.org/packages/c5/58/a79003b91ac2c6890fc5d90145c662fd5771c6f11447f116b63300436bc9/typer-0.12.5.tar.gz#sha256=f592f089bedcc8ec1b974125d64851029c3b1af145f04aca64d69410f0c9b722",
+    "pre_built": false,
+    "version": "0.12.5",
+    "canonicalized_name": "typer",
+    "edges": [
+      {
+        "key": "pdm-backend==2.4.3",
+        "req_type": "build-system",
+        "req": "pdm-backend"
+      },
+      {
+        "key": "click==8.1.8",
+        "req_type": "install",
+        "req": "click>=8.0.0"
+      },
+      {
+        "key": "rich==13.9.4",
+        "req_type": "install",
+        "req": "rich>=10.11.0"
+      },
+      {
+        "key": "shellingham==1.5.4",
+        "req_type": "install",
+        "req": "shellingham>=1.3.0"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions>=3.7.4.3"
+      }
+    ]
+  },
+  "shellingham==1.5.4": {
+    "download_url": "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz#sha256=8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de",
+    "pre_built": false,
+    "version": "1.5.4",
+    "canonicalized_name": "shellingham",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      }
+    ]
+  },
+  "rich==13.9.4": {
+    "download_url": "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz#sha256=439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098",
+    "pre_built": false,
+    "version": "13.9.4",
+    "canonicalized_name": "rich",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0"
+      },
+      {
+        "key": "markdown-it-py==3.0.0",
+        "req_type": "install",
+        "req": "markdown-it-py>=2.2.0"
+      },
+      {
+        "key": "pygments==2.19.1",
+        "req_type": "install",
+        "req": "pygments<3.0.0,>=2.13.0"
+      }
+    ]
+  },
+  "pygments==2.19.1": {
+    "download_url": "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz#sha256=61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f",
+    "pre_built": false,
+    "version": "2.19.1",
+    "canonicalized_name": "pygments",
+    "edges": [
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      }
+    ]
+  },
+  "markdown-it-py==3.0.0": {
+    "download_url": "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz#sha256=e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb",
+    "pre_built": false,
+    "version": "3.0.0",
+    "canonicalized_name": "markdown-it-py",
+    "edges": [
+      {
+        "key": "flit-core==3.10.1",
+        "req_type": "build-system",
+        "req": "flit_core<4,>=3.4"
+      },
+      {
+        "key": "mdurl==0.1.2",
+        "req_type": "install",
+        "req": "mdurl~=0.1"
+      }
+    ]
+  },
+  "mdurl==0.1.2": {
+    "download_url": "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz#sha256=bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba",
+    "pre_built": false,
+    "version": "0.1.2",
+    "canonicalized_name": "mdurl",
+    "edges": [
+      {
+        "key": "flit-core==3.10.1",
+        "req_type": "build-system",
+        "req": "flit_core<4,>=3.2.0"
+      }
+    ]
+  },
+  "poetry-core==2.0.1": {
+    "download_url": "https://files.pythonhosted.org/packages/c4/f5/89d11008714e0a49cab9cba7cce89c66ea5a94f37cc6d283798cc1725fac/poetry_core-2.0.1.tar.gz#sha256=10177c2772469d9032a49f0d8707af761b1c597cea3b4fb31546e5cd436eb157",
+    "pre_built": false,
+    "version": "2.0.1",
+    "canonicalized_name": "poetry-core",
+    "edges": []
+  },
+  "click==8.1.8": {
+    "download_url": "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz#sha256=ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a",
+    "pre_built": false,
+    "version": "8.1.8",
+    "canonicalized_name": "click",
+    "edges": [
+      {
+        "key": "flit-core==3.10.1",
+        "req_type": "build-system",
+        "req": "flit_core<4"
+      }
+    ]
+  },
+  "pdm-backend==2.4.3": {
+    "download_url": "https://files.pythonhosted.org/packages/d9/bf/d75d568521cef171ae9138d9ab55c169a98ee803853ca87b7096e4636d5b/pdm_backend-2.4.3.tar.gz#sha256=dbd9047a7ac10d11a5227e97163b617ad5d665050476ff63867d971758200728",
+    "pre_built": false,
+    "version": "2.4.3",
+    "canonicalized_name": "pdm-backend",
+    "edges": []
+  },
+  "pyyaml==6.0.2": {
+    "download_url": "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz#sha256=d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e",
+    "pre_built": false,
+    "version": "6.0.2",
+    "canonicalized_name": "pyyaml",
+    "edges": [
+      {
+        "key": "cython==3.0.11",
+        "req_type": "build-system",
+        "req": "Cython; python_version < \"3.13\""
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      }
+    ]
+  },
+  "cython==3.0.11": {
+    "download_url": "https://files.pythonhosted.org/packages/84/4d/b720d6000f4ca77f030bd70f12550820f0766b568e43f11af7f7ad9061aa/cython-3.0.11.tar.gz#sha256=7146dd2af8682b4ca61331851e6aebce9fe5158e75300343f80c07ca80b1faff",
+    "pre_built": false,
+    "version": "3.0.11",
+    "canonicalized_name": "cython",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "pillow==10.4.0": {
+    "download_url": "https://files.pythonhosted.org/packages/cd/74/ad3d526f3bf7b6d3f408b73fde271ec69dfac8b81341a318ce825f2b3812/pillow-10.4.0.tar.gz#sha256=166c1cd4d24309b30d61f79f4a9114b7b2313d7450912277855ff5dfd7cd4a06",
+    "pre_built": false,
+    "version": "10.4.0",
+    "canonicalized_name": "pillow",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=67.8"
+      }
+    ]
+  },
+  "pandas==2.2.3": {
+    "download_url": "https://files.pythonhosted.org/packages/9c/d6/9f8431bacc2e19dca897724cd097b1bb224a6ad5433784a44b587c7c13af/pandas-2.2.3.tar.gz#sha256=4f18ba62b61d7e192368b84517265a99b4d7ee8912f8708660fb4a366cc82667",
+    "pre_built": false,
+    "version": "2.2.3",
+    "canonicalized_name": "pandas",
+    "edges": [
+      {
+        "key": "cython==3.0.11",
+        "req_type": "build-system",
+        "req": "Cython~=3.0.5"
+      },
+      {
+        "key": "meson==1.2.1",
+        "req_type": "build-system",
+        "req": "meson==1.2.1"
+      },
+      {
+        "key": "meson-python==0.13.1",
+        "req_type": "build-system",
+        "req": "meson-python==0.13.1"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "build-system",
+        "req": "numpy>=2.0"
+      },
+      {
+        "key": "versioneer==0.29",
+        "req_type": "build-system",
+        "req": "versioneer[toml]"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy>=1.23.2; python_version == \"3.11\""
+      },
+      {
+        "key": "python-dateutil==2.9.0.post0",
+        "req_type": "install",
+        "req": "python-dateutil>=2.8.2"
+      },
+      {
+        "key": "pytz==2024.2",
+        "req_type": "install",
+        "req": "pytz>=2020.1"
+      },
+      {
+        "key": "tzdata==2025.1",
+        "req_type": "install",
+        "req": "tzdata>=2022.7"
+      }
+    ]
+  },
+  "tzdata==2025.1": {
+    "download_url": "https://files.pythonhosted.org/packages/43/0f/fa4723f22942480be4ca9527bbde8d43f6c3f2fe8412f00e7f5f6746bc8b/tzdata-2025.1.tar.gz#sha256=24894909e88cdb28bd1636c6887801df64cb485bd593f2fd83ef29075a81d694",
+    "pre_built": false,
+    "version": "2025.1",
+    "canonicalized_name": "tzdata",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      }
+    ]
+  },
+  "pytz==2024.2": {
+    "download_url": "https://files.pythonhosted.org/packages/3a/31/3c70bf7603cc2dca0f19bdc53b4537a797747a58875b552c8c413d963a3f/pytz-2024.2.tar.gz#sha256=2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a",
+    "pre_built": false,
+    "version": "2024.2",
+    "canonicalized_name": "pytz",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "python-dateutil==2.9.0.post0": {
+    "download_url": "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz#sha256=37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+    "pre_built": false,
+    "version": "2.9.0.post0",
+    "canonicalized_name": "python-dateutil",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools; python_version != \"3.3\""
+      },
+      {
+        "key": "setuptools-scm==7.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm<8.0"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-backend",
+        "req": "setuptools_scm"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-sdist",
+        "req": "setuptools_scm"
+      },
+      {
+        "key": "six==1.17.0",
+        "req_type": "install",
+        "req": "six>=1.5"
+      }
+    ]
+  },
+  "six==1.17.0": {
+    "download_url": "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz#sha256=ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81",
+    "pre_built": false,
+    "version": "1.17.0",
+    "canonicalized_name": "six",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "setuptools-scm==7.1.0": {
+    "download_url": "https://files.pythonhosted.org/packages/98/12/2c1e579bb968759fc512391473340d0661b1a8c96a59fb7c65b02eec1321/setuptools_scm-7.1.0.tar.gz#sha256=6c508345a771aad7d56ebff0e70628bf2b0ec7573762be9960214730de278f27",
+    "pre_built": false,
+    "version": "7.1.0",
+    "canonicalized_name": "setuptools-scm",
+    "edges": [
+      {
+        "key": "packaging==24.2",
+        "req_type": "build-system",
+        "req": "packaging>=20.0"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=45"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "build-system",
+        "req": "typing_extensions"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging>=20.0"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "install",
+        "req": "setuptools"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions"
+      }
+    ]
+  },
+  "numpy==2.2.2": {
+    "download_url": "https://files.pythonhosted.org/packages/ec/d0/c12ddfd3a02274be06ffc71f3efc6d0e457b0409c4481596881e748cb264/numpy-2.2.2.tar.gz#sha256=ed6906f61834d687738d25988ae117683705636936cc605be0bb208b23df4d8f",
+    "pre_built": false,
+    "version": "2.2.2",
+    "canonicalized_name": "numpy",
+    "edges": [
+      {
+        "key": "cython==3.0.11",
+        "req_type": "build-system",
+        "req": "Cython>=3.0.6"
+      },
+      {
+        "key": "meson-python==0.15.0",
+        "req_type": "build-system",
+        "req": "meson-python>=0.15.0"
+      },
+      {
+        "key": "patchelf==0.18.0.0",
+        "req_type": "build-backend",
+        "req": "patchelf>=0.11.0"
+      }
+    ]
+  },
+  "patchelf==0.18.0.0": {
+    "download_url": "https://files.pythonhosted.org/packages/53/65/b7cddff782ebed7c9fcc488bf3eced29d3b0eee51bf1258a9f80ab07267b/patchelf-0.18.0.0.tar.gz#sha256=955f968dc27ebadd7277623a66370c53f77c25fd491299f81899c33f3a999f7a",
+    "pre_built": false,
+    "version": "0.18.0.0",
+    "canonicalized_name": "patchelf",
+    "edges": [
+      {
+        "key": "scikit-build==0.18.1",
+        "req_type": "build-system",
+        "req": "scikit-build>=0.12"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=42"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm>=5"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      }
+    ]
+  },
+  "scikit-build==0.18.1": {
+    "download_url": "https://files.pythonhosted.org/packages/56/54/2beb41f3fcddb4ea238634c6c23fe93115090d8799a45f626a83e6934c16/scikit_build-0.18.1.tar.gz#sha256=a4152ac5a084d499c28a7797be0628d8366c336e2fb0e1a063eb32e55efcb8e7",
+    "pre_built": false,
+    "version": "0.18.1",
+    "canonicalized_name": "scikit-build",
+    "edges": [
+      {
+        "key": "hatch-fancy-pypi-readme==24.1.0",
+        "req_type": "build-system",
+        "req": "hatch-fancy-pypi-readme"
+      },
+      {
+        "key": "hatch-vcs==0.4.0",
+        "req_type": "build-system",
+        "req": "hatch-vcs"
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      },
+      {
+        "key": "distro==1.9.0",
+        "req_type": "install",
+        "req": "distro"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "install",
+        "req": "setuptools>=42.0.0"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "install",
+        "req": "wheel>=0.32.0"
+      }
+    ]
+  },
+  "distro==1.9.0": {
+    "download_url": "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz#sha256=2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed",
+    "pre_built": false,
+    "version": "1.9.0",
+    "canonicalized_name": "distro",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      }
+    ]
+  },
+  "hatch-vcs==0.4.0": {
+    "download_url": "https://files.pythonhosted.org/packages/f5/c9/54bb4fa27b4e4a014ef3bb17710cdf692b3aa2cbc7953da885f1bf7e06ea/hatch_vcs-0.4.0.tar.gz#sha256=093810748fe01db0d451fabcf2c1ac2688caefd232d4ede967090b1c1b07d9f7",
+    "pre_built": false,
+    "version": "0.4.0",
+    "canonicalized_name": "hatch-vcs",
+    "edges": [
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling>=1.1.0"
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "install",
+        "req": "hatchling>=1.1.0"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "install",
+        "req": "setuptools-scm>=6.4.0"
+      }
+    ]
+  },
+  "meson-python==0.15.0": {
+    "download_url": "https://files.pythonhosted.org/packages/a2/3b/276b596824a0820987fdcc7721618453b4f9a8305fe20b611a00ac3f948e/meson_python-0.15.0.tar.gz#sha256=fddb73eecd49e89c1c41c87937cd89c2d0b65a1c63ba28238681d4bd9484d26f",
+    "pre_built": false,
+    "version": "0.15.0",
+    "canonicalized_name": "meson-python",
+    "edges": [
+      {
+        "key": "meson==1.7.0",
+        "req_type": "build-system",
+        "req": "meson>=0.63.3; python_version < \"3.12\""
+      },
+      {
+        "key": "pyproject-metadata==0.9.0",
+        "req_type": "build-system",
+        "req": "pyproject-metadata>=0.7.1"
+      },
+      {
+        "key": "patchelf==0.18.0.0",
+        "req_type": "build-backend",
+        "req": "patchelf>=0.11.0"
+      },
+      {
+        "key": "meson==1.7.0",
+        "req_type": "install",
+        "req": "meson>=0.63.3; python_version < \"3.12\""
+      },
+      {
+        "key": "pyproject-metadata==0.9.0",
+        "req_type": "install",
+        "req": "pyproject-metadata>=0.7.1"
+      }
+    ]
+  },
+  "pyproject-metadata==0.9.0": {
+    "download_url": "https://files.pythonhosted.org/packages/c0/79/406a9f56c435caaaca4a1c66397e4f63ecd48a72a6c4fc1d9ecdaac66acb/pyproject_metadata-0.9.0.tar.gz#sha256=8511c00a4cad96686af6a6b4143433298beb96105a9379afdc9b0328f4f260c9",
+    "pre_built": false,
+    "version": "0.9.0",
+    "canonicalized_name": "pyproject-metadata",
+    "edges": [
+      {
+        "key": "flit-core==3.10.1",
+        "req_type": "build-system",
+        "req": "flit-core"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging>=19.0"
+      }
+    ]
+  },
+  "meson==1.7.0": {
+    "download_url": "https://files.pythonhosted.org/packages/02/98/bbcaf6caaaa0510a68834f119ac793a8abade6ff827fc2791eeb6f8b4a66/meson-1.7.0.tar.gz#sha256=08efbe84803eed07f863b05092d653a9d348f7038761d900412fddf56deb0284",
+    "pre_built": false,
+    "version": "1.7.0",
+    "canonicalized_name": "meson",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=42"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      }
+    ]
+  },
+  "versioneer==0.29": {
+    "download_url": "https://files.pythonhosted.org/packages/32/d7/854e45d2b03e1a8ee2aa6429dd396d002ce71e5d88b77551b2fb249cb382/versioneer-0.29.tar.gz#sha256=5ab283b9857211d61b53318b7c792cf68e798e765ee17c27ade9f6c924235731",
+    "pre_built": false,
+    "version": "0.29",
+    "canonicalized_name": "versioneer",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      }
+    ]
+  },
+  "meson-python==0.13.1": {
+    "download_url": "https://files.pythonhosted.org/packages/fb/54/9551a0810f3f95f761c31d902d3706b7bfe67253e81b33c0994b2c0f9b3b/meson_python-0.13.1.tar.gz#sha256=63b3170001425c42fa4cfedadb9051cbd28925ff8eed7c40d36ba0099e3c7618",
+    "pre_built": false,
+    "version": "0.13.1",
+    "canonicalized_name": "meson-python",
+    "edges": [
+      {
+        "key": "meson==1.7.0",
+        "req_type": "build-system",
+        "req": "meson>=0.63.3"
+      },
+      {
+        "key": "pyproject-metadata==0.9.0",
+        "req_type": "build-system",
+        "req": "pyproject-metadata>=0.7.1"
+      },
+      {
+        "key": "meson==1.7.0",
+        "req_type": "install",
+        "req": "meson>=0.63.3"
+      },
+      {
+        "key": "pyproject-metadata==0.9.0",
+        "req_type": "install",
+        "req": "pyproject-metadata>=0.7.1"
+      }
+    ]
+  },
+  "meson==1.2.1": {
+    "download_url": "https://files.pythonhosted.org/packages/f2/21/3326fe66aa091b3653d12affd1c3928e17c9ac386708ec42b4fad87eefac/meson-1.2.1.tar.gz#sha256=b1db3a153087549497ee52b1c938d2134e0338214fe14f7efd16fecd57b639f5",
+    "pre_built": false,
+    "version": "1.2.1",
+    "canonicalized_name": "meson",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=42"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      }
+    ]
+  },
+  "latex2mathml==3.77.0": {
+    "download_url": "https://files.pythonhosted.org/packages/a3/dc/6630656e3aa7430b61acefcc3d8a9c23110790193cde0eed1c27a31e4187/latex2mathml-3.77.0.tar.gz#sha256=e2f501d1878f2e489c3f6f12786bef74c62f712d2770f7f3c837eb20a55d0a1e",
+    "pre_built": false,
+    "version": "3.77.0",
+    "canonicalized_name": "latex2mathml",
+    "edges": [
+      {
+        "key": "poetry-core==2.1.2",
+        "req_type": "build-system",
+        "req": "poetry-core"
+      }
+    ]
+  },
+  "poetry-core==2.1.2": {
+    "download_url": "https://files.pythonhosted.org/packages/84/2a/572c141e2a15b933b4a49eb888b0ae7335604f57c0f91a7298ae56d2df7c/poetry_core-2.1.2.tar.gz#sha256=f9dbbbd0ebf9755476a1d57f04b30e9aecf71ca9dc2fcd4b17aba92c0002aa04",
+    "pre_built": false,
+    "version": "2.1.2",
+    "canonicalized_name": "poetry-core",
+    "edges": []
+  },
+  "jsonschema==4.23.0": {
+    "download_url": "https://files.pythonhosted.org/packages/38/2e/03362ee4034a4c917f697890ccd4aec0800ccf9ded7f511971c75451deec/jsonschema-4.23.0.tar.gz#sha256=d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4",
+    "pre_built": false,
+    "version": "4.23.0",
+    "canonicalized_name": "jsonschema",
+    "edges": [
+      {
+        "key": "hatch-fancy-pypi-readme==24.1.0",
+        "req_type": "build-system",
+        "req": "hatch-fancy-pypi-readme"
+      },
+      {
+        "key": "hatch-vcs==0.4.0",
+        "req_type": "build-system",
+        "req": "hatch-vcs"
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      },
+      {
+        "key": "attrs==25.1.0",
+        "req_type": "install",
+        "req": "attrs>=22.2.0"
+      },
+      {
+        "key": "jsonschema-specifications==2024.10.1",
+        "req_type": "install",
+        "req": "jsonschema-specifications>=2023.03.6"
+      },
+      {
+        "key": "referencing==0.36.2",
+        "req_type": "install",
+        "req": "referencing>=0.28.4"
+      },
+      {
+        "key": "rpds-py==0.18.1",
+        "req_type": "install",
+        "req": "rpds-py>=0.7.1"
+      }
+    ]
+  },
+  "rpds-py==0.18.1": {
+    "download_url": "https://files.pythonhosted.org/packages/2d/aa/e7c404bdee1db7be09860dff423d022ffdce9269ec8e6532cce09ee7beea/rpds_py-0.18.1.tar.gz#sha256=dc48b479d540770c811fbd1eb9ba2bb66951863e448efec2e2c102625328e92f",
+    "pre_built": false,
+    "version": "0.18.1",
+    "canonicalized_name": "rpds-py",
+    "edges": [
+      {
+        "key": "maturin==1.8.1",
+        "req_type": "build-system",
+        "req": "maturin<2.0,>=1.0"
+      }
+    ]
+  },
+  "referencing==0.36.2": {
+    "download_url": "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz#sha256=df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa",
+    "pre_built": false,
+    "version": "0.36.2",
+    "canonicalized_name": "referencing",
+    "edges": [
+      {
+        "key": "hatch-vcs==0.4.0",
+        "req_type": "build-system",
+        "req": "hatch-vcs"
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      },
+      {
+        "key": "attrs==25.1.0",
+        "req_type": "install",
+        "req": "attrs>=22.2.0"
+      },
+      {
+        "key": "rpds-py==0.18.1",
+        "req_type": "install",
+        "req": "rpds-py>=0.7.0"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions>=4.4.0; python_version < \"3.13\""
+      }
+    ]
+  },
+  "attrs==25.1.0": {
+    "download_url": "https://files.pythonhosted.org/packages/49/7c/fdf464bcc51d23881d110abd74b512a42b3d5d376a55a831b44c603ae17f/attrs-25.1.0.tar.gz#sha256=1c97078a80c814273a76b2a298a932eb681c87415c11dee0a6921de7f1b02c3e",
+    "pre_built": false,
+    "version": "25.1.0",
+    "canonicalized_name": "attrs",
+    "edges": [
+      {
+        "key": "hatch-fancy-pypi-readme==24.1.0",
+        "req_type": "build-system",
+        "req": "hatch-fancy-pypi-readme>=23.2.0"
+      },
+      {
+        "key": "hatch-vcs==0.4.0",
+        "req_type": "build-system",
+        "req": "hatch-vcs"
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      }
+    ]
+  },
+  "jsonschema-specifications==2024.10.1": {
+    "download_url": "https://files.pythonhosted.org/packages/10/db/58f950c996c793472e336ff3655b13fbcf1e3b359dcf52dcf3ed3b52c352/jsonschema_specifications-2024.10.1.tar.gz#sha256=0f38b83639958ce1152d02a7f062902c41c8fd20d558b0c34344292d417ae272",
+    "pre_built": false,
+    "version": "2024.10.1",
+    "canonicalized_name": "jsonschema-specifications",
+    "edges": [
+      {
+        "key": "hatch-vcs==0.4.0",
+        "req_type": "build-system",
+        "req": "hatch-vcs"
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      },
+      {
+        "key": "referencing==0.36.2",
+        "req_type": "install",
+        "req": "referencing>=0.31.0"
+      }
+    ]
+  },
+  "jsonref==1.1.0": {
+    "download_url": "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz#sha256=32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552",
+    "pre_built": false,
+    "version": "1.1.0",
+    "canonicalized_name": "jsonref",
+    "edges": [
+      {
+        "key": "pdm-pep517==1.1.4",
+        "req_type": "build-system",
+        "req": "pdm-pep517>=1.0.0"
+      }
+    ]
+  },
+  "pdm-pep517==1.1.4": {
+    "download_url": "https://files.pythonhosted.org/packages/43/42/5c8818b70fc4b25c99e56aeeb3484ede076114c8a0772675b44a3b7891cc/pdm-pep517-1.1.4.tar.gz#sha256=7f49121e70b42dca296fac962210dd2da07a39575fc5673137ad661633b2cf3f",
+    "pre_built": false,
+    "version": "1.1.4",
+    "canonicalized_name": "pdm-pep517",
+    "edges": []
+  },
+  "transformers==4.48.1": {
+    "download_url": "https://files.pythonhosted.org/packages/21/6b/caf620fae7fbf35947c81e7dd0834493b9ad9b71bb9e433025ac7a07e79a/transformers-4.48.1.tar.gz#sha256=7c1931facc3ee8adcbf86fc7a87461d54c1e40eca3bb57fef1ee9f3ecd32187e",
+    "pre_built": false,
+    "version": "4.48.1",
+    "canonicalized_name": "transformers",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "filelock==3.17.0",
+        "req_type": "install",
+        "req": "filelock"
+      },
+      {
+        "key": "huggingface-hub==0.30.1",
+        "req_type": "install",
+        "req": "huggingface-hub<1.0,>=0.24.0"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy>=1.17"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging>=20.0"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml>=5.1"
+      },
+      {
+        "key": "regex==2024.11.6",
+        "req_type": "install",
+        "req": "regex!=2019.12.17"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests"
+      },
+      {
+        "key": "safetensors==0.4.5",
+        "req_type": "install",
+        "req": "safetensors>=0.4.1"
+      },
+      {
+        "key": "tokenizers==0.21.0",
+        "req_type": "install",
+        "req": "tokenizers<0.22,>=0.21"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm>=4.27"
+      }
+    ]
+  },
+  "tqdm==4.67.1": {
+    "download_url": "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz#sha256=f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2",
+    "pre_built": false,
+    "version": "4.67.1",
+    "canonicalized_name": "tqdm",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=42"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm[toml]>=3.4"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      }
+    ]
+  },
+  "tokenizers==0.21.0": {
+    "download_url": "https://files.pythonhosted.org/packages/20/41/c2be10975ca37f6ec40d7abd7e98a5213bb04f284b869c1a24e6504fd94d/tokenizers-0.21.0.tar.gz#sha256=ee0894bf311b75b0c03079f33859ae4b2334d675d4e93f5a4132e1eae2834fe4",
+    "pre_built": false,
+    "version": "0.21.0",
+    "canonicalized_name": "tokenizers",
+    "edges": [
+      {
+        "key": "maturin==1.8.1",
+        "req_type": "build-system",
+        "req": "maturin<2.0,>=1.0"
+      },
+      {
+        "key": "huggingface-hub==0.30.1",
+        "req_type": "install",
+        "req": "huggingface-hub<1.0,>=0.16.4"
+      }
+    ]
+  },
+  "huggingface-hub==0.30.1": {
+    "download_url": "https://files.pythonhosted.org/packages/78/be/049689a7197630e75c4bb53021cb209a56617c9bf39b3a0950650d1f96e1/huggingface_hub-0.30.1.tar.gz#sha256=f379e8b8d0791295602538856638460ae3cf679c7f304201eb80fb98c771950e",
+    "pre_built": false,
+    "version": "0.30.1",
+    "canonicalized_name": "huggingface-hub",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "filelock==3.17.0",
+        "req_type": "install",
+        "req": "filelock"
+      },
+      {
+        "key": "fsspec==2024.12.0",
+        "req_type": "install",
+        "req": "fsspec>=2023.5.0"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging>=20.9"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml>=5.1"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm>=4.42.1"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions>=3.7.4.3"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "filelock==3.17.0",
+        "req_type": "install",
+        "req": "filelock"
+      },
+      {
+        "key": "fsspec==2024.12.0",
+        "req_type": "install",
+        "req": "fsspec>=2023.5.0"
+      },
+      {
+        "key": "hf-transfer==0.1.8",
+        "req_type": "install",
+        "req": "hf_transfer>=0.1.4; extra == \"hf-transfer\""
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging>=20.9"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml>=5.1"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm>=4.42.1"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions>=3.7.4.3"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "filelock==3.17.0",
+        "req_type": "install",
+        "req": "filelock"
+      },
+      {
+        "key": "fsspec==2024.12.0",
+        "req_type": "install",
+        "req": "fsspec>=2023.5.0"
+      },
+      {
+        "key": "hf-transfer==0.1.8",
+        "req_type": "install",
+        "req": "hf_transfer>=0.1.4; extra == \"hf-transfer\""
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging>=20.9"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml>=5.1"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm>=4.42.1"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions>=3.7.4.3"
+      }
+    ]
+  },
+  "requests==2.32.3": {
+    "download_url": "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz#sha256=55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760",
+    "pre_built": false,
+    "version": "2.32.3",
+    "canonicalized_name": "requests",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "certifi==2024.12.14",
+        "req_type": "install",
+        "req": "certifi>=2017.4.17"
+      },
+      {
+        "key": "charset-normalizer==3.4.1",
+        "req_type": "install",
+        "req": "charset-normalizer<4,>=2"
+      },
+      {
+        "key": "idna==3.10",
+        "req_type": "install",
+        "req": "idna<4,>=2.5"
+      },
+      {
+        "key": "urllib3==2.3.0",
+        "req_type": "install",
+        "req": "urllib3<3,>=1.21.1"
+      }
+    ]
+  },
+  "urllib3==2.3.0": {
+    "download_url": "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz#sha256=f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d",
+    "pre_built": false,
+    "version": "2.3.0",
+    "canonicalized_name": "urllib3",
+    "edges": [
+      {
+        "key": "hatch-vcs==0.4.0",
+        "req_type": "build-system",
+        "req": "hatch-vcs==0.4.0"
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling<2,>=1.6.0"
+      }
+    ]
+  },
+  "idna==3.10": {
+    "download_url": "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz#sha256=12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
+    "pre_built": false,
+    "version": "3.10",
+    "canonicalized_name": "idna",
+    "edges": [
+      {
+        "key": "flit-core==3.10.1",
+        "req_type": "build-system",
+        "req": "flit_core<4,>=3.2"
+      }
+    ]
+  },
+  "charset-normalizer==3.4.1": {
+    "download_url": "https://files.pythonhosted.org/packages/16/b0/572805e227f01586461c80e0fd25d65a2115599cc9dad142fee4b747c357/charset_normalizer-3.4.1.tar.gz#sha256=44251f18cd68a75b56585dd00dae26183e102cd5e0f9f1466e6df5da2ed64ea3",
+    "pre_built": false,
+    "version": "3.4.1",
+    "canonicalized_name": "charset-normalizer",
+    "edges": [
+      {
+        "key": "mypy==1.14.0",
+        "req_type": "build-system",
+        "req": "mypy<=1.14.0,>=1.4.1"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools-scm"
+      }
+    ]
+  },
+  "mypy==1.14.0": {
+    "download_url": "https://files.pythonhosted.org/packages/8c/7b/08046ef9330735f536a09a2e31b00f42bccdb2795dcd979636ba43bb2d63/mypy-1.14.0.tar.gz#sha256=822dbd184d4a9804df5a7d5335a68cf7662930e70b8c1bc976645d1509f9a9d6",
+    "pre_built": false,
+    "version": "1.14.0",
+    "canonicalized_name": "mypy",
+    "edges": [
+      {
+        "key": "mypy-extensions==1.0.0",
+        "req_type": "build-system",
+        "req": "mypy_extensions>=1.0.0"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=75.1.0"
+      },
+      {
+        "key": "types-psutil==6.1.0.20241221",
+        "req_type": "build-system",
+        "req": "types-psutil"
+      },
+      {
+        "key": "types-setuptools==75.8.0.20250110",
+        "req_type": "build-system",
+        "req": "types-setuptools"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "build-system",
+        "req": "typing_extensions>=4.6.0"
+      },
+      {
+        "key": "mypy-extensions==1.0.0",
+        "req_type": "install",
+        "req": "mypy_extensions>=1.0.0"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing_extensions>=4.6.0"
+      }
+    ]
+  },
+  "mypy-extensions==1.0.0": {
+    "download_url": "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz#sha256=75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782",
+    "pre_built": false,
+    "version": "1.0.0",
+    "canonicalized_name": "mypy-extensions",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "types-setuptools==75.8.0.20250110": {
+    "download_url": "https://files.pythonhosted.org/packages/f7/42/5713e90d4f9683f2301d900f33e4fc2405ad8ac224dda30f6cb7f4cd215b/types_setuptools-75.8.0.20250110.tar.gz#sha256=96f7ec8bbd6e0a54ea180d66ad68ad7a1d7954e7281a710ea2de75e355545271",
+    "pre_built": false,
+    "version": "75.8.0.20250110",
+    "canonicalized_name": "types-setuptools",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "types-psutil==6.1.0.20241221": {
+    "download_url": "https://files.pythonhosted.org/packages/44/8c/5f82cd554cc5bb79d137f082e4c9f8d22e85c8c08dabee4971d422a9abdd/types_psutil-6.1.0.20241221.tar.gz#sha256=600f5a36bd5e0eb8887f0e3f3ff2cf154d90690ad8123c8a707bba4ab94d3185",
+    "pre_built": false,
+    "version": "6.1.0.20241221",
+    "canonicalized_name": "types-psutil",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "certifi==2024.12.14": {
+    "download_url": "https://files.pythonhosted.org/packages/0f/bd/1d41ee578ce09523c81a15426705dd20969f5abf006d1afe8aeff0dd776a/certifi-2024.12.14.tar.gz#sha256=b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db",
+    "pre_built": false,
+    "version": "2024.12.14",
+    "canonicalized_name": "certifi",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "hf-transfer==0.1.8": {
+    "download_url": "https://files.pythonhosted.org/packages/d3/0e/ba51e31148f0a9bc8d44878086535c2dc6d9a8dce321250e9bcdd3c110ea/hf_transfer-0.1.8.tar.gz#sha256=26d229468152e7a3ec12664cac86b8c2800695fd85f9c9a96677a775cc04f0b3",
+    "pre_built": false,
+    "version": "0.1.8",
+    "canonicalized_name": "hf-transfer",
+    "edges": [
+      {
+        "key": "maturin==1.8.1",
+        "req_type": "build-system",
+        "req": "maturin<2,>=1.4"
+      }
+    ]
+  },
+  "fsspec==2024.12.0": {
+    "download_url": "https://files.pythonhosted.org/packages/ee/11/de70dee31455c546fbc88301971ec03c328f3d1138cfba14263f651e9551/fsspec-2024.12.0.tar.gz#sha256=670700c977ed2fb51e0d9f9253177ed20cbde4a3e5c0283cc5385b5870c8533f",
+    "pre_built": false,
+    "version": "2024.12.0",
+    "canonicalized_name": "fsspec",
+    "edges": [
+      {
+        "key": "hatch-vcs==0.4.0",
+        "req_type": "build-system",
+        "req": "hatch-vcs"
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      },
+      {
+        "key": "hatch-vcs==0.4.0",
+        "req_type": "build-system",
+        "req": "hatch-vcs"
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      },
+      {
+        "key": "aiohttp==3.11.11",
+        "req_type": "install",
+        "req": "aiohttp!=4.0.0a0,!=4.0.0a1; extra == \"http\""
+      }
+    ]
+  },
+  "aiohttp==3.11.11": {
+    "download_url": "https://files.pythonhosted.org/packages/fe/ed/f26db39d29cd3cb2f5a3374304c713fe5ab5a0e4c8ee25a0c45cc6adf844/aiohttp-3.11.11.tar.gz#sha256=bb49c7f1e6ebf3821a42d81d494f538107610c3a705987f53068546b0e90303e",
+    "pre_built": false,
+    "version": "3.11.11",
+    "canonicalized_name": "aiohttp",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=46.4.0"
+      },
+      {
+        "key": "aiohappyeyeballs==2.4.4",
+        "req_type": "install",
+        "req": "aiohappyeyeballs>=2.3.0"
+      },
+      {
+        "key": "aiosignal==1.3.2",
+        "req_type": "install",
+        "req": "aiosignal>=1.1.2"
+      },
+      {
+        "key": "attrs==25.1.0",
+        "req_type": "install",
+        "req": "attrs>=17.3.0"
+      },
+      {
+        "key": "frozenlist==1.5.0",
+        "req_type": "install",
+        "req": "frozenlist>=1.1.1"
+      },
+      {
+        "key": "multidict==6.1.0",
+        "req_type": "install",
+        "req": "multidict<7.0,>=4.5"
+      },
+      {
+        "key": "propcache==0.2.1",
+        "req_type": "install",
+        "req": "propcache>=0.2.0"
+      },
+      {
+        "key": "yarl==1.18.3",
+        "req_type": "install",
+        "req": "yarl<2.0,>=1.17.0"
+      }
+    ]
+  },
+  "yarl==1.18.3": {
+    "download_url": "https://files.pythonhosted.org/packages/b7/9d/4b94a8e6d2b51b599516a5cb88e5bc99b4d8d4583e468057eaa29d5f0918/yarl-1.18.3.tar.gz#sha256=ac1801c45cbf77b6c99242eeff4fffb5e4e73a800b5c4ad4fc0be5def634d2e1",
+    "pre_built": false,
+    "version": "1.18.3",
+    "canonicalized_name": "yarl",
+    "edges": [
+      {
+        "key": "cython==3.0.11",
+        "req_type": "build-system",
+        "req": "Cython>=3.0.0"
+      },
+      {
+        "key": "expandvars==0.12.0",
+        "req_type": "build-system",
+        "req": "expandvars"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=47"
+      },
+      {
+        "key": "cython==3.0.11",
+        "req_type": "build-backend",
+        "req": "Cython; python_version < \"3.12\""
+      },
+      {
+        "key": "cython==3.0.11",
+        "req_type": "build-sdist",
+        "req": "Cython; python_version < \"3.12\""
+      },
+      {
+        "key": "idna==3.10",
+        "req_type": "install",
+        "req": "idna>=2.0"
+      },
+      {
+        "key": "multidict==6.1.0",
+        "req_type": "install",
+        "req": "multidict>=4.0"
+      },
+      {
+        "key": "propcache==0.2.1",
+        "req_type": "install",
+        "req": "propcache>=0.2.0"
+      }
+    ]
+  },
+  "propcache==0.2.1": {
+    "download_url": "https://files.pythonhosted.org/packages/20/c8/2a13f78d82211490855b2fb303b6721348d0787fdd9a12ac46d99d3acde1/propcache-0.2.1.tar.gz#sha256=3f77ce728b19cb537714499928fe800c3dda29e8d9428778fc7c186da4c09a64",
+    "pre_built": false,
+    "version": "0.2.1",
+    "canonicalized_name": "propcache",
+    "edges": [
+      {
+        "key": "expandvars==0.12.0",
+        "req_type": "build-system",
+        "req": "expandvars"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=47"
+      },
+      {
+        "key": "cython==3.0.11",
+        "req_type": "build-backend",
+        "req": "Cython; python_version < \"3.12\""
+      },
+      {
+        "key": "cython==3.0.11",
+        "req_type": "build-sdist",
+        "req": "Cython; python_version < \"3.12\""
+      }
+    ]
+  },
+  "expandvars==0.12.0": {
+    "download_url": "https://files.pythonhosted.org/packages/2b/a5/46d1f58edcae1d632fafdfee313e378240e002ae45d26502bac938bd8751/expandvars-0.12.0.tar.gz#sha256=7d1adfa55728cf4b5d812ece3d087703faea953e0c0a1a78415de9df5024d844",
+    "pre_built": false,
+    "version": "0.12.0",
+    "canonicalized_name": "expandvars",
+    "edges": [
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      }
+    ]
+  },
+  "multidict==6.1.0": {
+    "download_url": "https://files.pythonhosted.org/packages/d6/be/504b89a5e9ca731cd47487e91c469064f8ae5af93b7259758dcfc2b9c848/multidict-6.1.0.tar.gz#sha256=22ae2ebf9b0c69d206c003e2f6a914ea33f0a932d4aa16f236afc049d9958f4a",
+    "pre_built": false,
+    "version": "6.1.0",
+    "canonicalized_name": "multidict",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40"
+      }
+    ]
+  },
+  "frozenlist==1.5.0": {
+    "download_url": "https://files.pythonhosted.org/packages/8f/ed/0f4cec13a93c02c47ec32d81d11c0c1efbadf4a471e3f3ce7cad366cbbd3/frozenlist-1.5.0.tar.gz#sha256=81d5af29e61b9c8348e876d442253723928dce6433e0e76cd925cd83f1b4b817",
+    "pre_built": false,
+    "version": "1.5.0",
+    "canonicalized_name": "frozenlist",
+    "edges": [
+      {
+        "key": "expandvars==0.12.0",
+        "req_type": "build-system",
+        "req": "expandvars"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=47"
+      },
+      {
+        "key": "cython==3.0.11",
+        "req_type": "build-backend",
+        "req": "Cython"
+      },
+      {
+        "key": "cython==3.0.11",
+        "req_type": "build-sdist",
+        "req": "Cython"
+      }
+    ]
+  },
+  "aiosignal==1.3.2": {
+    "download_url": "https://files.pythonhosted.org/packages/ba/b5/6d55e80f6d8a08ce22b982eafa278d823b541c925f11ee774b0b9c43473d/aiosignal-1.3.2.tar.gz#sha256=a8c255c66fafb1e499c9351d0bf32ff2d8a0321595ebac3b93713656d2436f54",
+    "pre_built": false,
+    "version": "1.3.2",
+    "canonicalized_name": "aiosignal",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=51.0"
+      },
+      {
+        "key": "frozenlist==1.5.0",
+        "req_type": "install",
+        "req": "frozenlist>=1.1.0"
+      }
+    ]
+  },
+  "aiohappyeyeballs==2.4.4": {
+    "download_url": "https://files.pythonhosted.org/packages/7f/55/e4373e888fdacb15563ef6fa9fa8c8252476ea071e96fb46defac9f18bf2/aiohappyeyeballs-2.4.4.tar.gz#sha256=5fdd7d87889c63183afc18ce9271f9b0a7d32c2303e394468dd45d514a757745",
+    "pre_built": false,
+    "version": "2.4.4",
+    "canonicalized_name": "aiohappyeyeballs",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0"
+      }
+    ]
+  },
+  "filelock==3.17.0": {
+    "download_url": "https://files.pythonhosted.org/packages/dc/9c/0b15fb47b464e1b663b1acd1253a062aa5feecb07d4e597daea542ebd2b5/filelock-3.17.0.tar.gz#sha256=ee4e77401ef576ebb38cd7f13b9b28893194acc20a8e68e18730ba9c0e54660e",
+    "pre_built": false,
+    "version": "3.17.0",
+    "canonicalized_name": "filelock",
+    "edges": [
+      {
+        "key": "hatch-vcs==0.4.0",
+        "req_type": "build-system",
+        "req": "hatch-vcs>=0.4"
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling>=1.27"
+      }
+    ]
+  },
+  "safetensors==0.4.5": {
+    "download_url": "https://files.pythonhosted.org/packages/cb/46/a1c56ed856c6ac3b1a8b37abe5be0cac53219367af1331e721b04d122577/safetensors-0.4.5.tar.gz#sha256=d73de19682deabb02524b3d5d1f8b3aaba94c72f1bbfc7911b9b9d5d391c0310",
+    "pre_built": false,
+    "version": "0.4.5",
+    "canonicalized_name": "safetensors",
+    "edges": [
+      {
+        "key": "maturin==1.8.1",
+        "req_type": "build-system",
+        "req": "maturin<2.0,>=1.0"
+      },
+      {
+        "key": "maturin==1.8.1",
+        "req_type": "build-system",
+        "req": "maturin<2.0,>=1.0"
+      },
+      {
+        "key": "safetensors==0.4.5",
+        "req_type": "install",
+        "req": "safetensors[numpy]; extra == \"torch\""
+      },
+      {
+        "key": "maturin==1.8.1",
+        "req_type": "build-system",
+        "req": "maturin<2.0,>=1.0"
+      },
+      {
+        "key": "numpy==2.2.4",
+        "req_type": "install",
+        "req": "numpy>=1.21.6; extra == \"numpy\""
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "install",
+        "req": "torch>=1.10; extra == \"torch\""
+      }
+    ]
+  },
+  "torch==2.5.1": {
+    "download_url": "https://files.pythonhosted.org/packages/d1/35/e8b2daf02ce933e4518e6f5682c72fd0ed66c15910ea1fb4168f442b71c4/torch-2.5.1-cp311-cp311-manylinux1_x86_64.whl#sha256=de5b7d6740c4b636ef4db92be922f0edc425b65ed78c5076c43c42d362a45457",
+    "pre_built": false,
+    "version": "2.5.1",
+    "canonicalized_name": "torch",
+    "edges": [
+      {
+        "key": "astunparse==1.6.3",
+        "req_type": "build-system",
+        "req": "astunparse"
+      },
+      {
+        "key": "filelock==3.17.0",
+        "req_type": "build-system",
+        "req": "filelock"
+      },
+      {
+        "key": "iniconfig==2.0.0",
+        "req_type": "build-system",
+        "req": "iniconfig"
+      },
+      {
+        "key": "ninja==1.11.1.1",
+        "req_type": "build-system",
+        "req": "ninja"
+      },
+      {
+        "key": "numpy==1.26.4",
+        "req_type": "build-system",
+        "req": "numpy<2.0.0"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "build-system",
+        "req": "packaging"
+      },
+      {
+        "key": "pluggy==1.5.0",
+        "req_type": "build-system",
+        "req": "pluggy"
+      },
+      {
+        "key": "pybind11==2.13.6",
+        "req_type": "build-system",
+        "req": "pybind11"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "build-system",
+        "req": "pyyaml"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "build-system",
+        "req": "requests"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "build-system",
+        "req": "typing-extensions"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      },
+      {
+        "key": "filelock==3.17.0",
+        "req_type": "install",
+        "req": "filelock"
+      },
+      {
+        "key": "fsspec==2024.12.0",
+        "req_type": "install",
+        "req": "fsspec"
+      },
+      {
+        "key": "jinja2==3.1.5",
+        "req_type": "install",
+        "req": "jinja2"
+      },
+      {
+        "key": "networkx==3.4.2",
+        "req_type": "install",
+        "req": "networkx"
+      },
+      {
+        "key": "sympy==1.13.1",
+        "req_type": "install",
+        "req": "sympy==1.13.1; python_version >= \"3.9\""
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions>=4.8.0"
+      }
+    ]
+  },
+  "sympy==1.13.1": {
+    "download_url": "https://files.pythonhosted.org/packages/ca/99/5a5b6f19ff9f083671ddf7b9632028436167cd3d33e11015754e41b249a4/sympy-1.13.1.tar.gz#sha256=9cebf7e04ff162015ce31c9c6c9144daa34a93bd082f54fd8f12deca4f47515f",
+    "pre_built": false,
+    "version": "1.13.1",
+    "canonicalized_name": "sympy",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "mpmath==1.3.0",
+        "req_type": "install",
+        "req": "mpmath<1.4,>=1.1.0"
+      }
+    ]
+  },
+  "mpmath==1.3.0": {
+    "download_url": "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz#sha256=7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f",
+    "pre_built": false,
+    "version": "1.3.0",
+    "canonicalized_name": "mpmath",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-backend",
+        "req": "setuptools>=36.7.0"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-sdist",
+        "req": "setuptools>=36.7.0"
+      }
+    ]
+  },
+  "networkx==3.4.2": {
+    "download_url": "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz#sha256=307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1",
+    "pre_built": false,
+    "version": "3.4.2",
+    "canonicalized_name": "networkx",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=61.2"
+      }
+    ]
+  },
+  "jinja2==3.1.5": {
+    "download_url": "https://files.pythonhosted.org/packages/af/92/b3130cbbf5591acf9ade8708c365f3238046ac7cb8ccba6e81abccb0ccff/jinja2-3.1.5.tar.gz#sha256=8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb",
+    "pre_built": false,
+    "version": "3.1.5",
+    "canonicalized_name": "jinja2",
+    "edges": [
+      {
+        "key": "flit-core==3.10.1",
+        "req_type": "build-system",
+        "req": "flit_core<4"
+      },
+      {
+        "key": "markupsafe==3.0.2",
+        "req_type": "install",
+        "req": "MarkupSafe>=2.0"
+      }
+    ]
+  },
+  "markupsafe==3.0.2": {
+    "download_url": "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz#sha256=ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0",
+    "pre_built": false,
+    "version": "3.0.2",
+    "canonicalized_name": "markupsafe",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=70.1"
+      }
+    ]
+  },
+  "pybind11==2.13.6": {
+    "download_url": "https://files.pythonhosted.org/packages/d2/c1/72b9622fcb32ff98b054f724e213c7f70d6898baa714f4516288456ceaba/pybind11-2.13.6.tar.gz#sha256=ba6af10348c12b24e92fa086b39cfba0eff619b61ac77c406167d813b096d39a",
+    "pre_built": false,
+    "version": "2.13.6",
+    "canonicalized_name": "pybind11",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=42"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      }
+    ]
+  },
+  "numpy==1.26.4": {
+    "download_url": "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz#sha256=2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010",
+    "pre_built": false,
+    "version": "1.26.4",
+    "canonicalized_name": "numpy",
+    "edges": [
+      {
+        "key": "cython==3.0.11",
+        "req_type": "build-system",
+        "req": "Cython<3.1,>=0.29.34"
+      },
+      {
+        "key": "meson-python==0.15.0",
+        "req_type": "build-system",
+        "req": "meson-python<0.16.0,>=0.15.0"
+      }
+    ]
+  },
+  "ninja==1.11.1.1": {
+    "download_url": "https://files.pythonhosted.org/packages/37/2c/d717d13a413d6f7579cdaa1e28e6e2c98de95461549b08d311c8a5bf4c51/ninja-1.11.1.1.tar.gz#sha256=9d793b08dd857e38d0b6ffe9e6b7145d7c485a42dcfea04905ca0cdb6017cc3c",
+    "pre_built": false,
+    "version": "1.11.1.1",
+    "canonicalized_name": "ninja",
+    "edges": [
+      {
+        "key": "scikit-build==0.18.1",
+        "req_type": "build-system",
+        "req": "scikit-build"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=42"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools-scm[toml]"
+      }
+    ]
+  },
+  "iniconfig==2.0.0": {
+    "download_url": "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz#sha256=2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
+    "pre_built": false,
+    "version": "2.0.0",
+    "canonicalized_name": "iniconfig",
+    "edges": [
+      {
+        "key": "hatch-vcs==0.4.0",
+        "req_type": "build-system",
+        "req": "hatch-vcs"
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      }
+    ]
+  },
+  "astunparse==1.6.3": {
+    "download_url": "https://files.pythonhosted.org/packages/f3/af/4182184d3c338792894f34a62672919db7ca008c89abee9b564dd34d8029/astunparse-1.6.3.tar.gz#sha256=5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872",
+    "pre_built": false,
+    "version": "1.6.3",
+    "canonicalized_name": "astunparse",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "six==1.17.0",
+        "req_type": "install",
+        "req": "six<2.0,>=1.6.1"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "install",
+        "req": "wheel<1.0,>=0.23.0"
+      }
+    ]
+  },
+  "numpy==2.2.4": {
+    "download_url": "https://files.pythonhosted.org/packages/e1/78/31103410a57bc2c2b93a3597340a8119588571f6a4539067546cb9a0bfac/numpy-2.2.4.tar.gz#sha256=9ba03692a45d3eef66559efe1d1096c4b9b75c0986b5dff5530c378fb8331d4f",
+    "pre_built": false,
+    "version": "2.2.4",
+    "canonicalized_name": "numpy",
+    "edges": [
+      {
+        "key": "cython==3.0.11",
+        "req_type": "build-system",
+        "req": "Cython>=3.0.6"
+      },
+      {
+        "key": "meson-python==0.15.0",
+        "req_type": "build-system",
+        "req": "meson-python>=0.15.0"
+      }
+    ]
+  },
+  "regex==2024.11.6": {
+    "download_url": "https://files.pythonhosted.org/packages/8e/5f/bd69653fbfb76cf8604468d3b4ec4c403197144c7bfe0e6a5fc9e02a07cb/regex-2024.11.6.tar.gz#sha256=7ab159b063c52a0333c884e4679f8d7a85112ee3078fe3d9004b2dd875585519",
+    "pre_built": false,
+    "version": "2024.11.6",
+    "canonicalized_name": "regex",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      }
+    ]
+  },
+  "semchunk==2.2.2": {
+    "download_url": "https://files.pythonhosted.org/packages/62/96/c418c322730b385e81d4ab462e68dd48bb2dbda4d8efa17cad2ca468d9ac/semchunk-2.2.2.tar.gz#sha256=940e89896e64eeb01de97ba60f51c8c7b96c6a3951dfcf574f25ce2146752f52",
+    "pre_built": false,
+    "version": "2.2.2",
+    "canonicalized_name": "semchunk",
+    "edges": [
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      },
+      {
+        "key": "mpire==2.10.2",
+        "req_type": "install",
+        "req": "mpire[dill]"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm"
+      }
+    ]
+  },
+  "mpire==2.10.2": {
+    "download_url": "https://files.pythonhosted.org/packages/3a/93/80ac75c20ce54c785648b4ed363c88f148bf22637e10c9863db4fbe73e74/mpire-2.10.2.tar.gz#sha256=f66a321e93fadff34585a4bfa05e95bd946cf714b442f51c529038eb45773d97",
+    "pre_built": false,
+    "version": "2.10.2",
+    "canonicalized_name": "mpire",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "multiprocess==0.70.16",
+        "req_type": "install",
+        "req": "multiprocess>=0.70.15; python_version >= \"3.11\" and extra == \"dill\""
+      },
+      {
+        "key": "pygments==2.19.1",
+        "req_type": "install",
+        "req": "pygments>=2.0"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm>=4.27"
+      }
+    ]
+  },
+  "multiprocess==0.70.16": {
+    "download_url": "https://files.pythonhosted.org/packages/b5/ae/04f39c5d0d0def03247c2893d6f2b83c136bf3320a2154d7b8858f2ba72d/multiprocess-0.70.16.tar.gz#sha256=161af703d4652a0e1410be6abccecde4a7ddffd19341be0a7011b94aeb171ac1",
+    "pre_built": false,
+    "version": "0.70.16",
+    "canonicalized_name": "multiprocess",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=42"
+      },
+      {
+        "key": "dill==0.3.9",
+        "req_type": "install",
+        "req": "dill>=0.3.8"
+      }
+    ]
+  },
+  "dill==0.3.9": {
+    "download_url": "https://files.pythonhosted.org/packages/70/43/86fe3f9e130c4137b0f1b50784dd70a5087b911fe07fa81e53e0c4c47fea/dill-0.3.9.tar.gz#sha256=81aa267dddf68cbfe8029c42ca9ec6a4ab3b22371d1c450abc54422577b4512c",
+    "pre_built": false,
+    "version": "0.3.9",
+    "canonicalized_name": "dill",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=42"
+      }
+    ]
+  },
+  "docling==2.28.4": {
+    "download_url": "https://files.pythonhosted.org/packages/9b/6a/5916fec9e8d321d96182b42a855ecc18363ae18dbfb27d10a94ff95c1639/docling-2.28.4.tar.gz#sha256=d4e6c1ca787b176db930212340e0e8391c1b0b65dddcf2a3c4cdb92ce08acc15",
+    "pre_built": false,
+    "version": "2.28.4",
+    "canonicalized_name": "docling",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core"
+      },
+      {
+        "key": "beautifulsoup4==4.12.3",
+        "req_type": "install",
+        "req": "beautifulsoup4<5.0.0,>=4.12.3"
+      },
+      {
+        "key": "certifi==2024.12.14",
+        "req_type": "install",
+        "req": "certifi>=2024.7.4"
+      },
+      {
+        "key": "docling-core==2.25.0",
+        "req_type": "install",
+        "req": "docling-core[chunking]<3.0.0,>=2.24.1"
+      },
+      {
+        "key": "docling-ibm-models==3.4.1",
+        "req_type": "install",
+        "req": "docling-ibm-models<4.0.0,>=3.4.0"
+      },
+      {
+        "key": "docling-parse==4.0.0",
+        "req_type": "install",
+        "req": "docling-parse<5.0.0,>=4.0.0"
+      },
+      {
+        "key": "filetype==1.2.0",
+        "req_type": "install",
+        "req": "filetype<2.0.0,>=1.2.0"
+      },
+      {
+        "key": "huggingface-hub==0.30.1",
+        "req_type": "install",
+        "req": "huggingface_hub<1,>=0.23"
+      },
+      {
+        "key": "lxml==5.3.0",
+        "req_type": "install",
+        "req": "lxml<6.0.0,>=4.0.0"
+      },
+      {
+        "key": "marko==2.1.2",
+        "req_type": "install",
+        "req": "marko<3.0.0,>=2.1.2"
+      },
+      {
+        "key": "openpyxl==3.1.5",
+        "req_type": "install",
+        "req": "openpyxl<4.0.0,>=3.1.5"
+      },
+      {
+        "key": "pandas==2.2.3",
+        "req_type": "install",
+        "req": "pandas<3.0.0,>=2.1.4"
+      },
+      {
+        "key": "pillow==11.1.0",
+        "req_type": "install",
+        "req": "pillow<12.0.0,>=10.0.0"
+      },
+      {
+        "key": "pluggy==1.5.0",
+        "req_type": "install",
+        "req": "pluggy<2.0.0,>=1.0.0"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic<3.0.0,>=2.0.0"
+      },
+      {
+        "key": "pydantic-settings==2.7.1",
+        "req_type": "install",
+        "req": "pydantic-settings<3.0.0,>=2.3.0"
+      },
+      {
+        "key": "pylatexenc==2.10",
+        "req_type": "install",
+        "req": "pylatexenc<3.0,>=2.10"
+      },
+      {
+        "key": "pypdfium2==4.30.1",
+        "req_type": "install",
+        "req": "pypdfium2<5.0.0,>=4.30.0"
+      },
+      {
+        "key": "python-docx==1.1.2",
+        "req_type": "install",
+        "req": "python-docx<2.0.0,>=1.1.2"
+      },
+      {
+        "key": "python-pptx==1.0.2",
+        "req_type": "install",
+        "req": "python-pptx<2.0.0,>=1.0.2"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests<3.0.0,>=2.32.2"
+      },
+      {
+        "key": "rtree==1.3.0",
+        "req_type": "install",
+        "req": "rtree<2.0.0,>=1.3.0"
+      },
+      {
+        "key": "scipy==1.15.1",
+        "req_type": "install",
+        "req": "scipy<2.0.0,>=1.6.0; python_version >= \"3.10\""
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm<5.0.0,>=4.65.0"
+      },
+      {
+        "key": "typer==0.12.5",
+        "req_type": "install",
+        "req": "typer<0.13.0,>=0.12.5"
+      }
+    ]
+  },
+  "scipy==1.15.1": {
+    "download_url": "https://files.pythonhosted.org/packages/76/c6/8eb0654ba0c7d0bb1bf67bf8fbace101a8e4f250f7722371105e8b6f68fc/scipy-1.15.1.tar.gz#sha256=033a75ddad1463970c96a88063a1df87ccfddd526437136b6ee81ff0312ebdf6",
+    "pre_built": false,
+    "version": "1.15.1",
+    "canonicalized_name": "scipy",
+    "edges": [
+      {
+        "key": "cython==3.0.11",
+        "req_type": "build-system",
+        "req": "Cython<3.1.0,>=3.0.8"
+      },
+      {
+        "key": "meson-python==0.17.1",
+        "req_type": "build-system",
+        "req": "meson-python<0.20.0,>=0.15.0"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "build-system",
+        "req": "numpy<2.5,>=2.0.0"
+      },
+      {
+        "key": "pybind11==2.13.6",
+        "req_type": "build-system",
+        "req": "pybind11<2.14.0,>=2.13.2"
+      },
+      {
+        "key": "pythran==0.17.0",
+        "req_type": "build-system",
+        "req": "pythran<0.18.0,>=0.14.0"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy<2.5,>=1.23.5"
+      }
+    ]
+  },
+  "pythran==0.17.0": {
+    "download_url": "https://files.pythonhosted.org/packages/34/2d/4ac363a2eecd68c372b058d1b95a5f262c70776e107619cdcb5a4b68e1a3/pythran-0.17.0.tar.gz#sha256=3b77d6d970a6cf5b448facc7d4f6229c3e73909ac27ea2480c843afdadbad0fb",
+    "pre_built": false,
+    "version": "0.17.0",
+    "canonicalized_name": "pythran",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=62"
+      },
+      {
+        "key": "beniget==0.4.2.post1",
+        "req_type": "install",
+        "req": "beniget~=0.4.0"
+      },
+      {
+        "key": "gast==0.6.0",
+        "req_type": "install",
+        "req": "gast~=0.6.0"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy"
+      },
+      {
+        "key": "ply==3.11",
+        "req_type": "install",
+        "req": "ply>=3.4"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "install",
+        "req": "setuptools"
+      }
+    ]
+  },
+  "ply==3.11": {
+    "download_url": "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz#sha256=00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3",
+    "pre_built": false,
+    "version": "3.11",
+    "canonicalized_name": "ply",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "gast==0.6.0": {
+    "download_url": "https://github.com/serge-sans-paille/gast/archive/refs/tags/0.6.0.tar.gz",
+    "pre_built": false,
+    "version": "0.6.0",
+    "canonicalized_name": "gast",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "beniget==0.4.2.post1": {
+    "download_url": "https://files.pythonhosted.org/packages/2e/27/5bb01af8f2860d431b98d0721b96ff2cea979106cae3f2d093ec74f6400c/beniget-0.4.2.post1.tar.gz#sha256=a0258537e65e7e14ec33a86802f865a667f949bb6c73646d55e42f7c45a052ae",
+    "pre_built": false,
+    "version": "0.4.2.post1",
+    "canonicalized_name": "beniget",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "gast==0.6.0",
+        "req_type": "install",
+        "req": "gast>=0.5.0"
+      }
+    ]
+  },
+  "meson-python==0.17.1": {
+    "download_url": "https://files.pythonhosted.org/packages/67/66/91d242ea8dd1729addd36069318ba2cd03874872764f316c3bb51b633ed2/meson_python-0.17.1.tar.gz#sha256=efb91f69f2e19eef7bc9a471ed2a4e730088cc6b39eacaf3e49fc4f930eb5f83",
+    "pre_built": false,
+    "version": "0.17.1",
+    "canonicalized_name": "meson-python",
+    "edges": [
+      {
+        "key": "meson==1.7.0",
+        "req_type": "build-system",
+        "req": "meson>=0.63.3; python_version < \"3.12\""
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "build-system",
+        "req": "packaging>=19.0"
+      },
+      {
+        "key": "pyproject-metadata==0.9.0",
+        "req_type": "build-system",
+        "req": "pyproject-metadata>=0.7.1"
+      },
+      {
+        "key": "meson==1.7.0",
+        "req_type": "install",
+        "req": "meson>=0.63.3; python_version < \"3.12\""
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging>=19.0"
+      },
+      {
+        "key": "pyproject-metadata==0.9.0",
+        "req_type": "install",
+        "req": "pyproject-metadata>=0.7.1"
+      }
+    ]
+  },
+  "rtree==1.3.0": {
+    "download_url": "https://files.pythonhosted.org/packages/6e/79/44fdc619e87bd7b5388f76418719bd8b99de5565475f74a2e0d82b401062/rtree-1.3.0.tar.gz#sha256=b36e9dd2dc60ffe3d02e367242d2c26f7281b00e1aaf0c39590442edaaadd916",
+    "pre_built": false,
+    "version": "1.3.0",
+    "canonicalized_name": "rtree",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=61"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      }
+    ]
+  },
+  "python-pptx==1.0.2": {
+    "download_url": "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz#sha256=479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095",
+    "pre_built": false,
+    "version": "1.0.2",
+    "canonicalized_name": "python-pptx",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=61.0.0"
+      },
+      {
+        "key": "pillow==11.1.0",
+        "req_type": "install",
+        "req": "Pillow>=3.3.2"
+      },
+      {
+        "key": "xlsxwriter==3.2.1",
+        "req_type": "install",
+        "req": "XlsxWriter>=0.5.7"
+      },
+      {
+        "key": "lxml==5.3.0",
+        "req_type": "install",
+        "req": "lxml>=3.1.0"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions>=4.9.0"
+      }
+    ]
+  },
+  "lxml==5.3.0": {
+    "download_url": "https://files.pythonhosted.org/packages/e7/6b/20c3a4b24751377aaa6307eb230b66701024012c29dd374999cc92983269/lxml-5.3.0.tar.gz#sha256=4e109ca30d1edec1ac60cdbe341905dc3b8f55b16855e03a54aaf59e51ec8c6f",
+    "pre_built": false,
+    "version": "5.3.0",
+    "canonicalized_name": "lxml",
+    "edges": [
+      {
+        "key": "cython==3.0.11",
+        "req_type": "build-system",
+        "req": "Cython>=3.0.11"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      }
+    ]
+  },
+  "xlsxwriter==3.2.1": {
+    "download_url": "https://files.pythonhosted.org/packages/48/4f/108b0bada5cfcc47c24ea6181f4c563fbafef50bcc0054089c256b2ae578/XlsxWriter-3.2.1.tar.gz#sha256=97618759cb264fb6a93397f660cca156ffa9561743b1823dafb60dc4474e1902",
+    "pre_built": false,
+    "version": "3.2.1",
+    "canonicalized_name": "xlsxwriter",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "python-docx==1.1.2": {
+    "download_url": "https://files.pythonhosted.org/packages/35/e4/386c514c53684772885009c12b67a7edd526c15157778ac1b138bc75063e/python_docx-1.1.2.tar.gz#sha256=0cf1f22e95b9002addca7948e16f2cd7acdfd498047f1941ca5d293db7762efd",
+    "pre_built": false,
+    "version": "1.1.2",
+    "canonicalized_name": "python-docx",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=61.0.0"
+      },
+      {
+        "key": "lxml==5.3.0",
+        "req_type": "install",
+        "req": "lxml>=3.1.0"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions>=4.9.0"
+      }
+    ]
+  },
+  "pypdfium2==4.30.1": {
+    "download_url": "https://files.pythonhosted.org/packages/55/d4/905e621c62598a08168c272b42fc00136c8861cfce97afb2a1ecbd99487a/pypdfium2-4.30.1.tar.gz#sha256=5f5c7c6d03598e107d974f66b220a49436aceb191da34cda5f692be098a814ce",
+    "pre_built": false,
+    "version": "4.30.1",
+    "canonicalized_name": "pypdfium2",
+    "edges": [
+      {
+        "key": "packaging==24.2",
+        "req_type": "build-system",
+        "req": "packaging"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel!=0.38.0,!=0.38.1"
+      }
+    ]
+  },
+  "pylatexenc==2.10": {
+    "download_url": "https://files.pythonhosted.org/packages/5d/ab/34ec41718af73c00119d0351b7a2531d2ebddb51833a36448fc7b862be60/pylatexenc-2.10.tar.gz#sha256=3dd8fd84eb46dc30bee1e23eaab8d8fb5a7f507347b23e5f38ad9675c84f40d3",
+    "pre_built": false,
+    "version": "2.10",
+    "canonicalized_name": "pylatexenc",
+    "edges": [
+      {
+        "key": "setuptools==78.1.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "setuptools==78.1.0": {
+    "download_url": "https://files.pythonhosted.org/packages/a9/5a/0db4da3bc908df06e5efae42b44e75c81dd52716e10192ff36d0c1c8e379/setuptools-78.1.0.tar.gz#sha256=18fd474d4a82a5f83dac888df697af65afa82dec7323d09c3e37d1f14288da54",
+    "pre_built": false,
+    "version": "78.1.0",
+    "canonicalized_name": "setuptools",
+    "edges": []
+  },
+  "pydantic-settings==2.7.1": {
+    "download_url": "https://files.pythonhosted.org/packages/73/7b/c58a586cd7d9ac66d2ee4ba60ca2d241fa837c02bca9bea80a9a8c3d22a9/pydantic_settings-2.7.1.tar.gz#sha256=10c9caad35e64bfb3c2fbf70a078c0e25cc92499782e5200747f942a065dec93",
+    "pre_built": false,
+    "version": "2.7.1",
+    "canonicalized_name": "pydantic-settings",
+    "edges": [
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic>=2.7.0"
+      },
+      {
+        "key": "python-dotenv==1.0.1",
+        "req_type": "install",
+        "req": "python-dotenv>=0.21.0"
+      }
+    ]
+  },
+  "python-dotenv==1.0.1": {
+    "download_url": "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz#sha256=e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca",
+    "pre_built": false,
+    "version": "1.0.1",
+    "canonicalized_name": "python-dotenv",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "openpyxl==3.1.5": {
+    "download_url": "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz#sha256=cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050",
+    "pre_built": false,
+    "version": "3.1.5",
+    "canonicalized_name": "openpyxl",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "et-xmlfile==2.0.0",
+        "req_type": "install",
+        "req": "et-xmlfile"
+      }
+    ]
+  },
+  "et-xmlfile==2.0.0": {
+    "download_url": "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz#sha256=dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54",
+    "pre_built": false,
+    "version": "2.0.0",
+    "canonicalized_name": "et-xmlfile",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "marko==2.1.2": {
+    "download_url": "https://files.pythonhosted.org/packages/8c/38/6ea5d8600b94432656c669816a479580d9f1c49ef6b426282f4ba261ae9b/marko-2.1.2.tar.gz#sha256=a9170006b879376e6845c91b1ae3dce2992772954b99b70175ff888537186011",
+    "pre_built": false,
+    "version": "2.1.2",
+    "canonicalized_name": "marko",
+    "edges": [
+      {
+        "key": "pdm-backend==2.4.3",
+        "req_type": "build-system",
+        "req": "pdm-backend"
+      }
+    ]
+  },
+  "filetype==1.2.0": {
+    "download_url": "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz#sha256=66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb",
+    "pre_built": false,
+    "version": "1.2.0",
+    "canonicalized_name": "filetype",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "docling-ibm-models==3.4.1": {
+    "download_url": "https://files.pythonhosted.org/packages/eb/a5/88d5b7c970d5e10a06062fe9e9de3cde6acdefcc1f85854f689a82863c2a/docling_ibm_models-3.4.1.tar.gz#sha256=093b4dff2ea284a4953c3aa009e29945208b8d389b94fb14940a03a93f673e96",
+    "pre_built": false,
+    "version": "3.4.1",
+    "canonicalized_name": "docling-ibm-models",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0"
+      },
+      {
+        "key": "pillow==10.4.0",
+        "req_type": "install",
+        "req": "Pillow<12.0.0,>=10.0.0"
+      },
+      {
+        "key": "docling-core==2.25.0",
+        "req_type": "install",
+        "req": "docling-core<3.0.0,>=2.19.0"
+      },
+      {
+        "key": "huggingface-hub==0.30.1",
+        "req_type": "install",
+        "req": "huggingface_hub<1,>=0.23"
+      },
+      {
+        "key": "jsonlines==3.1.0",
+        "req_type": "install",
+        "req": "jsonlines<4.0.0,>=3.1.0"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy<3.0.0,>=1.24.4; sys_platform != \"darwin\" or platform_machine != \"x86_64\""
+      },
+      {
+        "key": "opencv-python-headless==4.11.0.86",
+        "req_type": "install",
+        "req": "opencv-python-headless<5.0.0.0,>=4.6.0.66"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic<3.0.0,>=2.0.0"
+      },
+      {
+        "key": "safetensors==0.4.5",
+        "req_type": "install",
+        "req": "safetensors[torch]<1,>=0.4.3"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "install",
+        "req": "torch<3.0.0,>=2.2.2"
+      },
+      {
+        "key": "torchvision==0.20.1",
+        "req_type": "install",
+        "req": "torchvision<1,>=0"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm<5.0.0,>=4.64.0"
+      },
+      {
+        "key": "transformers==4.51.0",
+        "req_type": "install",
+        "req": "transformers<5.0.0,>=4.42.0; sys_platform != \"darwin\" or platform_machine != \"x86_64\""
+      }
+    ]
+  },
+  "transformers==4.51.0": {
+    "download_url": "https://files.pythonhosted.org/packages/38/75/6ebdae4d6f4574f47139a070445245537e43482d006f615af8e23d5bf05e/transformers-4.51.0.tar.gz#sha256=2d302563ff6c2cc2d0e88ef352cf059f9a21ce18102fd43662bb1246f70b8a84",
+    "pre_built": false,
+    "version": "4.51.0",
+    "canonicalized_name": "transformers",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "filelock==3.17.0",
+        "req_type": "install",
+        "req": "filelock"
+      },
+      {
+        "key": "huggingface-hub==0.30.1",
+        "req_type": "install",
+        "req": "huggingface-hub<1.0,>=0.30.0"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy>=1.17"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging>=20.0"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml>=5.1"
+      },
+      {
+        "key": "regex==2024.11.6",
+        "req_type": "install",
+        "req": "regex!=2019.12.17"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests"
+      },
+      {
+        "key": "safetensors==0.4.5",
+        "req_type": "install",
+        "req": "safetensors>=0.4.3"
+      },
+      {
+        "key": "tokenizers==0.21.0",
+        "req_type": "install",
+        "req": "tokenizers<0.22,>=0.21"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm>=4.27"
+      }
+    ]
+  },
+  "torchvision==0.20.1": {
+    "download_url": "https://files.pythonhosted.org/packages/de/e9/e190ecec448d5a2abad8348cf085fcb39962a491e3f40dcb023721e04feb/torchvision-0.20.1-cp311-cp311-manylinux1_x86_64.whl#sha256=86f6523dee420000fe14c3527f6c8e0175139fda7d995b187f54a0b0ebec7eb6",
+    "pre_built": false,
+    "version": "0.20.1",
+    "canonicalized_name": "torchvision",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "build-system",
+        "req": "torch"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy"
+      },
+      {
+        "key": "pillow==11.1.0",
+        "req_type": "install",
+        "req": "pillow!=8.3.*,>=5.3.0"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "install",
+        "req": "torch"
+      }
+    ]
+  },
+  "opencv-python-headless==4.11.0.86": {
+    "download_url": "https://files.pythonhosted.org/packages/36/2f/5b2b3ba52c864848885ba988f24b7f105052f68da9ab0e693cc7c25b0b30/opencv-python-headless-4.11.0.86.tar.gz#sha256=996eb282ca4b43ec6a3972414de0e2331f5d9cda2b41091a49739c19fb843798",
+    "pre_built": false,
+    "version": "4.11.0.86",
+    "canonicalized_name": "opencv-python-headless",
+    "edges": [
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "build-system",
+        "req": "numpy>=2.0.0; python_version >= \"3.9\""
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "build-system",
+        "req": "packaging"
+      },
+      {
+        "key": "pip==25.0",
+        "req_type": "build-system",
+        "req": "pip"
+      },
+      {
+        "key": "scikit-build==0.18.1",
+        "req_type": "build-system",
+        "req": "scikit-build>=0.14.0"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy>=1.17.3; python_version >= \"3.8\""
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy>=1.21.2; python_version >= \"3.10\""
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy>=1.17.0; python_version >= \"3.7\""
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy>=1.19.3; python_version >= \"3.9\""
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy>=1.23.5; python_version >= \"3.11\""
+      }
+    ]
+  },
+  "pip==25.0": {
+    "download_url": "https://files.pythonhosted.org/packages/47/3e/68beeeeb306ea20ffd30b3ed993f531d16cd884ec4f60c9b1e238f69f2af/pip-25.0.tar.gz#sha256=8e0a97f7b4c47ae4a494560da84775e9e2f671d415d8d828e052efefb206b30b",
+    "pre_built": false,
+    "version": "25.0",
+    "canonicalized_name": "pip",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=67.6.1"
+      }
+    ]
+  },
+  "jsonlines==3.1.0": {
+    "download_url": "https://files.pythonhosted.org/packages/2a/c8/efdb87403dae07cf20faf75449eae41898b71d6a8d4ebaf9c80d5be215f5/jsonlines-3.1.0.tar.gz#sha256=2579cb488d96f815b0eb81629e3e6b0332da0962a18fa3532958f7ba14a5c37f",
+    "pre_built": false,
+    "version": "3.1.0",
+    "canonicalized_name": "jsonlines",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "attrs==25.1.0",
+        "req_type": "install",
+        "req": "attrs>=19.2.0"
+      }
+    ]
+  },
+  "beautifulsoup4==4.12.3": {
+    "download_url": "https://files.pythonhosted.org/packages/b3/ca/824b1195773ce6166d388573fc106ce56d4a805bd7427b624e063596ec58/beautifulsoup4-4.12.3.tar.gz#sha256=74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051",
+    "pre_built": false,
+    "version": "4.12.3",
+    "canonicalized_name": "beautifulsoup4",
+    "edges": [
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      },
+      {
+        "key": "soupsieve==2.6",
+        "req_type": "install",
+        "req": "soupsieve>1.2"
+      }
+    ]
+  },
+  "soupsieve==2.6": {
+    "download_url": "https://files.pythonhosted.org/packages/d7/ce/fbaeed4f9fb8b2daa961f90591662df6a86c1abf25c548329a86920aedfb/soupsieve-2.6.tar.gz#sha256=e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb",
+    "pre_built": false,
+    "version": "2.6",
+    "canonicalized_name": "soupsieve",
+    "edges": [
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling>=0.21.1"
+      }
+    ]
+  },
+  "kfp==2.11.0": {
+    "download_url": "https://files.pythonhosted.org/packages/ff/23/f2cbf26c53585c45e02156ea68547f97c1880dfd63377b059d4c0305215c/kfp-2.11.0.tar.gz#sha256=7195019246f800fb842bb071c8d3a106ca3d2e812540f90a6b23c3ed19207ae5",
+    "pre_built": false,
+    "version": "2.11.0",
+    "canonicalized_name": "kfp",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "instructlab-sdg==0.7.2": {
+    "download_url": "https://files.pythonhosted.org/packages/2d/7e/defa73113c058058046ee8f0cad860e19a1b41d686b2c18ab2e1a473edd8/instructlab_sdg-0.7.2.tar.gz#sha256=572c6a23371d7aa1929284569a7fe4454ae2d34faf579ea4289011826f418302",
+    "pre_built": false,
+    "version": "0.7.2",
+    "canonicalized_name": "instructlab-sdg",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=64"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm>=8"
+      },
+      {
+        "key": "gitpython==3.1.44",
+        "req_type": "install",
+        "req": "GitPython<4.0.0,>=3.1.42"
+      },
+      {
+        "key": "click==8.1.8",
+        "req_type": "install",
+        "req": "click<9.0.0,>=8.1.7"
+      },
+      {
+        "key": "datasets==2.21.0",
+        "req_type": "install",
+        "req": "datasets<3.0.0,>=2.18.0"
+      },
+      {
+        "key": "docling==2.8.3",
+        "req_type": "install",
+        "req": "docling[tesserocr]<=2.8.3,>=2.4.2; sys_platform != \"darwin\""
+      },
+      {
+        "key": "docling-parse==2.1.2",
+        "req_type": "install",
+        "req": "docling-parse<3.0.0,>=2.0.0"
+      },
+      {
+        "key": "gguf==0.14.0",
+        "req_type": "install",
+        "req": "gguf>=0.6.0"
+      },
+      {
+        "key": "httpx==0.28.1",
+        "req_type": "install",
+        "req": "httpx<1.0.0,>=0.25.0"
+      },
+      {
+        "key": "instructlab-schema==0.4.2",
+        "req_type": "install",
+        "req": "instructlab-schema>=0.4.0"
+      },
+      {
+        "key": "jinja2==3.1.5",
+        "req_type": "install",
+        "req": "jinja2>=3.0.0"
+      },
+      {
+        "key": "langchain-text-splitters==0.3.5",
+        "req_type": "install",
+        "req": "langchain-text-splitters"
+      },
+      {
+        "key": "openai==1.65.5",
+        "req_type": "install",
+        "req": "openai<2.0.0,>=1.13.3"
+      },
+      {
+        "key": "sentencepiece==0.2.0",
+        "req_type": "install",
+        "req": "sentencepiece>=0.2.0"
+      },
+      {
+        "key": "tabulate==0.9.0",
+        "req_type": "install",
+        "req": "tabulate>=0.9.0"
+      },
+      {
+        "key": "tenacity==9.0.0",
+        "req_type": "install",
+        "req": "tenacity!=8.4.0,>=8.3.0"
+      },
+      {
+        "key": "transformers==4.48.1",
+        "req_type": "install",
+        "req": "transformers>=4.41.2"
+      },
+      {
+        "key": "xdg-base-dirs==6.0.2",
+        "req_type": "install",
+        "req": "xdg-base-dirs>=6.0.1"
+      }
+    ]
+  },
+  "xdg-base-dirs==6.0.2": {
+    "download_url": "https://files.pythonhosted.org/packages/bf/d0/bbe05a15347538aaf9fa5b51ac3b97075dfb834931fcb77d81fbdb69e8f6/xdg_base_dirs-6.0.2.tar.gz#sha256=950504e14d27cf3c9cb37744680a43bf0ac42efefc4ef4acf98dc736cab2bced",
+    "pre_built": false,
+    "version": "6.0.2",
+    "canonicalized_name": "xdg-base-dirs",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0"
+      }
+    ]
+  },
+  "tenacity==9.0.0": {
+    "download_url": "https://files.pythonhosted.org/packages/cd/94/91fccdb4b8110642462e653d5dcb27e7b674742ad68efd146367da7bdb10/tenacity-9.0.0.tar.gz#sha256=807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b",
+    "pre_built": false,
+    "version": "9.0.0",
+    "canonicalized_name": "tenacity",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools!=24.0.0,!=34.0.0,!=34.0.1,!=34.0.2,!=34.0.3,!=34.1.0,!=34.1.1,!=34.2.0,!=34.3.0,!=34.3.1,!=34.3.2,!=36.2.0,>=21.0.0"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm[toml]>=3.4"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-backend",
+        "req": "setuptools_scm"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-sdist",
+        "req": "setuptools_scm"
+      }
+    ]
+  },
+  "sentencepiece==0.2.0": {
+    "download_url": "https://files.pythonhosted.org/packages/c9/d2/b9c7ca067c26d8ff085d252c89b5f69609ca93fb85a00ede95f4857865d4/sentencepiece-0.2.0.tar.gz#sha256=a52c19171daaf2e697dc6cbe67684e0fa341b1248966f6aebb541de654d15843",
+    "pre_built": false,
+    "version": "0.2.0",
+    "canonicalized_name": "sentencepiece",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "openai==1.65.5": {
+    "download_url": "https://files.pythonhosted.org/packages/56/cf/e02fb2c5a834803e6f29f43fd3dfe010303282d1ea450a5b95e28608860a/openai-1.65.5.tar.gz#sha256=17d39096bbcaf6c86580244b493a59e16613460147f0ba5ab6e608cdb6628149",
+    "pre_built": false,
+    "version": "1.65.5",
+    "canonicalized_name": "openai",
+    "edges": [
+      {
+        "key": "hatch-fancy-pypi-readme==24.1.0",
+        "req_type": "build-system",
+        "req": "hatch-fancy-pypi-readme"
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      },
+      {
+        "key": "anyio==4.8.0",
+        "req_type": "install",
+        "req": "anyio<5,>=3.5.0"
+      },
+      {
+        "key": "distro==1.9.0",
+        "req_type": "install",
+        "req": "distro<2,>=1.7.0"
+      },
+      {
+        "key": "httpx==0.28.1",
+        "req_type": "install",
+        "req": "httpx<1,>=0.23.0"
+      },
+      {
+        "key": "jiter==0.8.2",
+        "req_type": "install",
+        "req": "jiter<1,>=0.4.0"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic<3,>=1.9.0"
+      },
+      {
+        "key": "sniffio==1.3.1",
+        "req_type": "install",
+        "req": "sniffio"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm>4"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions<5,>=4.11"
+      }
+    ]
+  },
+  "sniffio==1.3.1": {
+    "download_url": "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz#sha256=f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc",
+    "pre_built": false,
+    "version": "1.3.1",
+    "canonicalized_name": "sniffio",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=64"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm>=6.4"
+      }
+    ]
+  },
+  "jiter==0.8.2": {
+    "download_url": "https://files.pythonhosted.org/packages/f8/70/90bc7bd3932e651486861df5c8ffea4ca7c77d28e8532ddefe2abc561a53/jiter-0.8.2.tar.gz#sha256=cd73d3e740666d0e639f678adb176fad25c1bcbdae88d8d7b857e1783bb4212d",
+    "pre_built": false,
+    "version": "0.8.2",
+    "canonicalized_name": "jiter",
+    "edges": [
+      {
+        "key": "maturin==1.8.1",
+        "req_type": "build-system",
+        "req": "maturin<2,>=1"
+      }
+    ]
+  },
+  "httpx==0.28.1": {
+    "download_url": "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz#sha256=75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc",
+    "pre_built": false,
+    "version": "0.28.1",
+    "canonicalized_name": "httpx",
+    "edges": [
+      {
+        "key": "hatch-fancy-pypi-readme==24.1.0",
+        "req_type": "build-system",
+        "req": "hatch-fancy-pypi-readme"
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      },
+      {
+        "key": "anyio==4.8.0",
+        "req_type": "install",
+        "req": "anyio"
+      },
+      {
+        "key": "certifi==2024.12.14",
+        "req_type": "install",
+        "req": "certifi"
+      },
+      {
+        "key": "httpcore==1.0.7",
+        "req_type": "install",
+        "req": "httpcore==1.*"
+      },
+      {
+        "key": "idna==3.10",
+        "req_type": "install",
+        "req": "idna"
+      }
+    ]
+  },
+  "httpcore==1.0.7": {
+    "download_url": "https://files.pythonhosted.org/packages/6a/41/d7d0a89eb493922c37d343b607bc1b5da7f5be7e383740b4753ad8943e90/httpcore-1.0.7.tar.gz#sha256=8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c",
+    "pre_built": false,
+    "version": "1.0.7",
+    "canonicalized_name": "httpcore",
+    "edges": [
+      {
+        "key": "hatch-fancy-pypi-readme==24.1.0",
+        "req_type": "build-system",
+        "req": "hatch-fancy-pypi-readme"
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      },
+      {
+        "key": "certifi==2024.12.14",
+        "req_type": "install",
+        "req": "certifi"
+      },
+      {
+        "key": "h11==0.14.0",
+        "req_type": "install",
+        "req": "h11<0.15,>=0.13"
+      }
+    ]
+  },
+  "h11==0.14.0": {
+    "download_url": "https://files.pythonhosted.org/packages/f5/38/3af3d3633a34a3316095b39c8e8fb4853a28a536e55d347bd8d8e9a14b03/h11-0.14.0.tar.gz#sha256=8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d",
+    "pre_built": false,
+    "version": "0.14.0",
+    "canonicalized_name": "h11",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "anyio==4.8.0": {
+    "download_url": "https://files.pythonhosted.org/packages/a3/73/199a98fc2dae33535d6b8e8e6ec01f8c1d76c9adb096c6b7d64823038cde/anyio-4.8.0.tar.gz#sha256=1d9fe889df5212298c0c0723fa20479d1b94883a2df44bd3897aa91083316f7a",
+    "pre_built": false,
+    "version": "4.8.0",
+    "canonicalized_name": "anyio",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=64"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm>=6.4"
+      },
+      {
+        "key": "idna==3.10",
+        "req_type": "install",
+        "req": "idna>=2.8"
+      },
+      {
+        "key": "sniffio==1.3.1",
+        "req_type": "install",
+        "req": "sniffio>=1.1"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing_extensions>=4.5; python_version < \"3.13\""
+      }
+    ]
+  },
+  "langchain-text-splitters==0.3.5": {
+    "download_url": "https://files.pythonhosted.org/packages/10/35/a6f8d6b1bb0e6e8c00b49bce4d1a115f8b68368b1899f65bb34dbbb44160/langchain_text_splitters-0.3.5.tar.gz#sha256=11cb7ca3694e5bdd342bc16d3875b7f7381651d4a53cbb91d34f22412ae16443",
+    "pre_built": false,
+    "version": "0.3.5",
+    "canonicalized_name": "langchain-text-splitters",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0"
+      },
+      {
+        "key": "langchain-core==0.3.31",
+        "req_type": "install",
+        "req": "langchain-core<0.4.0,>=0.3.29"
+      }
+    ]
+  },
+  "langchain-core==0.3.31": {
+    "download_url": "https://files.pythonhosted.org/packages/7b/ad/b8b70ce5c0660b7cd945a49417c9321716d8866b5a4581927fcd90a620f8/langchain_core-0.3.31.tar.gz#sha256=5ffa56354c07de9efaa4139609659c63e7d9b29da2c825f6bab9392ec98300df",
+    "pre_built": false,
+    "version": "0.3.31",
+    "canonicalized_name": "langchain-core",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "PyYAML>=5.3"
+      },
+      {
+        "key": "jsonpatch==1.33",
+        "req_type": "install",
+        "req": "jsonpatch<2.0,>=1.33"
+      },
+      {
+        "key": "langsmith==0.3.2",
+        "req_type": "install",
+        "req": "langsmith<0.4,>=0.1.125"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging<25,>=23.2"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic<3.0.0,>=2.5.2; python_full_version < \"3.12.4\""
+      },
+      {
+        "key": "tenacity==9.0.0",
+        "req_type": "install",
+        "req": "tenacity!=8.4.0,<10.0.0,>=8.1.0"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions>=4.7"
+      }
+    ]
+  },
+  "langsmith==0.3.2": {
+    "download_url": "https://files.pythonhosted.org/packages/75/85/081bc035b0a64f364973e9dc43dcecddb3bf7ed7166254731564716eeb47/langsmith-0.3.2.tar.gz#sha256=7724668e9705734ab25a7977fc34a9ee15a40ba4108987926c69293a05d40229",
+    "pre_built": false,
+    "version": "0.3.2",
+    "canonicalized_name": "langsmith",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core"
+      },
+      {
+        "key": "httpx==0.28.1",
+        "req_type": "install",
+        "req": "httpx<1,>=0.23.0"
+      },
+      {
+        "key": "orjson==3.10.13",
+        "req_type": "install",
+        "req": "orjson<4.0.0,>=3.9.14; platform_python_implementation != \"PyPy\""
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic<3,>=1; python_full_version < \"3.12.4\""
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests<3,>=2"
+      },
+      {
+        "key": "requests-toolbelt==1.0.0",
+        "req_type": "install",
+        "req": "requests-toolbelt<2.0.0,>=1.0.0"
+      },
+      {
+        "key": "zstandard==0.23.0",
+        "req_type": "install",
+        "req": "zstandard<0.24.0,>=0.23.0"
+      }
+    ]
+  },
+  "zstandard==0.23.0": {
+    "download_url": "https://files.pythonhosted.org/packages/ed/f6/2ac0287b442160a89d726b17a9184a4c615bb5237db763791a7fd16d9df1/zstandard-0.23.0.tar.gz#sha256=b2d8c62d08e7255f68f7a740bae85b3c9b8e5466baa9cbf7f57f1cde0ac6bc09",
+    "pre_built": false,
+    "version": "0.23.0",
+    "canonicalized_name": "zstandard",
+    "edges": [
+      {
+        "key": "cffi==1.17.1",
+        "req_type": "build-system",
+        "req": "cffi>=1.16.0; python_version <= \"3.12\""
+      },
+      {
+        "key": "setuptools==68.2.2",
+        "req_type": "build-system",
+        "req": "setuptools<69.0.0"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-backend",
+        "req": "wheel"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-sdist",
+        "req": "wheel"
+      }
+    ]
+  },
+  "setuptools==68.2.2": {
+    "download_url": "https://files.pythonhosted.org/packages/ef/cc/93f7213b2ab5ed383f98ce8020e632ef256b406b8569606c3f160ed8e1c9/setuptools-68.2.2.tar.gz#sha256=4ac1475276d2f1c48684874089fefcd83bd7162ddaafb81fac866ba0db282a87",
+    "pre_built": false,
+    "version": "68.2.2",
+    "canonicalized_name": "setuptools",
+    "edges": [
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-backend",
+        "req": "wheel"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-sdist",
+        "req": "wheel"
+      }
+    ]
+  },
+  "cffi==1.17.1": {
+    "download_url": "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz#sha256=1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824",
+    "pre_built": false,
+    "version": "1.17.1",
+    "canonicalized_name": "cffi",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=66.1"
+      },
+      {
+        "key": "pycparser==2.22",
+        "req_type": "install",
+        "req": "pycparser"
+      }
+    ]
+  },
+  "pycparser==2.22": {
+    "download_url": "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz#sha256=491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6",
+    "pre_built": false,
+    "version": "2.22",
+    "canonicalized_name": "pycparser",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "requests-toolbelt==1.0.0": {
+    "download_url": "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz#sha256=7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6",
+    "pre_built": false,
+    "version": "1.0.0",
+    "canonicalized_name": "requests-toolbelt",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests<3.0.0,>=2.0.1"
+      }
+    ]
+  },
+  "orjson==3.10.13": {
+    "download_url": "https://files.pythonhosted.org/packages/45/0b/8c7eaf1e2152f1e0fb28ae7b22e2b35a6b1992953a1ebe0371ba4d41d3ad/orjson-3.10.13.tar.gz#sha256=eb9bfb14ab8f68d9d9492d4817ae497788a15fd7da72e14dfabc289c3bb088ec",
+    "pre_built": false,
+    "version": "3.10.13",
+    "canonicalized_name": "orjson",
+    "edges": [
+      {
+        "key": "maturin==1.7.8",
+        "req_type": "build-system",
+        "req": "maturin==1.7.8"
+      }
+    ]
+  },
+  "maturin==1.7.8": {
+    "download_url": "https://files.pythonhosted.org/packages/ab/1e/085ddc0e5b08ae7af7a743a0dd6ed06b22a1332288488f1a333137885150/maturin-1.7.8.tar.gz#sha256=649c6ef3f0fa4c5f596140d761dc5a4d577c485cc32fb5b9b344a8280352880d",
+    "pre_built": false,
+    "version": "1.7.8",
+    "canonicalized_name": "maturin",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      },
+      {
+        "key": "setuptools-rust==1.10.2",
+        "req_type": "build-system",
+        "req": "setuptools-rust>=1.4.0"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel>=0.36.2"
+      }
+    ]
+  },
+  "jsonpatch==1.33": {
+    "download_url": "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz#sha256=9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c",
+    "pre_built": false,
+    "version": "1.33",
+    "canonicalized_name": "jsonpatch",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "jsonpointer==3.0.0",
+        "req_type": "install",
+        "req": "jsonpointer>=1.9"
+      }
+    ]
+  },
+  "jsonpointer==3.0.0": {
+    "download_url": "https://files.pythonhosted.org/packages/6a/0a/eebeb1fa92507ea94016a2a790b93c2ae41a7e18778f85471dc54475ed25/jsonpointer-3.0.0.tar.gz#sha256=2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef",
+    "pre_built": false,
+    "version": "3.0.0",
+    "canonicalized_name": "jsonpointer",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "instructlab-schema==0.4.2": {
+    "download_url": "https://files.pythonhosted.org/packages/25/a4/cc7739ef88de649123c7c0dd3972c7ec0226dfab91410c54efa5254a4eef/instructlab_schema-0.4.2.tar.gz#sha256=03274e97012796f6d8ba57ad797ab82e2f5cdecf4ec61635d7f8c6effbe3d31e",
+    "pre_built": false,
+    "version": "0.4.2",
+    "canonicalized_name": "instructlab-schema",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=70.1.0"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm>=8"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "PyYAML>=6.0.0"
+      },
+      {
+        "key": "jsonschema==4.23.0",
+        "req_type": "install",
+        "req": "jsonschema>=4.22.0"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing_extensions"
+      },
+      {
+        "key": "yamllint==1.35.1",
+        "req_type": "install",
+        "req": "yamllint>=1.35.1"
+      }
+    ]
+  },
+  "yamllint==1.35.1": {
+    "download_url": "https://files.pythonhosted.org/packages/da/06/d8cee5c3dfd550cc0a466ead8b321138198485d1034130ac1393cc49d63e/yamllint-1.35.1.tar.gz#sha256=7a003809f88324fd2c877734f2d575ee7881dd9043360657cc8049c809eba6cd",
+    "pre_built": false,
+    "version": "1.35.1",
+    "canonicalized_name": "yamllint",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=61"
+      },
+      {
+        "key": "pathspec==0.12.1",
+        "req_type": "install",
+        "req": "pathspec>=0.5.3"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml"
+      }
+    ]
+  },
+  "gguf==0.14.0": {
+    "download_url": "https://files.pythonhosted.org/packages/e4/51/d532d776d01d9ed60d930fe58554ecb05806fc9aaffa2400344d3a9d630b/gguf-0.14.0.tar.gz#sha256=d9996f197a777831cf9e01efac24cbfa817787375305b8c4ee16074778e2bce8",
+    "pre_built": false,
+    "version": "0.14.0",
+    "canonicalized_name": "gguf",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy>=1.17"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml>=5.1"
+      },
+      {
+        "key": "sentencepiece==0.2.0",
+        "req_type": "install",
+        "req": "sentencepiece<=0.2.0,>=0.1.98"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm>=4.27"
+      }
+    ]
+  },
+  "docling-parse==2.1.2": {
+    "download_url": "https://files.pythonhosted.org/packages/85/9a/58855094b70708aa00529a959e4e6e17ef0f7c23a492eed7277002f8bc27/docling_parse-2.1.2.tar.gz#sha256=3c249f50e6351eb6126331a179fe86b64dc2073e9f881d52f8c8fb391633b89e",
+    "pre_built": false,
+    "version": "2.1.2",
+    "canonicalized_name": "docling-parse",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core"
+      },
+      {
+        "key": "pybind11==2.13.6",
+        "req_type": "build-system",
+        "req": "pybind11>=2.13.1"
+      },
+      {
+        "key": "tabulate==0.9.0",
+        "req_type": "install",
+        "req": "tabulate<1.0.0,>=0.9.0"
+      }
+    ]
+  },
+  "docling==2.8.3": {
+    "download_url": "https://files.pythonhosted.org/packages/5e/f8/4c5ce7f0c79338a20c208100913ef49090388fdd6f5d6ad52e07c581f6a4/docling-2.8.3.tar.gz#sha256=2273182748171b312c2efd547c92bec7cb02601090ddb7bfa8f33d26c388b622",
+    "pre_built": false,
+    "version": "2.8.3",
+    "canonicalized_name": "docling",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core"
+      },
+      {
+        "key": "beautifulsoup4==4.12.3",
+        "req_type": "install",
+        "req": "beautifulsoup4<5.0.0,>=4.12.3"
+      },
+      {
+        "key": "certifi==2024.12.14",
+        "req_type": "install",
+        "req": "certifi>=2024.7.4"
+      },
+      {
+        "key": "deepsearch-glm==0.26.2",
+        "req_type": "install",
+        "req": "deepsearch-glm<0.27.0,>=0.26.1"
+      },
+      {
+        "key": "docling-core==2.15.1",
+        "req_type": "install",
+        "req": "docling-core<3.0.0,>=2.6.1"
+      },
+      {
+        "key": "docling-ibm-models==2.0.8",
+        "req_type": "install",
+        "req": "docling-ibm-models<3.0.0,>=2.0.6"
+      },
+      {
+        "key": "docling-parse==2.1.2",
+        "req_type": "install",
+        "req": "docling-parse<3.0.0,>=2.0.5"
+      },
+      {
+        "key": "filetype==1.2.0",
+        "req_type": "install",
+        "req": "filetype<2.0.0,>=1.2.0"
+      },
+      {
+        "key": "huggingface-hub==0.30.1",
+        "req_type": "install",
+        "req": "huggingface_hub<1,>=0.23"
+      },
+      {
+        "key": "lxml==5.3.0",
+        "req_type": "install",
+        "req": "lxml<6.0.0,>=4.0.0"
+      },
+      {
+        "key": "marko==2.1.2",
+        "req_type": "install",
+        "req": "marko<3.0.0,>=2.1.2"
+      },
+      {
+        "key": "openpyxl==3.1.5",
+        "req_type": "install",
+        "req": "openpyxl<4.0.0,>=3.1.5"
+      },
+      {
+        "key": "pandas==2.2.3",
+        "req_type": "install",
+        "req": "pandas<3.0.0,>=2.1.4"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic<2.10,>=2.0.0"
+      },
+      {
+        "key": "pydantic-settings==2.7.1",
+        "req_type": "install",
+        "req": "pydantic-settings<3.0.0,>=2.3.0"
+      },
+      {
+        "key": "pypdfium2==4.30.1",
+        "req_type": "install",
+        "req": "pypdfium2<5.0.0,>=4.30.0"
+      },
+      {
+        "key": "python-docx==1.1.2",
+        "req_type": "install",
+        "req": "python-docx<2.0.0,>=1.1.2"
+      },
+      {
+        "key": "python-pptx==1.0.2",
+        "req_type": "install",
+        "req": "python-pptx<2.0.0,>=1.0.2"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests<3.0.0,>=2.32.3"
+      },
+      {
+        "key": "rtree==1.3.0",
+        "req_type": "install",
+        "req": "rtree<2.0.0,>=1.3.0"
+      },
+      {
+        "key": "scipy==1.15.1",
+        "req_type": "install",
+        "req": "scipy<2.0.0,>=1.6.0"
+      },
+      {
+        "key": "tesserocr==2.7.1",
+        "req_type": "install",
+        "req": "tesserocr<3.0.0,>=2.7.1; extra == \"tesserocr\""
+      },
+      {
+        "key": "typer==0.12.5",
+        "req_type": "install",
+        "req": "typer<0.13.0,>=0.12.5"
+      }
+    ]
+  },
+  "tesserocr==2.7.1": {
+    "download_url": "https://files.pythonhosted.org/packages/1c/26/21e95383b4316773dab9db892885e2eae74da05f14d520de7b66e5f9ddbb/tesserocr-2.7.1.tar.gz#sha256=3744c5c8bbabf18172849c7731be00dc2e5e44f8c556d37c850e788794ae0af4",
+    "pre_built": false,
+    "version": "2.7.1",
+    "canonicalized_name": "tesserocr",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "cython==3.0.11",
+        "req_type": "build-backend",
+        "req": "Cython<3.1.0,>=0.23"
+      },
+      {
+        "key": "cython==3.0.11",
+        "req_type": "build-sdist",
+        "req": "Cython<3.1.0,>=0.23"
+      }
+    ]
+  },
+  "docling-ibm-models==2.0.8": {
+    "download_url": "https://files.pythonhosted.org/packages/23/cb/6b2ac7aeb4fed0c2975894e4f97b1e1a2722b00c1447ef02080a3748786d/docling_ibm_models-2.0.8.tar.gz#sha256=b11c2da52e972cb345381ede2d77710d7f3f15946e483786545c3a7b767aa3c1",
+    "pre_built": false,
+    "version": "2.0.8",
+    "canonicalized_name": "docling-ibm-models",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0"
+      },
+      {
+        "key": "pillow==10.4.0",
+        "req_type": "install",
+        "req": "Pillow<11.0.0,>=10.0.0"
+      },
+      {
+        "key": "huggingface-hub==0.30.1",
+        "req_type": "install",
+        "req": "huggingface_hub<1,>=0.23"
+      },
+      {
+        "key": "jsonlines==3.1.0",
+        "req_type": "install",
+        "req": "jsonlines<4.0.0,>=3.1.0"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy<3.0.0,>=1.24.4"
+      },
+      {
+        "key": "opencv-python-headless==4.11.0.86",
+        "req_type": "install",
+        "req": "opencv-python-headless<5.0.0.0,>=4.6.0.66"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "install",
+        "req": "torch<3.0.0,>=2.2.2"
+      },
+      {
+        "key": "torchvision==0.20.1",
+        "req_type": "install",
+        "req": "torchvision<1,>=0"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm<5.0.0,>=4.64.0"
+      }
+    ]
+  },
+  "docling-core==2.15.1": {
+    "download_url": "https://files.pythonhosted.org/packages/52/61/9204dc91cb1b4def7c0bc098881c10e6c9a804580b9e74fe7c4fda7dbb63/docling_core-2.15.1.tar.gz#sha256=588d941b5bfc393a79e779ab64819c60763e7f182ec5221ee37da4be91dd802f",
+    "pre_built": false,
+    "version": "2.15.1",
+    "canonicalized_name": "docling-core",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0"
+      },
+      {
+        "key": "jsonref==1.1.0",
+        "req_type": "install",
+        "req": "jsonref<2.0.0,>=1.1.0"
+      },
+      {
+        "key": "jsonschema==4.23.0",
+        "req_type": "install",
+        "req": "jsonschema<5.0.0,>=4.16.0"
+      },
+      {
+        "key": "pandas==2.2.3",
+        "req_type": "install",
+        "req": "pandas<3.0.0,>=2.1.4"
+      },
+      {
+        "key": "pillow==10.4.0",
+        "req_type": "install",
+        "req": "pillow<11.0.0,>=10.3.0"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic!=2.10.0,!=2.10.1,!=2.10.2,<3.0.0,>=2.6.0"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml<7.0.0,>=5.1"
+      },
+      {
+        "key": "semchunk==2.2.2",
+        "req_type": "install",
+        "req": "semchunk<3.0.0,>=2.2.0; extra == \"chunking\""
+      },
+      {
+        "key": "tabulate==0.9.0",
+        "req_type": "install",
+        "req": "tabulate<0.10.0,>=0.9.0"
+      },
+      {
+        "key": "transformers==4.48.1",
+        "req_type": "install",
+        "req": "transformers<5.0.0,>=4.34.0; extra == \"chunking\""
+      },
+      {
+        "key": "typer==0.12.5",
+        "req_type": "install",
+        "req": "typer<0.13.0,>=0.12.5"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions<5.0.0,>=4.12.2"
+      },
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0"
+      },
+      {
+        "key": "jsonref==1.1.0",
+        "req_type": "install",
+        "req": "jsonref<2.0.0,>=1.1.0"
+      },
+      {
+        "key": "jsonschema==4.23.0",
+        "req_type": "install",
+        "req": "jsonschema<5.0.0,>=4.16.0"
+      },
+      {
+        "key": "pandas==2.2.3",
+        "req_type": "install",
+        "req": "pandas<3.0.0,>=2.1.4"
+      },
+      {
+        "key": "pillow==10.4.0",
+        "req_type": "install",
+        "req": "pillow<11.0.0,>=10.3.0"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic!=2.10.0,!=2.10.1,!=2.10.2,<3.0.0,>=2.6.0"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml<7.0.0,>=5.1"
+      },
+      {
+        "key": "tabulate==0.9.0",
+        "req_type": "install",
+        "req": "tabulate<0.10.0,>=0.9.0"
+      },
+      {
+        "key": "typer==0.12.5",
+        "req_type": "install",
+        "req": "typer<0.13.0,>=0.12.5"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions<5.0.0,>=4.12.2"
+      }
+    ]
+  },
+  "deepsearch-glm==0.26.2": {
+    "download_url": "https://files.pythonhosted.org/packages/20/62/71c5bb87aa46e52e669014e73776113788f8382d8a49eeaf550092926c92/deepsearch_glm-0.26.2.tar.gz#sha256=7a607e78903b66d28beac3408156c11ab7b34ee70e8ccd0d292b28433e5a9c1d",
+    "pre_built": false,
+    "version": "0.26.2",
+    "canonicalized_name": "deepsearch-glm",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core"
+      },
+      {
+        "key": "pybind11==2.13.6",
+        "req_type": "build-system",
+        "req": "pybind11>=2.13.1"
+      },
+      {
+        "key": "docling-core==2.15.1",
+        "req_type": "install",
+        "req": "docling-core<3.0,>=2.0"
+      },
+      {
+        "key": "docutils==0.21.2",
+        "req_type": "install",
+        "req": "docutils!=0.21"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy<3.0.0,>=1.24.4"
+      },
+      {
+        "key": "pandas==2.2.3",
+        "req_type": "install",
+        "req": "pandas<3.0.0,>=1.5.1"
+      },
+      {
+        "key": "python-dotenv==1.0.1",
+        "req_type": "install",
+        "req": "python-dotenv<2.0.0,>=1.0.0"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests<3.0.0,>=2.32.3"
+      },
+      {
+        "key": "rich==13.9.4",
+        "req_type": "install",
+        "req": "rich<14.0.0,>=13.7.0"
+      },
+      {
+        "key": "tabulate==0.9.0",
+        "req_type": "install",
+        "req": "tabulate>=0.8.9"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm<5.0.0,>=4.64.0"
+      }
+    ]
+  },
+  "docutils==0.21.2": {
+    "download_url": "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz#sha256=3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f",
+    "pre_built": false,
+    "version": "0.21.2",
+    "canonicalized_name": "docutils",
+    "edges": [
+      {
+        "key": "flit-core==3.10.1",
+        "req_type": "build-system",
+        "req": "flit_core<4,>=3.4"
+      }
+    ]
+  },
+  "datasets==2.21.0": {
+    "download_url": "https://files.pythonhosted.org/packages/e5/a5/38719e5cff7aa0537a6be37d21cc1fdd7096e9565e8fce2d46a822e10b5b/datasets-2.21.0.tar.gz#sha256=998f85a8460f1bd982e5bd058f8a0808eef424249e3df1e8cdd594ccd0dc8ba2",
+    "pre_built": false,
+    "version": "2.21.0",
+    "canonicalized_name": "datasets",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "aiohttp==3.11.11",
+        "req_type": "install",
+        "req": "aiohttp"
+      },
+      {
+        "key": "dill==0.3.8",
+        "req_type": "install",
+        "req": "dill<0.3.9,>=0.3.0"
+      },
+      {
+        "key": "filelock==3.17.0",
+        "req_type": "install",
+        "req": "filelock"
+      },
+      {
+        "key": "fsspec==2024.6.1",
+        "req_type": "install",
+        "req": "fsspec[http]<=2024.6.1,>=2023.1.0"
+      },
+      {
+        "key": "huggingface-hub==0.30.1",
+        "req_type": "install",
+        "req": "huggingface-hub>=0.21.2"
+      },
+      {
+        "key": "multiprocess==0.70.16",
+        "req_type": "install",
+        "req": "multiprocess"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy>=1.17"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging"
+      },
+      {
+        "key": "pandas==2.2.3",
+        "req_type": "install",
+        "req": "pandas"
+      },
+      {
+        "key": "pyarrow==18.1.0",
+        "req_type": "install",
+        "req": "pyarrow>=15.0.0"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml>=5.1"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests>=2.32.2"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm>=4.66.3"
+      },
+      {
+        "key": "xxhash==3.5.0",
+        "req_type": "install",
+        "req": "xxhash"
+      }
+    ]
+  },
+  "xxhash==3.5.0": {
+    "download_url": "https://files.pythonhosted.org/packages/00/5e/d6e5258d69df8b4ed8c83b6664f2b47d30d2dec551a29ad72a6c69eafd31/xxhash-3.5.0.tar.gz#sha256=84f2caddf951c9cbf8dc2e22a89d4ccf5d86391ac6418fe81e3c67d0cf60b45f",
+    "pre_built": false,
+    "version": "3.5.0",
+    "canonicalized_name": "xxhash",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=45"
+      }
+    ]
+  },
+  "pyarrow==18.1.0": {
+    "download_url": "https://files.pythonhosted.org/packages/7f/7b/640785a9062bb00314caa8a387abce547d2a420cf09bd6c715fe659ccffb/pyarrow-18.1.0.tar.gz#sha256=9386d3ca9c145b5539a1cfc75df07757dff870168c959b473a0bccbc3abc8c73",
+    "pre_built": false,
+    "version": "18.1.0",
+    "canonicalized_name": "pyarrow",
+    "edges": [
+      {
+        "key": "build==1.2.2.post1",
+        "req_type": "build-system",
+        "req": "build"
+      },
+      {
+        "key": "cython==3.0.11",
+        "req_type": "build-system",
+        "req": "cython>=0.29.31"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "build-system",
+        "req": "numpy>=1.25; python_version >= \"3.9\""
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=64"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm[toml]>=8"
+      }
+    ]
+  },
+  "build==1.2.2.post1": {
+    "download_url": "https://files.pythonhosted.org/packages/7d/46/aeab111f8e06793e4f0e421fcad593d547fb8313b50990f31681ee2fb1ad/build-1.2.2.post1.tar.gz#sha256=b36993e92ca9375a219c99e606a122ff365a760a2d4bba0caa09bd5278b608b7",
+    "pre_built": false,
+    "version": "1.2.2.post1",
+    "canonicalized_name": "build",
+    "edges": [
+      {
+        "key": "flit-core==3.10.1",
+        "req_type": "build-system",
+        "req": "flit-core>=3.8"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging>=19.1"
+      },
+      {
+        "key": "pyproject-hooks==1.2.0",
+        "req_type": "install",
+        "req": "pyproject_hooks"
+      }
+    ]
+  },
+  "pyproject-hooks==1.2.0": {
+    "download_url": "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz#sha256=1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8",
+    "pre_built": false,
+    "version": "1.2.0",
+    "canonicalized_name": "pyproject-hooks",
+    "edges": [
+      {
+        "key": "flit-core==3.10.1",
+        "req_type": "build-system",
+        "req": "flit_core<4,>=3.2"
+      }
+    ]
+  },
+  "fsspec==2024.6.1": {
+    "download_url": "https://files.pythonhosted.org/packages/90/b6/eba5024a9889fcfff396db543a34bef0ab9d002278f163129f9f01005960/fsspec-2024.6.1.tar.gz#sha256=fad7d7e209dd4c1208e3bbfda706620e0da5142bebbd9c384afb95b07e798e49",
+    "pre_built": false,
+    "version": "2024.6.1",
+    "canonicalized_name": "fsspec",
+    "edges": [
+      {
+        "key": "hatch-vcs==0.4.0",
+        "req_type": "build-system",
+        "req": "hatch-vcs"
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      },
+      {
+        "key": "aiohttp==3.11.11",
+        "req_type": "install",
+        "req": "aiohttp!=4.0.0a0,!=4.0.0a1; extra == \"http\""
+      }
+    ]
+  },
+  "dill==0.3.8": {
+    "download_url": "https://files.pythonhosted.org/packages/17/4d/ac7ffa80c69ea1df30a8aa11b3578692a5118e7cd1aa157e3ef73b092d15/dill-0.3.8.tar.gz#sha256=3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca",
+    "pre_built": false,
+    "version": "0.3.8",
+    "canonicalized_name": "dill",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=42"
+      }
+    ]
+  },
+  "gitpython==3.1.44": {
+    "download_url": "https://files.pythonhosted.org/packages/c0/89/37df0b71473153574a5cdef8f242de422a0f5d26d7a9e231e6f169b4ad14/gitpython-3.1.44.tar.gz#sha256=c87e30b26253bf5418b01b0660f818967f3c503193838337fe5e573331249269",
+    "pre_built": false,
+    "version": "3.1.44",
+    "canonicalized_name": "gitpython",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      },
+      {
+        "key": "gitdb==4.0.12",
+        "req_type": "install",
+        "req": "gitdb<5,>=4.0.1"
+      }
+    ]
+  },
+  "gitdb==4.0.12": {
+    "download_url": "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz#sha256=5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571",
+    "pre_built": false,
+    "version": "4.0.12",
+    "canonicalized_name": "gitdb",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "smmap==5.0.2",
+        "req_type": "install",
+        "req": "smmap<6,>=3.0.1"
+      }
+    ]
+  },
+  "smmap==5.0.2": {
+    "download_url": "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz#sha256=26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5",
+    "pre_built": false,
+    "version": "5.0.2",
+    "canonicalized_name": "smmap",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "instructlab==0.23.5": {
+    "download_url": "https://files.pythonhosted.org/packages/c2/40/283a205637b26af6061754bfb656415398c335b69841b8c8d67bb749e1ff/instructlab-0.23.5.tar.gz#sha256=3bf48da0f53fa9bec4968cc312958e0e6cb2c988209333b6ace94ca42e4fce5d",
+    "pre_built": false,
+    "version": "0.23.5",
+    "canonicalized_name": "instructlab",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=70.1.0"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm>=8"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      },
+      {
+        "key": "gitpython==3.1.44",
+        "req_type": "install",
+        "req": "GitPython>=3.1.42"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "PyYAML>=6.0.0"
+      },
+      {
+        "key": "boto3==1.36.6",
+        "req_type": "install",
+        "req": "boto3>=1.35.96"
+      },
+      {
+        "key": "click==8.1.8",
+        "req_type": "install",
+        "req": "click<9.0.0,>=8.1.7"
+      },
+      {
+        "key": "click-didyoumean==0.3.1",
+        "req_type": "install",
+        "req": "click-didyoumean>=0.3.0"
+      },
+      {
+        "key": "datasets==3.2.0",
+        "req_type": "install",
+        "req": "datasets>=2.18.0"
+      },
+      {
+        "key": "docling-core==2.15.1",
+        "req_type": "install",
+        "req": "docling-core[chunking]>=2.10.0"
+      },
+      {
+        "key": "filelock==3.18.0",
+        "req_type": "install",
+        "req": "filelock"
+      },
+      {
+        "key": "gguf==0.14.0",
+        "req_type": "install",
+        "req": "gguf>=0.6.0"
+      },
+      {
+        "key": "haystack-ai==2.9.0",
+        "req_type": "install",
+        "req": "haystack-ai>=2.8"
+      },
+      {
+        "key": "httpx==0.28.1",
+        "req_type": "install",
+        "req": "httpx>=0.25.0"
+      },
+      {
+        "key": "huggingface-hub==0.30.1",
+        "req_type": "install",
+        "req": "huggingface_hub[hf_transfer]>=0.1.8"
+      },
+      {
+        "key": "instructlab-eval==0.5.1",
+        "req_type": "install",
+        "req": "instructlab-eval<0.6.0,>=0.5.1"
+      },
+      {
+        "key": "instructlab-quantize==0.1.0",
+        "req_type": "install",
+        "req": "instructlab-quantize>=0.1.0"
+      },
+      {
+        "key": "instructlab-schema==0.4.2",
+        "req_type": "install",
+        "req": "instructlab-schema>=0.4.2"
+      },
+      {
+        "key": "instructlab-sdg==0.7.2",
+        "req_type": "install",
+        "req": "instructlab-sdg<0.8.0,>=0.7.2"
+      },
+      {
+        "key": "instructlab-training==0.7.0",
+        "req_type": "install",
+        "req": "instructlab-training<0.8.0,>=0.7.0"
+      },
+      {
+        "key": "instructlab-training==0.7.0",
+        "req_type": "install",
+        "req": "instructlab-training[cuda]>=0.7.0; extra == \"cuda\""
+      },
+      {
+        "key": "llama-cpp-python==0.3.2",
+        "req_type": "install",
+        "req": "llama_cpp_python[server]==0.3.2"
+      },
+      {
+        "key": "numpy==1.26.4",
+        "req_type": "install",
+        "req": "numpy<2.0.0,>=1.26.4"
+      },
+      {
+        "key": "openai==1.65.5",
+        "req_type": "install",
+        "req": "openai>=1.13.3"
+      },
+      {
+        "key": "peft==0.14.0",
+        "req_type": "install",
+        "req": "peft>=0.9.0"
+      },
+      {
+        "key": "prompt-toolkit==3.0.50",
+        "req_type": "install",
+        "req": "prompt-toolkit>=3.0.38"
+      },
+      {
+        "key": "psutil==6.1.1",
+        "req_type": "install",
+        "req": "psutil>=6.0.0"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic>=2.7.4"
+      },
+      {
+        "key": "pydantic-yaml==1.4.0",
+        "req_type": "install",
+        "req": "pydantic_yaml>=1.2.0"
+      },
+      {
+        "key": "rich==13.9.4",
+        "req_type": "install",
+        "req": "rich>=13.3.1"
+      },
+      {
+        "key": "rouge-score==0.1.2",
+        "req_type": "install",
+        "req": "rouge-score>=0.1.2"
+      },
+      {
+        "key": "ruamel-yaml==0.18.10",
+        "req_type": "install",
+        "req": "ruamel.yaml>=0.17.0"
+      },
+      {
+        "key": "sentence-transformers==3.4.0",
+        "req_type": "install",
+        "req": "sentence-transformers>=3.0.0"
+      },
+      {
+        "key": "sentencepiece==0.2.0",
+        "req_type": "install",
+        "req": "sentencepiece>=0.2.0"
+      },
+      {
+        "key": "tokenizers==0.21.0",
+        "req_type": "install",
+        "req": "tokenizers>=0.11.1"
+      },
+      {
+        "key": "toml==0.10.2",
+        "req_type": "install",
+        "req": "toml>=0.10.2"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "install",
+        "req": "torch<2.6.0,>=2.3.0"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm>=4.66.2"
+      },
+      {
+        "key": "transformers==4.48.1",
+        "req_type": "install",
+        "req": "transformers>=4.41.2"
+      },
+      {
+        "key": "trl==0.13.0",
+        "req_type": "install",
+        "req": "trl<0.15.0,>=0.12.2"
+      },
+      {
+        "key": "wandb==0.16.6",
+        "req_type": "install",
+        "req": "wandb>=0.16.4"
+      },
+      {
+        "key": "xdg-base-dirs==6.0.2",
+        "req_type": "install",
+        "req": "xdg-base-dirs>=6.0.1"
+      }
+    ]
+  },
+  "wandb==0.16.6": {
+    "download_url": "https://files.pythonhosted.org/packages/e5/d2/fdd399df703539233fcb99182067be0e16f7fbdbd00e83e372982faeeac0/wandb-0.16.6.tar.gz#sha256=86f491e3012d715e0d7d7421a4d6de41abef643b7403046261f962f3e512fe1c",
+    "pre_built": false,
+    "version": "0.16.6",
+    "canonicalized_name": "wandb",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>61"
+      },
+      {
+        "key": "click==8.1.8",
+        "req_type": "install",
+        "req": "Click!=8.0.0,>=7.1"
+      },
+      {
+        "key": "gitpython==3.1.44",
+        "req_type": "install",
+        "req": "GitPython!=3.1.29,>=1.0.0"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "PyYAML"
+      },
+      {
+        "key": "appdirs==1.4.4",
+        "req_type": "install",
+        "req": "appdirs>=1.4.3"
+      },
+      {
+        "key": "docker-pycreds==0.4.0",
+        "req_type": "install",
+        "req": "docker-pycreds>=0.4.0"
+      },
+      {
+        "key": "protobuf==4.25.6",
+        "req_type": "install",
+        "req": "protobuf!=4.21.0,<5,>=3.19.0; python_version > \"3.9\" and sys_platform == \"linux\""
+      },
+      {
+        "key": "psutil==6.1.1",
+        "req_type": "install",
+        "req": "psutil>=5.0.0"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests<3,>=2.0.0"
+      },
+      {
+        "key": "sentry-sdk==2.20.0",
+        "req_type": "install",
+        "req": "sentry-sdk>=1.0.0"
+      },
+      {
+        "key": "setproctitle==1.3.4",
+        "req_type": "install",
+        "req": "setproctitle"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "install",
+        "req": "setuptools"
+      }
+    ]
+  },
+  "setproctitle==1.3.4": {
+    "download_url": "https://files.pythonhosted.org/packages/ae/4e/b09341b19b9ceb8b4c67298ab4a08ef7a4abdd3016c7bb152e9b6379031d/setproctitle-1.3.4.tar.gz#sha256=3b40d32a3e1f04e94231ed6dfee0da9e43b4f9c6b5450d53e6dd7754c34e0c50",
+    "pre_built": false,
+    "version": "1.3.4",
+    "canonicalized_name": "setproctitle",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "sentry-sdk==2.20.0": {
+    "download_url": "https://files.pythonhosted.org/packages/68/e8/6a366c0cd5e129dda6ecb20ff097f70b18182c248d4c27e813c21f98992a/sentry_sdk-2.20.0.tar.gz#sha256=afa82713a92facf847df3c6f63cec71eb488d826a50965def3d7722aa6f0fdab",
+    "pre_built": false,
+    "version": "2.20.0",
+    "canonicalized_name": "sentry-sdk",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "certifi==2024.12.14",
+        "req_type": "install",
+        "req": "certifi"
+      },
+      {
+        "key": "urllib3==2.3.0",
+        "req_type": "install",
+        "req": "urllib3>=1.26.11"
+      }
+    ]
+  },
+  "psutil==6.1.1": {
+    "download_url": "https://files.pythonhosted.org/packages/1f/5a/07871137bb752428aa4b659f910b399ba6f291156bdea939be3e96cae7cb/psutil-6.1.1.tar.gz#sha256=cf8496728c18f2d0b45198f06895be52f36611711746b7f30c464b422b50e2f5",
+    "pre_built": false,
+    "version": "6.1.1",
+    "canonicalized_name": "psutil",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=43"
+      }
+    ]
+  },
+  "protobuf==4.25.6": {
+    "download_url": "https://files.pythonhosted.org/packages/48/d5/cccc7e82bbda9909ced3e7a441a24205ea07fea4ce23a772743c0c7611fa/protobuf-4.25.6.tar.gz#sha256=f8cfbae7c5afd0d0eaccbe73267339bff605a2315860bb1ba08eb66670a9a91f",
+    "pre_built": false,
+    "version": "4.25.6",
+    "canonicalized_name": "protobuf",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "docker-pycreds==0.4.0": {
+    "download_url": "https://files.pythonhosted.org/packages/c5/e6/d1f6c00b7221e2d7c4b470132c931325c8b22c51ca62417e300f5ce16009/docker-pycreds-0.4.0.tar.gz#sha256=6ce3270bcaf404cc4c3e27e4b6c70d3521deae82fb508767870fdbf772d584d4",
+    "pre_built": false,
+    "version": "0.4.0",
+    "canonicalized_name": "docker-pycreds",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "six==1.17.0",
+        "req_type": "install",
+        "req": "six>=1.4.0"
+      }
+    ]
+  },
+  "appdirs==1.4.4": {
+    "download_url": "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz#sha256=7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
+    "pre_built": false,
+    "version": "1.4.4",
+    "canonicalized_name": "appdirs",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "trl==0.13.0": {
+    "download_url": "https://files.pythonhosted.org/packages/01/4b/73924544701445ee8cb55cce80a5917242d6f8a6f16c76408e29111209d7/trl-0.13.0-py3-none-any.whl#sha256=792aa68a98821934a890182c842f9f8b43127eea510a7c2bd660a10bc59de7e8",
+    "pre_built": false,
+    "version": "0.13.0",
+    "canonicalized_name": "trl",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "accelerate==1.3.0",
+        "req_type": "install",
+        "req": "accelerate>=0.34.0"
+      },
+      {
+        "key": "datasets==3.2.0",
+        "req_type": "install",
+        "req": "datasets>=2.21.0"
+      },
+      {
+        "key": "rich==13.9.4",
+        "req_type": "install",
+        "req": "rich"
+      },
+      {
+        "key": "transformers==4.48.1",
+        "req_type": "install",
+        "req": "transformers>=4.46.0"
+      }
+    ]
+  },
+  "datasets==3.2.0": {
+    "download_url": "https://files.pythonhosted.org/packages/fc/48/744286c044e2b942d4fa67f92816126522ad1f0675def0ea3264e6242005/datasets-3.2.0.tar.gz#sha256=9a6e1a356052866b5dbdd9c9eedb000bf3fc43d986e3584d9b028f4976937229",
+    "pre_built": false,
+    "version": "3.2.0",
+    "canonicalized_name": "datasets",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "aiohttp==3.11.11",
+        "req_type": "install",
+        "req": "aiohttp"
+      },
+      {
+        "key": "dill==0.3.8",
+        "req_type": "install",
+        "req": "dill<0.3.9,>=0.3.0"
+      },
+      {
+        "key": "filelock==3.17.0",
+        "req_type": "install",
+        "req": "filelock"
+      },
+      {
+        "key": "fsspec==2024.9.0",
+        "req_type": "install",
+        "req": "fsspec[http]<=2024.9.0,>=2023.1.0"
+      },
+      {
+        "key": "huggingface-hub==0.30.1",
+        "req_type": "install",
+        "req": "huggingface-hub>=0.23.0"
+      },
+      {
+        "key": "multiprocess==0.70.16",
+        "req_type": "install",
+        "req": "multiprocess<0.70.17"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy>=1.17"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging"
+      },
+      {
+        "key": "pandas==2.2.3",
+        "req_type": "install",
+        "req": "pandas"
+      },
+      {
+        "key": "pyarrow==18.1.0",
+        "req_type": "install",
+        "req": "pyarrow>=15.0.0"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml>=5.1"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests>=2.32.2"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm>=4.66.3"
+      },
+      {
+        "key": "xxhash==3.5.0",
+        "req_type": "install",
+        "req": "xxhash"
+      }
+    ]
+  },
+  "fsspec==2024.9.0": {
+    "download_url": "https://files.pythonhosted.org/packages/62/7c/12b0943011daaaa9c35c2a2e22e5eb929ac90002f08f1259d69aedad84de/fsspec-2024.9.0.tar.gz#sha256=4b0afb90c2f21832df142f292649035d80b421f60a9e1c027802e5a0da2b04e8",
+    "pre_built": false,
+    "version": "2024.9.0",
+    "canonicalized_name": "fsspec",
+    "edges": [
+      {
+        "key": "hatch-vcs==0.4.0",
+        "req_type": "build-system",
+        "req": "hatch-vcs"
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      },
+      {
+        "key": "aiohttp==3.11.11",
+        "req_type": "install",
+        "req": "aiohttp!=4.0.0a0,!=4.0.0a1; extra == \"http\""
+      }
+    ]
+  },
+  "accelerate==1.3.0": {
+    "download_url": "https://files.pythonhosted.org/packages/85/15/0fab0260ab4069e5224e637d2e400538bb27b0dfc36f17daf68db9770d78/accelerate-1.3.0.tar.gz#sha256=518631c0adb80bd3d42fb29e7e2dc2256bcd7c786b0ba9119bbaa08611b36d9c",
+    "pre_built": false,
+    "version": "1.3.0",
+    "canonicalized_name": "accelerate",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "huggingface-hub==0.30.1",
+        "req_type": "install",
+        "req": "huggingface_hub>=0.21.0"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy<3.0.0,>=1.17"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging>=20.0"
+      },
+      {
+        "key": "psutil==6.1.1",
+        "req_type": "install",
+        "req": "psutil"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml"
+      },
+      {
+        "key": "safetensors==0.4.5",
+        "req_type": "install",
+        "req": "safetensors>=0.4.3"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "install",
+        "req": "torch>=2.0.0"
+      }
+    ]
+  },
+  "toml==0.10.2": {
+    "download_url": "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz#sha256=b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f",
+    "pre_built": false,
+    "version": "0.10.2",
+    "canonicalized_name": "toml",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "sentence-transformers==3.4.0": {
+    "download_url": "https://files.pythonhosted.org/packages/c9/85/46c3fa0560cf7b57bc1f135d386120b95d131780e3558bf1f244bdeaa61f/sentence_transformers-3.4.0.tar.gz#sha256=334288062d4b888cdd7b75913fead46b1e42bfe836f8343d23478d17f799e650",
+    "pre_built": false,
+    "version": "3.4.0",
+    "canonicalized_name": "sentence-transformers",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=42"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      },
+      {
+        "key": "pillow==11.1.0",
+        "req_type": "install",
+        "req": "Pillow"
+      },
+      {
+        "key": "huggingface-hub==0.30.1",
+        "req_type": "install",
+        "req": "huggingface-hub>=0.20.0"
+      },
+      {
+        "key": "scikit-learn==1.6.1",
+        "req_type": "install",
+        "req": "scikit-learn"
+      },
+      {
+        "key": "scipy==1.15.1",
+        "req_type": "install",
+        "req": "scipy"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "install",
+        "req": "torch>=1.11.0"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm"
+      },
+      {
+        "key": "transformers==4.48.1",
+        "req_type": "install",
+        "req": "transformers<5.0.0,>=4.41.0"
+      }
+    ]
+  },
+  "scikit-learn==1.6.1": {
+    "download_url": "https://files.pythonhosted.org/packages/9e/a5/4ae3b3a0755f7b35a280ac90b28817d1f380318973cff14075ab41ef50d9/scikit_learn-1.6.1.tar.gz#sha256=b4fc2525eca2c69a59260f583c56a7557c6ccdf8deafdba6e060f94c1c59738e",
+    "pre_built": false,
+    "version": "1.6.1",
+    "canonicalized_name": "scikit-learn",
+    "edges": [
+      {
+        "key": "cython==3.0.11",
+        "req_type": "build-system",
+        "req": "Cython>=3.0.10"
+      },
+      {
+        "key": "meson-python==0.17.1",
+        "req_type": "build-system",
+        "req": "meson-python>=0.16.0"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "build-system",
+        "req": "numpy>=2"
+      },
+      {
+        "key": "scipy==1.15.1",
+        "req_type": "build-system",
+        "req": "scipy>=1.6.0"
+      },
+      {
+        "key": "joblib==1.4.2",
+        "req_type": "install",
+        "req": "joblib>=1.2.0"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy>=1.19.5"
+      },
+      {
+        "key": "scipy==1.15.1",
+        "req_type": "install",
+        "req": "scipy>=1.6.0"
+      },
+      {
+        "key": "threadpoolctl==3.5.0",
+        "req_type": "install",
+        "req": "threadpoolctl>=3.1.0"
+      }
+    ]
+  },
+  "threadpoolctl==3.5.0": {
+    "download_url": "https://files.pythonhosted.org/packages/bd/55/b5148dcbf72f5cde221f8bfe3b6a540da7aa1842f6b491ad979a6c8b84af/threadpoolctl-3.5.0.tar.gz#sha256=082433502dd922bf738de0d8bcc4fdcbf0979ff44c42bd40f5af8a282f6fa107",
+    "pre_built": false,
+    "version": "3.5.0",
+    "canonicalized_name": "threadpoolctl",
+    "edges": [
+      {
+        "key": "flit-core==3.10.1",
+        "req_type": "build-system",
+        "req": "flit_core<4,>=2"
+      }
+    ]
+  },
+  "joblib==1.4.2": {
+    "download_url": "https://files.pythonhosted.org/packages/64/33/60135848598c076ce4b231e1b1895170f45fbcaeaa2c9d5e38b04db70c35/joblib-1.4.2.tar.gz#sha256=2382c5816b2636fbd20a09e0f4e9dad4736765fdfb7dca582943b9c1366b3f0e",
+    "pre_built": false,
+    "version": "1.4.2",
+    "canonicalized_name": "joblib",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=61.2"
+      }
+    ]
+  },
+  "ruamel-yaml==0.18.10": {
+    "download_url": "https://files.pythonhosted.org/packages/ea/46/f44d8be06b85bc7c4d8c95d658be2b68f27711f279bf9dd0612a5e4794f5/ruamel.yaml-0.18.10.tar.gz#sha256=20c86ab29ac2153f80a428e1254a8adf686d3383df04490514ca3b79a362db58",
+    "pre_built": false,
+    "version": "0.18.10",
+    "canonicalized_name": "ruamel-yaml",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      },
+      {
+        "key": "ruamel-yaml-clib==0.2.12",
+        "req_type": "install",
+        "req": "ruamel.yaml.clib>=0.2.7; platform_python_implementation == \"CPython\" and python_version < \"3.13\""
+      }
+    ]
+  },
+  "ruamel-yaml-clib==0.2.12": {
+    "download_url": "https://files.pythonhosted.org/packages/20/84/80203abff8ea4993a87d823a5f632e4d92831ef75d404c9fc78d0176d2b5/ruamel.yaml.clib-0.2.12.tar.gz#sha256=6c8fbb13ec503f99a91901ab46e0b07ae7941cd527393187039aec586fdfd36f",
+    "pre_built": false,
+    "version": "0.2.12",
+    "canonicalized_name": "ruamel-yaml-clib",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      }
+    ]
+  },
+  "rouge-score==0.1.2": {
+    "download_url": "https://files.pythonhosted.org/packages/e2/c5/9136736c37022a6ad27fea38f3111eb8f02fe75d067f9a985cc358653102/rouge_score-0.1.2.tar.gz#sha256=c7d4da2683e68c9abf0135ef915d63a46643666f848e558a1b9f7ead17ff0f04",
+    "pre_built": false,
+    "version": "0.1.2",
+    "canonicalized_name": "rouge-score",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "absl-py==2.1.0",
+        "req_type": "install",
+        "req": "absl-py"
+      },
+      {
+        "key": "nltk==3.9.1",
+        "req_type": "install",
+        "req": "nltk"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy"
+      },
+      {
+        "key": "six==1.17.0",
+        "req_type": "install",
+        "req": "six>=1.14.0"
+      }
+    ]
+  },
+  "nltk==3.9.1": {
+    "download_url": "https://files.pythonhosted.org/packages/3c/87/db8be88ad32c2d042420b6fd9ffd4a149f9a0d7f0e86b3f543be2eeeedd2/nltk-3.9.1.tar.gz#sha256=87d127bd3de4bd89a4f81265e5fa59cb1b199b27440175370f7417d2bc7ae868",
+    "pre_built": false,
+    "version": "3.9.1",
+    "canonicalized_name": "nltk",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "click==8.1.8",
+        "req_type": "install",
+        "req": "click"
+      },
+      {
+        "key": "joblib==1.4.2",
+        "req_type": "install",
+        "req": "joblib"
+      },
+      {
+        "key": "regex==2024.11.6",
+        "req_type": "install",
+        "req": "regex>=2021.8.3"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm"
+      }
+    ]
+  },
+  "absl-py==2.1.0": {
+    "download_url": "https://files.pythonhosted.org/packages/7a/8f/fc001b92ecc467cc32ab38398bd0bfb45df46e7523bf33c2ad22a505f06e/absl-py-2.1.0.tar.gz#sha256=7820790efbb316739cde8b4e19357243fc3608a152024288513dd968d7d959ff",
+    "pre_built": false,
+    "version": "2.1.0",
+    "canonicalized_name": "absl-py",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "pydantic-yaml==1.4.0": {
+    "download_url": "https://files.pythonhosted.org/packages/84/b8/19446b74d31a6ff09eb69af3be01c5031c8bf5dc62e4205a22d50d629333/pydantic_yaml-1.4.0.tar.gz#sha256=09f6b9ec9d80550dd3a58596a6a0948a1830fae94b73329b95c2b9dbfc35ae00",
+    "pre_built": false,
+    "version": "1.4.0",
+    "canonicalized_name": "pydantic-yaml",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=61.0.0"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools-scm[toml]>=6.2"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic>=1.8"
+      },
+      {
+        "key": "ruamel-yaml==0.18.10",
+        "req_type": "install",
+        "req": "ruamel.yaml<0.19.0,>=0.16.0"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions>=4.5.0"
+      }
+    ]
+  },
+  "prompt-toolkit==3.0.50": {
+    "download_url": "https://files.pythonhosted.org/packages/a1/e1/bd15cb8ffdcfeeb2bdc215de3c3cffca11408d829e4b8416dcfe71ba8854/prompt_toolkit-3.0.50.tar.gz#sha256=544748f3860a2623ca5cd6d2795e7a14f3d0e1c3c9728359013f79877fc89bab",
+    "pre_built": false,
+    "version": "3.0.50",
+    "canonicalized_name": "prompt-toolkit",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "wcwidth==0.2.13",
+        "req_type": "install",
+        "req": "wcwidth"
+      }
+    ]
+  },
+  "wcwidth==0.2.13": {
+    "download_url": "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz#sha256=72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5",
+    "pre_built": false,
+    "version": "0.2.13",
+    "canonicalized_name": "wcwidth",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "peft==0.14.0": {
+    "download_url": "https://files.pythonhosted.org/packages/21/33/fb0c31eaa8162c01e9250b21aa65d46a5339f17a818a97c68391db2ff44b/peft-0.14.0.tar.gz#sha256=546d69af7b42f5ef715a3d3261ed818bc917ae6055e5d7e187ed3f2c76ad72dc",
+    "pre_built": false,
+    "version": "0.14.0",
+    "canonicalized_name": "peft",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "accelerate==1.3.0",
+        "req_type": "install",
+        "req": "accelerate>=0.21.0"
+      },
+      {
+        "key": "huggingface-hub==0.30.1",
+        "req_type": "install",
+        "req": "huggingface_hub>=0.25.0"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy>=1.17"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging>=20.0"
+      },
+      {
+        "key": "psutil==6.1.1",
+        "req_type": "install",
+        "req": "psutil"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml"
+      },
+      {
+        "key": "safetensors==0.4.5",
+        "req_type": "install",
+        "req": "safetensors"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "install",
+        "req": "torch>=1.13.0"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm"
+      },
+      {
+        "key": "transformers==4.48.1",
+        "req_type": "install",
+        "req": "transformers"
+      }
+    ]
+  },
+  "llama-cpp-python==0.3.2": {
+    "download_url": "https://files.pythonhosted.org/packages/5f/0e/ff129005a33b955088fc7e4ecb57e5500b604fb97eca55ce8688dbe59680/llama_cpp_python-0.3.2.tar.gz#sha256=8fbf246a55a999f45015ed0d48f91b4ae04ae959827fac1cd6ac6ec65aed2e2f",
+    "pre_built": false,
+    "version": "0.3.2",
+    "canonicalized_name": "llama-cpp-python",
+    "edges": [
+      {
+        "key": "scikit-build-core==0.10.7",
+        "req_type": "build-system",
+        "req": "scikit-build-core[pyproject]>=0.9.2"
+      },
+      {
+        "key": "ninja==1.11.1.1",
+        "req_type": "build-backend",
+        "req": "ninja>=1.5"
+      },
+      {
+        "key": "ninja==1.11.1.1",
+        "req_type": "build-sdist",
+        "req": "ninja>=1.5"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "PyYAML>=5.1; extra == \"server\""
+      },
+      {
+        "key": "diskcache==5.6.3",
+        "req_type": "install",
+        "req": "diskcache>=5.6.1"
+      },
+      {
+        "key": "fastapi==0.115.7",
+        "req_type": "install",
+        "req": "fastapi>=0.100.0; extra == \"server\""
+      },
+      {
+        "key": "jinja2==3.1.5",
+        "req_type": "install",
+        "req": "jinja2>=2.11.3"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy>=1.20.0"
+      },
+      {
+        "key": "pydantic-settings==2.7.1",
+        "req_type": "install",
+        "req": "pydantic-settings>=2.0.1; extra == \"server\""
+      },
+      {
+        "key": "sse-starlette==2.2.1",
+        "req_type": "install",
+        "req": "sse-starlette>=1.6.1; extra == \"server\""
+      },
+      {
+        "key": "starlette-context==0.3.6",
+        "req_type": "install",
+        "req": "starlette-context<0.4,>=0.3.6; extra == \"server\""
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions>=4.5.0"
+      },
+      {
+        "key": "uvicorn==0.34.0",
+        "req_type": "install",
+        "req": "uvicorn>=0.22.0; extra == \"server\""
+      }
+    ]
+  },
+  "uvicorn==0.34.0": {
+    "download_url": "https://files.pythonhosted.org/packages/4b/4d/938bd85e5bf2edeec766267a5015ad969730bb91e31b44021dfe8b22df6c/uvicorn-0.34.0.tar.gz#sha256=404051050cd7e905de2c9a7e61790943440b3416f49cb409f965d9dcd0fa73e9",
+    "pre_built": false,
+    "version": "0.34.0",
+    "canonicalized_name": "uvicorn",
+    "edges": [
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      },
+      {
+        "key": "click==8.1.8",
+        "req_type": "install",
+        "req": "click>=7.0"
+      },
+      {
+        "key": "h11==0.14.0",
+        "req_type": "install",
+        "req": "h11>=0.8"
+      },
+      {
+        "key": "httptools==0.6.4",
+        "req_type": "install",
+        "req": "httptools>=0.6.3; extra == \"standard\""
+      },
+      {
+        "key": "python-dotenv==1.0.1",
+        "req_type": "install",
+        "req": "python-dotenv>=0.13; extra == \"standard\""
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml>=5.1; extra == \"standard\""
+      },
+      {
+        "key": "uvloop==0.21.0",
+        "req_type": "install",
+        "req": "uvloop!=0.15.0,!=0.15.1,>=0.14.0; (sys_platform != \"win32\" and (sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\")) and extra == \"standard\""
+      },
+      {
+        "key": "watchfiles==1.0.4",
+        "req_type": "install",
+        "req": "watchfiles>=0.13; extra == \"standard\""
+      },
+      {
+        "key": "websockets==14.2",
+        "req_type": "install",
+        "req": "websockets>=10.4; extra == \"standard\""
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      },
+      {
+        "key": "click==8.1.8",
+        "req_type": "install",
+        "req": "click>=7.0"
+      },
+      {
+        "key": "h11==0.14.0",
+        "req_type": "install",
+        "req": "h11>=0.8"
+      }
+    ]
+  },
+  "websockets==14.2": {
+    "download_url": "https://files.pythonhosted.org/packages/94/54/8359678c726243d19fae38ca14a334e740782336c9f19700858c4eb64a1e/websockets-14.2.tar.gz#sha256=5059ed9c54945efb321f097084b4c7e52c246f2c869815876a69d1efc4ad6eb5",
+    "pre_built": false,
+    "version": "14.2",
+    "canonicalized_name": "websockets",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      }
+    ]
+  },
+  "watchfiles==1.0.4": {
+    "download_url": "https://files.pythonhosted.org/packages/f5/26/c705fc77d0a9ecdb9b66f1e2976d95b81df3cae518967431e7dbf9b5e219/watchfiles-1.0.4.tar.gz#sha256=6ba473efd11062d73e4f00c2b730255f9c1bdd73cd5f9fe5b5da8dbd4a717205",
+    "pre_built": false,
+    "version": "1.0.4",
+    "canonicalized_name": "watchfiles",
+    "edges": [
+      {
+        "key": "maturin==1.8.1",
+        "req_type": "build-system",
+        "req": "maturin<2,>=0.14.16"
+      },
+      {
+        "key": "anyio==4.8.0",
+        "req_type": "install",
+        "req": "anyio>=3.0.0"
+      }
+    ]
+  },
+  "uvloop==0.21.0": {
+    "download_url": "https://files.pythonhosted.org/packages/af/c0/854216d09d33c543f12a44b393c402e89a920b1a0a7dc634c42de91b9cf6/uvloop-0.21.0.tar.gz#sha256=3bf12b0fda68447806a7ad847bfa591613177275d35b6724b1ee573faa3704e3",
+    "pre_built": false,
+    "version": "0.21.0",
+    "canonicalized_name": "uvloop",
+    "edges": [
+      {
+        "key": "cython==3.0.11",
+        "req_type": "build-system",
+        "req": "Cython~=3.0"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=60"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      }
+    ]
+  },
+  "httptools==0.6.4": {
+    "download_url": "https://files.pythonhosted.org/packages/a7/9a/ce5e1f7e131522e6d3426e8e7a490b3a01f39a6696602e1c4f33f9e94277/httptools-0.6.4.tar.gz#sha256=4e93eee4add6493b59a5c514da98c939b244fce4a0d8879cd3f466562f4b7d5c",
+    "pre_built": false,
+    "version": "0.6.4",
+    "canonicalized_name": "httptools",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "starlette-context==0.3.6": {
+    "download_url": "https://files.pythonhosted.org/packages/a8/21/aa5d3848fcb77f0e7c9f1844271826ff74d83fad9920ca7f8105e0dc02ee/starlette_context-0.3.6.tar.gz#sha256=d361a36ba2d4acca3ab680f917b25e281533d725374752d47607a859041958cb",
+    "pre_built": false,
+    "version": "0.3.6",
+    "canonicalized_name": "starlette-context",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core"
+      },
+      {
+        "key": "starlette==0.45.3",
+        "req_type": "install",
+        "req": "starlette"
+      }
+    ]
+  },
+  "starlette==0.45.3": {
+    "download_url": "https://files.pythonhosted.org/packages/ff/fb/2984a686808b89a6781526129a4b51266f678b2d2b97ab2d325e56116df8/starlette-0.45.3.tar.gz#sha256=2cbcba2a75806f8a41c722141486f37c28e30a0921c5f6fe4346cb0dcee1302f",
+    "pre_built": false,
+    "version": "0.45.3",
+    "canonicalized_name": "starlette",
+    "edges": [
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      },
+      {
+        "key": "anyio==4.8.0",
+        "req_type": "install",
+        "req": "anyio<5,>=3.6.2"
+      }
+    ]
+  },
+  "sse-starlette==2.2.1": {
+    "download_url": "https://files.pythonhosted.org/packages/71/a4/80d2a11af59fe75b48230846989e93979c892d3a20016b42bb44edb9e398/sse_starlette-2.2.1.tar.gz#sha256=54470d5f19274aeed6b2d473430b08b4b379ea851d953b11d7f1c4a2c118b419",
+    "pre_built": false,
+    "version": "2.2.1",
+    "canonicalized_name": "sse-starlette",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      },
+      {
+        "key": "anyio==4.8.0",
+        "req_type": "install",
+        "req": "anyio>=4.7.0"
+      },
+      {
+        "key": "starlette==0.45.3",
+        "req_type": "install",
+        "req": "starlette>=0.41.3"
+      }
+    ]
+  },
+  "fastapi==0.115.7": {
+    "download_url": "https://files.pythonhosted.org/packages/a2/f5/3f921e59f189e513adb9aef826e2841672d50a399fead4e69afdeb808ff4/fastapi-0.115.7.tar.gz#sha256=0f106da6c01d88a6786b3248fb4d7a940d071f6f488488898ad5d354b25ed015",
+    "pre_built": false,
+    "version": "0.115.7",
+    "canonicalized_name": "fastapi",
+    "edges": [
+      {
+        "key": "pdm-backend==2.4.3",
+        "req_type": "build-system",
+        "req": "pdm-backend"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0,>=1.7.4"
+      },
+      {
+        "key": "starlette==0.45.3",
+        "req_type": "install",
+        "req": "starlette<0.46.0,>=0.40.0"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions>=4.8.0"
+      }
+    ]
+  },
+  "diskcache==5.6.3": {
+    "download_url": "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz#sha256=2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc",
+    "pre_built": false,
+    "version": "5.6.3",
+    "canonicalized_name": "diskcache",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "scikit-build-core==0.10.7": {
+    "download_url": "https://files.pythonhosted.org/packages/34/75/ad5664c8050bbbea46a5f2b6a3dfbc6e6cf284826c0eee0a12f861364b3f/scikit_build_core-0.10.7.tar.gz#sha256=04cbb59fe795202a7eeede1849112ee9dcbf3469feebd9b8b36aa541336ac4f8",
+    "pre_built": false,
+    "version": "0.10.7",
+    "canonicalized_name": "scikit-build-core",
+    "edges": [
+      {
+        "key": "hatch-vcs==0.4.0",
+        "req_type": "build-system",
+        "req": "hatch-vcs"
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging>=21.3"
+      },
+      {
+        "key": "pathspec==0.12.1",
+        "req_type": "install",
+        "req": "pathspec>=0.10.1"
+      },
+      {
+        "key": "hatch-vcs==0.4.0",
+        "req_type": "build-system",
+        "req": "hatch-vcs"
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging>=21.3"
+      },
+      {
+        "key": "pathspec==0.12.1",
+        "req_type": "install",
+        "req": "pathspec>=0.10.1"
+      }
+    ]
+  },
+  "instructlab-training==0.7.0": {
+    "download_url": "https://files.pythonhosted.org/packages/df/82/165ad9d51a13231ccef6c5efb60160160b4ad52b1f3c96d41aade79c58c8/instructlab_training-0.7.0.tar.gz#sha256=3b923b7379b329336402953ba11e49805dbd703a4d9001746faddcebd6c398f3",
+    "pre_built": false,
+    "version": "0.7.0",
+    "canonicalized_name": "instructlab-training",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=64"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm>=8"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      },
+      {
+        "key": "aiofiles==24.1.0",
+        "req_type": "install",
+        "req": "aiofiles>=23.2.1"
+      },
+      {
+        "key": "datasets==3.2.0",
+        "req_type": "install",
+        "req": "datasets>=2.15.0"
+      },
+      {
+        "key": "instructlab-dolomite==0.2.0",
+        "req_type": "install",
+        "req": "instructlab-dolomite>=0.2.0"
+      },
+      {
+        "key": "numba==0.60.0",
+        "req_type": "install",
+        "req": "numba"
+      },
+      {
+        "key": "numpy==1.26.4",
+        "req_type": "install",
+        "req": "numpy<2.0.0,>=1.26.4; python_version != \"3.10\""
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging>=20.9"
+      },
+      {
+        "key": "peft==0.14.0",
+        "req_type": "install",
+        "req": "peft"
+      },
+      {
+        "key": "py-cpuinfo==9.0.0",
+        "req_type": "install",
+        "req": "py-cpuinfo"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic>=2.7.0"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml"
+      },
+      {
+        "key": "rich==13.9.4",
+        "req_type": "install",
+        "req": "rich"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "install",
+        "req": "torch>=2.3.0a0"
+      },
+      {
+        "key": "transformers==4.48.1",
+        "req_type": "install",
+        "req": "transformers>=4.45.2"
+      },
+      {
+        "key": "trl==0.13.0",
+        "req_type": "install",
+        "req": "trl>=0.9.4"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "install",
+        "req": "wheel>=0.43"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=64"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm>=8"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      },
+      {
+        "key": "accelerate==1.0.1",
+        "req_type": "install",
+        "req": "accelerate<1.1.0,>=0.34.2; extra == \"cuda\""
+      },
+      {
+        "key": "aiofiles==24.1.0",
+        "req_type": "install",
+        "req": "aiofiles>=23.2.1"
+      },
+      {
+        "key": "bitsandbytes==0.45.1",
+        "req_type": "install",
+        "req": "bitsandbytes>=0.43.1; extra == \"cuda\""
+      },
+      {
+        "key": "datasets==3.2.0",
+        "req_type": "install",
+        "req": "datasets>=2.15.0"
+      },
+      {
+        "key": "deepspeed==0.15.2",
+        "req_type": "install",
+        "req": "deepspeed>=0.14.3; extra == \"cuda\""
+      },
+      {
+        "key": "flash-attn==2.7.2.post1",
+        "req_type": "install",
+        "req": "flash-attn>=2.4.0; extra == \"cuda\""
+      },
+      {
+        "key": "instructlab-dolomite==0.2.0",
+        "req_type": "install",
+        "req": "instructlab-dolomite>=0.2.0"
+      },
+      {
+        "key": "numba==0.60.0",
+        "req_type": "install",
+        "req": "numba"
+      },
+      {
+        "key": "numpy==1.26.4",
+        "req_type": "install",
+        "req": "numpy<2.0.0,>=1.26.4; python_version != \"3.10\""
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging>=20.9"
+      },
+      {
+        "key": "peft==0.14.0",
+        "req_type": "install",
+        "req": "peft"
+      },
+      {
+        "key": "py-cpuinfo==9.0.0",
+        "req_type": "install",
+        "req": "py-cpuinfo"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic>=2.7.0"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml"
+      },
+      {
+        "key": "rich==13.9.4",
+        "req_type": "install",
+        "req": "rich"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "install",
+        "req": "torch>=2.3.0a0"
+      },
+      {
+        "key": "transformers==4.48.1",
+        "req_type": "install",
+        "req": "transformers>=4.45.2"
+      },
+      {
+        "key": "trl==0.13.0",
+        "req_type": "install",
+        "req": "trl>=0.9.4"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "install",
+        "req": "wheel>=0.43"
+      }
+    ]
+  },
+  "py-cpuinfo==9.0.0": {
+    "download_url": "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz#sha256=3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690",
+    "pre_built": false,
+    "version": "9.0.0",
+    "canonicalized_name": "py-cpuinfo",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      }
+    ]
+  },
+  "numba==0.60.0": {
+    "download_url": "https://files.pythonhosted.org/packages/3c/93/2849300a9184775ba274aba6f82f303343669b0592b7bb0849ea713dabb0/numba-0.60.0.tar.gz#sha256=5df6158e5584eece5fc83294b949fd30b9f1125df7708862205217e068aabf16",
+    "pre_built": false,
+    "version": "0.60.0",
+    "canonicalized_name": "numba",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "numpy==2.0.2",
+        "req_type": "build-backend",
+        "req": "numpy<2.1,>=2.0.0rc1"
+      },
+      {
+        "key": "numpy==2.0.2",
+        "req_type": "build-sdist",
+        "req": "numpy<2.1,>=2.0.0rc1"
+      },
+      {
+        "key": "llvmlite==0.43.0",
+        "req_type": "install",
+        "req": "llvmlite<0.44,>=0.43.0dev0"
+      },
+      {
+        "key": "numpy==2.0.2",
+        "req_type": "install",
+        "req": "numpy<2.1,>=1.22"
+      }
+    ]
+  },
+  "numpy==2.0.2": {
+    "download_url": "https://files.pythonhosted.org/packages/a9/75/10dd1f8116a8b796cb2c737b674e02d02e80454bda953fa7e65d8c12b016/numpy-2.0.2.tar.gz#sha256=883c987dee1880e2a864ab0dc9892292582510604156762362d9326444636e78",
+    "pre_built": false,
+    "version": "2.0.2",
+    "canonicalized_name": "numpy",
+    "edges": [
+      {
+        "key": "cython==3.0.11",
+        "req_type": "build-system",
+        "req": "Cython>=3.0.6"
+      },
+      {
+        "key": "meson-python==0.15.0",
+        "req_type": "build-system",
+        "req": "meson-python>=0.15.0"
+      }
+    ]
+  },
+  "llvmlite==0.43.0": {
+    "download_url": "https://files.pythonhosted.org/packages/9f/3d/f513755f285db51ab363a53e898b85562e950f79a2e6767a364530c2f645/llvmlite-0.43.0.tar.gz#sha256=ae2b5b5c3ef67354824fb75517c8db5fbe93bc02cd9671f3c62271626bc041d5",
+    "pre_built": false,
+    "version": "0.43.0",
+    "canonicalized_name": "llvmlite",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "instructlab-dolomite==0.2.0": {
+    "download_url": "https://files.pythonhosted.org/packages/b7/3e/ffe2a9164039b406d4c439f75c7fd053b25a4bcbd53f4b1928c9e1cccd23/instructlab_dolomite-0.2.0.tar.gz#sha256=3deef09135210f8e1158d93835e00a632694d7f1baa0d9fba3d5a6bad3a0c23e",
+    "pre_built": false,
+    "version": "0.2.0",
+    "canonicalized_name": "instructlab-dolomite",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=64"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm>=8"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      },
+      {
+        "key": "safetensors==0.4.5",
+        "req_type": "install",
+        "req": "safetensors"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "install",
+        "req": "torch"
+      },
+      {
+        "key": "transformers==4.48.1",
+        "req_type": "install",
+        "req": "transformers>=4.40.0"
+      }
+    ]
+  },
+  "flash-attn==2.7.2.post1": {
+    "download_url": "https://files.pythonhosted.org/packages/83/29/48df18cb51902a7cb7a0ee13327bb2cf50b6ba24bd2e8283d0a9538dde52/flash_attn-2.7.2.post1.tar.gz#sha256=574897afeb6cbd63e78a612dded95491efe4a46818245cf1a5ace7357d993faa",
+    "pre_built": false,
+    "version": "2.7.2.post1",
+    "canonicalized_name": "flash-attn",
+    "edges": [
+      {
+        "key": "ninja==1.11.1.1",
+        "req_type": "build-system",
+        "req": "ninja"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "build-system",
+        "req": "packaging"
+      },
+      {
+        "key": "psutil==6.1.1",
+        "req_type": "build-system",
+        "req": "psutil"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "build-system",
+        "req": "torch"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      },
+      {
+        "key": "ninja==1.11.1.1",
+        "req_type": "build-backend",
+        "req": "ninja"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "build-backend",
+        "req": "packaging"
+      },
+      {
+        "key": "psutil==6.1.1",
+        "req_type": "build-backend",
+        "req": "psutil"
+      },
+      {
+        "key": "ninja==1.11.1.1",
+        "req_type": "build-sdist",
+        "req": "ninja"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "build-sdist",
+        "req": "packaging"
+      },
+      {
+        "key": "psutil==6.1.1",
+        "req_type": "build-sdist",
+        "req": "psutil"
+      },
+      {
+        "key": "einops==0.8.0",
+        "req_type": "install",
+        "req": "einops"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "install",
+        "req": "torch"
+      }
+    ]
+  },
+  "einops==0.8.0": {
+    "download_url": "https://files.pythonhosted.org/packages/79/ca/9f5dcb8bead39959454c3912266bedc4c315839cee0e0ca9f4328f4588c1/einops-0.8.0.tar.gz#sha256=63486517fed345712a8385c100cb279108d9d47e6ae59099b07657e983deae85",
+    "pre_built": false,
+    "version": "0.8.0",
+    "canonicalized_name": "einops",
+    "edges": [
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling>=1.10.0"
+      }
+    ]
+  },
+  "deepspeed==0.15.2": {
+    "download_url": "https://files.pythonhosted.org/packages/a2/f7/ecd834b9a02beef30104845a520c1d138e6e7398b0ed14e5d347f3c40486/deepspeed-0.15.2.tar.gz#sha256=790e81e7337141b8e86a58e08e06615286c11f0798e00e4f8768126cbdf26eb6",
+    "pre_built": false,
+    "version": "0.15.2",
+    "canonicalized_name": "deepspeed",
+    "edges": [
+      {
+        "key": "ninja==1.11.1.1",
+        "req_type": "build-system",
+        "req": "ninja"
+      },
+      {
+        "key": "nvidia-ml-py==12.570.86",
+        "req_type": "build-system",
+        "req": "nvidia-ml-py"
+      },
+      {
+        "key": "psutil==6.1.1",
+        "req_type": "build-system",
+        "req": "psutil"
+      },
+      {
+        "key": "py-cpuinfo==9.0.0",
+        "req_type": "build-system",
+        "req": "py-cpuinfo"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "build-system",
+        "req": "torch"
+      },
+      {
+        "key": "hjson==3.1.0",
+        "req_type": "install",
+        "req": "hjson"
+      },
+      {
+        "key": "msgpack==1.1.0",
+        "req_type": "install",
+        "req": "msgpack"
+      },
+      {
+        "key": "ninja==1.11.1.1",
+        "req_type": "install",
+        "req": "ninja"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy"
+      },
+      {
+        "key": "nvidia-ml-py==12.570.86",
+        "req_type": "install",
+        "req": "nvidia-ml-py"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging>=20.0"
+      },
+      {
+        "key": "psutil==6.1.1",
+        "req_type": "install",
+        "req": "psutil"
+      },
+      {
+        "key": "py-cpuinfo==9.0.0",
+        "req_type": "install",
+        "req": "py-cpuinfo"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic>=2.0.0"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "install",
+        "req": "torch"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm"
+      }
+    ]
+  },
+  "nvidia-ml-py==12.570.86": {
+    "download_url": "https://files.pythonhosted.org/packages/ad/6e/7b0c9b88c7d520fb8639024a1a3b6dd1db03bf2c17ae85040c8758d2eb6f/nvidia_ml_py-12.570.86.tar.gz#sha256=0508d4a0c7b6d015cf574530b95a62ed4fc89da3b8b47e1aefe6777db170ec8b",
+    "pre_built": false,
+    "version": "12.570.86",
+    "canonicalized_name": "nvidia-ml-py",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "msgpack==1.1.0": {
+    "download_url": "https://files.pythonhosted.org/packages/cb/d0/7555686ae7ff5731205df1012ede15dd9d927f6227ea151e901c7406af4f/msgpack-1.1.0.tar.gz#sha256=dd432ccc2c72b914e4cb77afce64aab761c1137cc698be3984eee260bcb2896e",
+    "pre_built": false,
+    "version": "1.1.0",
+    "canonicalized_name": "msgpack",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=69.5.1"
+      }
+    ]
+  },
+  "hjson==3.1.0": {
+    "download_url": "https://files.pythonhosted.org/packages/82/e5/0b56d723a76ca67abadbf7fb71609fb0ea7e6926e94fcca6c65a85b36a0e/hjson-3.1.0.tar.gz#sha256=55af475a27cf83a7969c808399d7bccdec8fb836a07ddbd574587593b9cdcf75",
+    "pre_built": false,
+    "version": "3.1.0",
+    "canonicalized_name": "hjson",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "bitsandbytes==0.45.1": {
+    "download_url": "https://api.github.com/repos/bitsandbytes-foundation/bitsandbytes/tarball/refs/tags/0.45.1",
+    "pre_built": false,
+    "version": "0.45.1",
+    "canonicalized_name": "bitsandbytes",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=63.0.0"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy>=1.17"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "install",
+        "req": "torch~=2.0"
+      }
+    ]
+  },
+  "aiofiles==24.1.0": {
+    "download_url": "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz#sha256=22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c",
+    "pre_built": false,
+    "version": "24.1.0",
+    "canonicalized_name": "aiofiles",
+    "edges": [
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling"
+      }
+    ]
+  },
+  "accelerate==1.0.1": {
+    "download_url": "https://files.pythonhosted.org/packages/a0/04/7f1b79a02f66a7e87e1716849b3bd295445cc46ecb63cb7521e6f7a72282/accelerate-1.0.1.tar.gz#sha256=e8f95fc2db14915dc0a9182edfcf3068e5ddb2fa310b583717ad44e5c442399c",
+    "pre_built": false,
+    "version": "1.0.1",
+    "canonicalized_name": "accelerate",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "huggingface-hub==0.30.1",
+        "req_type": "install",
+        "req": "huggingface-hub>=0.21.0"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy<3.0.0,>=1.17"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging>=20.0"
+      },
+      {
+        "key": "psutil==6.1.1",
+        "req_type": "install",
+        "req": "psutil"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml"
+      },
+      {
+        "key": "safetensors==0.4.5",
+        "req_type": "install",
+        "req": "safetensors>=0.4.3"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "install",
+        "req": "torch>=1.10.0"
+      }
+    ]
+  },
+  "instructlab-quantize==0.1.0": {
+    "download_url": "https://files.pythonhosted.org/packages/8a/64/096fb66541bf001e881951e37ff0007ee48a9f9cac232396e9af970a2d02/instructlab_quantize-0.1.0.tar.gz#sha256=8666127e2fef2def319e690b5156bb8c006c8246b27b5146f858f725d2c32500",
+    "pre_built": false,
+    "version": "0.1.0",
+    "canonicalized_name": "instructlab-quantize",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=64"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm>=8"
+      }
+    ]
+  },
+  "instructlab-eval==0.5.1": {
+    "download_url": "https://files.pythonhosted.org/packages/2f/14/4cf4013e0975ddf1bc23f9ccaae53318c941b086a7e1d304293a7b0ce590/instructlab_eval-0.5.1.tar.gz#sha256=47d5e8387a1036c8e11c0fa8cf33a71060ab3158bdcaacfcd611f46354ebb8ab",
+    "pre_built": false,
+    "version": "0.5.1",
+    "canonicalized_name": "instructlab-eval",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=64"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm>=8"
+      },
+      {
+        "key": "gitpython==3.1.44",
+        "req_type": "install",
+        "req": "GitPython<4.0.0,>=3.1.42"
+      },
+      {
+        "key": "accelerate==1.3.0",
+        "req_type": "install",
+        "req": "accelerate"
+      },
+      {
+        "key": "httpx==0.28.1",
+        "req_type": "install",
+        "req": "httpx"
+      },
+      {
+        "key": "lm-eval==0.4.7",
+        "req_type": "install",
+        "req": "lm-eval>=0.4.4"
+      },
+      {
+        "key": "openai==1.65.5",
+        "req_type": "install",
+        "req": "openai<2.0.0,>=1.13.3"
+      },
+      {
+        "key": "pandas==2.2.3",
+        "req_type": "install",
+        "req": "pandas"
+      },
+      {
+        "key": "pandas-stubs==2.2.3.241126",
+        "req_type": "install",
+        "req": "pandas-stubs"
+      },
+      {
+        "key": "psutil==6.1.1",
+        "req_type": "install",
+        "req": "psutil"
+      },
+      {
+        "key": "ragas==0.2.12",
+        "req_type": "install",
+        "req": "ragas>=0.2.11"
+      },
+      {
+        "key": "shortuuid==1.0.13",
+        "req_type": "install",
+        "req": "shortuuid"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "install",
+        "req": "torch"
+      },
+      {
+        "key": "transformers==4.48.1",
+        "req_type": "install",
+        "req": "transformers"
+      }
+    ]
+  },
+  "shortuuid==1.0.13": {
+    "download_url": "https://files.pythonhosted.org/packages/8c/e2/bcf761f3bff95856203f9559baf3741c416071dd200c0fc19fad7f078f86/shortuuid-1.0.13.tar.gz#sha256=3bb9cf07f606260584b1df46399c0b87dd84773e7b25912b7e391e30797c5e72",
+    "pre_built": false,
+    "version": "1.0.13",
+    "canonicalized_name": "shortuuid",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core"
+      }
+    ]
+  },
+  "ragas==0.2.12": {
+    "download_url": "https://files.pythonhosted.org/packages/0e/2d/cd7414c8c26a7a11e41433a48207097558fede9e2d7e491731d7196b85fe/ragas-0.2.12.tar.gz#sha256=f70ff73a0691a764ba92d77ab2813cacfd4fdef32f368c2b157f22683c3d0d68",
+    "pre_built": false,
+    "version": "0.2.12",
+    "canonicalized_name": "ragas",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=45"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm[toml]>=6.2"
+      },
+      {
+        "key": "appdirs==1.4.4",
+        "req_type": "install",
+        "req": "appdirs"
+      },
+      {
+        "key": "datasets==3.2.0",
+        "req_type": "install",
+        "req": "datasets"
+      },
+      {
+        "key": "diskcache==5.6.3",
+        "req_type": "install",
+        "req": "diskcache>=5.6.3"
+      },
+      {
+        "key": "langchain==0.3.15",
+        "req_type": "install",
+        "req": "langchain"
+      },
+      {
+        "key": "langchain-community==0.3.15",
+        "req_type": "install",
+        "req": "langchain-community"
+      },
+      {
+        "key": "langchain-core==0.3.31",
+        "req_type": "install",
+        "req": "langchain-core"
+      },
+      {
+        "key": "langchain-openai==0.3.2",
+        "req_type": "install",
+        "req": "langchain_openai"
+      },
+      {
+        "key": "nest-asyncio==1.6.0",
+        "req_type": "install",
+        "req": "nest-asyncio"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy"
+      },
+      {
+        "key": "openai==1.65.5",
+        "req_type": "install",
+        "req": "openai>1"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic>=2"
+      },
+      {
+        "key": "tiktoken==0.8.0",
+        "req_type": "install",
+        "req": "tiktoken"
+      }
+    ]
+  },
+  "tiktoken==0.8.0": {
+    "download_url": "https://files.pythonhosted.org/packages/37/02/576ff3a6639e755c4f70997b2d315f56d6d71e0d046f4fb64cb81a3fb099/tiktoken-0.8.0.tar.gz#sha256=9ccbb2740f24542534369c5635cfd9b2b3c2490754a78ac8831d99f89f94eeb2",
+    "pre_built": false,
+    "version": "0.8.0",
+    "canonicalized_name": "tiktoken",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=62.4"
+      },
+      {
+        "key": "setuptools-rust==1.10.2",
+        "req_type": "build-system",
+        "req": "setuptools-rust>=1.5.2"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      },
+      {
+        "key": "regex==2024.11.6",
+        "req_type": "install",
+        "req": "regex>=2022.1.18"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests>=2.26.0"
+      }
+    ]
+  },
+  "nest-asyncio==1.6.0": {
+    "download_url": "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz#sha256=6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe",
+    "pre_built": false,
+    "version": "1.6.0",
+    "canonicalized_name": "nest-asyncio",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=42"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm[toml]>=3.4.3"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      }
+    ]
+  },
+  "langchain-openai==0.3.2": {
+    "download_url": "https://files.pythonhosted.org/packages/2e/b6/711dc59041ca3a93461ccc176f90f6ab321cc41b24b70031a68928d3086f/langchain_openai-0.3.2.tar.gz#sha256=c2c80ac0208eb7cefdef96f6353b00fa217979ffe83f0a21cc8666001df828c1",
+    "pre_built": false,
+    "version": "0.3.2",
+    "canonicalized_name": "langchain-openai",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0"
+      },
+      {
+        "key": "langchain-core==0.3.31",
+        "req_type": "install",
+        "req": "langchain-core<0.4.0,>=0.3.31"
+      },
+      {
+        "key": "openai==1.65.5",
+        "req_type": "install",
+        "req": "openai<2.0.0,>=1.58.1"
+      },
+      {
+        "key": "tiktoken==0.8.0",
+        "req_type": "install",
+        "req": "tiktoken<1,>=0.7"
+      }
+    ]
+  },
+  "langchain-community==0.3.15": {
+    "download_url": "https://files.pythonhosted.org/packages/ed/47/a66620af03f108a01f7120153f144639b7531052568320ab7e8a6bb603db/langchain_community-0.3.15.tar.gz#sha256=c2fee46a0ea1b94c475bd4263edb53d5615dbe37c5263480bf55cb8e465ac235",
+    "pre_built": false,
+    "version": "0.3.15",
+    "canonicalized_name": "langchain-community",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "PyYAML>=5.3"
+      },
+      {
+        "key": "sqlalchemy==2.0.37",
+        "req_type": "install",
+        "req": "SQLAlchemy<3,>=1.4"
+      },
+      {
+        "key": "aiohttp==3.11.11",
+        "req_type": "install",
+        "req": "aiohttp<4.0.0,>=3.8.3"
+      },
+      {
+        "key": "dataclasses-json==0.6.7",
+        "req_type": "install",
+        "req": "dataclasses-json<0.7,>=0.5.7"
+      },
+      {
+        "key": "httpx-sse==0.4.0",
+        "req_type": "install",
+        "req": "httpx-sse<0.5.0,>=0.4.0"
+      },
+      {
+        "key": "langchain==0.3.15",
+        "req_type": "install",
+        "req": "langchain<0.4.0,>=0.3.15"
+      },
+      {
+        "key": "langchain-core==0.3.31",
+        "req_type": "install",
+        "req": "langchain-core<0.4.0,>=0.3.31"
+      },
+      {
+        "key": "langsmith==0.3.2",
+        "req_type": "install",
+        "req": "langsmith<0.4,>=0.1.125"
+      },
+      {
+        "key": "numpy==1.26.4",
+        "req_type": "install",
+        "req": "numpy<2,>=1.22.4; python_version < \"3.12\""
+      },
+      {
+        "key": "pydantic-settings==2.7.1",
+        "req_type": "install",
+        "req": "pydantic-settings<3.0.0,>=2.4.0"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests<3,>=2"
+      },
+      {
+        "key": "tenacity==9.0.0",
+        "req_type": "install",
+        "req": "tenacity!=8.4.0,<10,>=8.1.0"
+      }
+    ]
+  },
+  "langchain==0.3.15": {
+    "download_url": "https://files.pythonhosted.org/packages/1b/f4/83bc6f112ea8a83a2694275d6978c3201b1ca2433de505614977a81cfa05/langchain-0.3.15.tar.gz#sha256=1204d67f8469cd8da5621d2b39501650a824d4c0d5a74264dfe3df9a7528897e",
+    "pre_built": false,
+    "version": "0.3.15",
+    "canonicalized_name": "langchain",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "PyYAML>=5.3"
+      },
+      {
+        "key": "sqlalchemy==2.0.37",
+        "req_type": "install",
+        "req": "SQLAlchemy<3,>=1.4"
+      },
+      {
+        "key": "aiohttp==3.11.11",
+        "req_type": "install",
+        "req": "aiohttp<4.0.0,>=3.8.3"
+      },
+      {
+        "key": "langchain-core==0.3.31",
+        "req_type": "install",
+        "req": "langchain-core<0.4.0,>=0.3.31"
+      },
+      {
+        "key": "langchain-text-splitters==0.3.5",
+        "req_type": "install",
+        "req": "langchain-text-splitters<0.4.0,>=0.3.3"
+      },
+      {
+        "key": "langsmith==0.3.2",
+        "req_type": "install",
+        "req": "langsmith<0.4,>=0.1.17"
+      },
+      {
+        "key": "numpy==1.26.4",
+        "req_type": "install",
+        "req": "numpy<2,>=1.22.4; python_version < \"3.12\""
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic<3.0.0,>=2.7.4"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests<3,>=2"
+      },
+      {
+        "key": "tenacity==9.0.0",
+        "req_type": "install",
+        "req": "tenacity!=8.4.0,<10,>=8.1.0"
+      }
+    ]
+  },
+  "sqlalchemy==2.0.37": {
+    "download_url": "https://files.pythonhosted.org/packages/3b/20/93ea2518df4d7a14ebe9ace9ab8bb92aaf7df0072b9007644de74172b06c/sqlalchemy-2.0.37.tar.gz#sha256=12b28d99a9c14eaf4055810df1001557176716de0167b91026e648e65229bffb",
+    "pre_built": false,
+    "version": "2.0.37",
+    "canonicalized_name": "sqlalchemy",
+    "edges": [
+      {
+        "key": "cython==3.0.11",
+        "req_type": "build-system",
+        "req": "cython>=0.29.24; platform_python_implementation == \"CPython\""
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=61.0"
+      },
+      {
+        "key": "greenlet==3.1.1",
+        "req_type": "install",
+        "req": "greenlet!=0.4.17; python_version < \"3.14\" and (platform_machine == \"aarch64\" or (platform_machine == \"ppc64le\" or (platform_machine == \"x86_64\" or (platform_machine == \"amd64\" or (platform_machine == \"AMD64\" or (platform_machine == \"win32\" or platform_machine == \"WIN32\"))))))"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions>=4.6.0"
+      }
+    ]
+  },
+  "greenlet==3.1.1": {
+    "download_url": "https://files.pythonhosted.org/packages/2f/ff/df5fede753cc10f6a5be0931204ea30c35fa2f2ea7a35b25bdaf4fe40e46/greenlet-3.1.1.tar.gz#sha256=4ce3ac6cdb6adf7946475d7ef31777c26d94bccc377e070a7986bd2d5c515467",
+    "pre_built": false,
+    "version": "3.1.1",
+    "canonicalized_name": "greenlet",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "httpx-sse==0.4.0": {
+    "download_url": "https://files.pythonhosted.org/packages/4c/60/8f4281fa9bbf3c8034fd54c0e7412e66edbab6bc74c4996bd616f8d0406e/httpx-sse-0.4.0.tar.gz#sha256=1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721",
+    "pre_built": false,
+    "version": "0.4.0",
+    "canonicalized_name": "httpx-sse",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools-scm"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      }
+    ]
+  },
+  "dataclasses-json==0.6.7": {
+    "download_url": "https://files.pythonhosted.org/packages/64/a4/f71d9cf3a5ac257c993b5ca3f93df5f7fb395c725e7f1e6479d2514173c3/dataclasses_json-0.6.7.tar.gz#sha256=b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0",
+    "pre_built": false,
+    "version": "0.6.7",
+    "canonicalized_name": "dataclasses-json",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.2.0"
+      },
+      {
+        "key": "poetry-dynamic-versioning==1.7.1",
+        "req_type": "build-system",
+        "req": "poetry-dynamic-versioning"
+      },
+      {
+        "key": "marshmallow==3.26.0",
+        "req_type": "install",
+        "req": "marshmallow<4.0.0,>=3.18.0"
+      },
+      {
+        "key": "typing-inspect==0.9.0",
+        "req_type": "install",
+        "req": "typing-inspect<1,>=0.4.0"
+      }
+    ]
+  },
+  "typing-inspect==0.9.0": {
+    "download_url": "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz#sha256=b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78",
+    "pre_built": false,
+    "version": "0.9.0",
+    "canonicalized_name": "typing-inspect",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "mypy-extensions==1.0.0",
+        "req_type": "install",
+        "req": "mypy_extensions>=0.3.0"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing_extensions>=3.7.4"
+      }
+    ]
+  },
+  "marshmallow==3.26.0": {
+    "download_url": "https://files.pythonhosted.org/packages/ed/3a/b392ca6582ce5c2e515a8ca365f89b6e631d864a80ecdc72e0bc1bf3aec6/marshmallow-3.26.0.tar.gz#sha256=eb36762a1cc76d7abf831e18a3a1b26d3d481bbc74581b8e532a3d3a8115e1cb",
+    "pre_built": false,
+    "version": "3.26.0",
+    "canonicalized_name": "marshmallow",
+    "edges": [
+      {
+        "key": "flit-core==3.10.1",
+        "req_type": "build-system",
+        "req": "flit_core<4"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging>=17.0"
+      }
+    ]
+  },
+  "poetry-dynamic-versioning==1.7.1": {
+    "download_url": "https://files.pythonhosted.org/packages/63/55/e4febcf6e6b9073e7bd29bf558735ea208272f56a2a1e026d29ebe06231e/poetry_dynamic_versioning-1.7.1.tar.gz#sha256=7304b8459af7b7114cd83429827c4d3d8b7d29df4129dde8dff61c76f93faaa3",
+    "pre_built": false,
+    "version": "1.7.1",
+    "canonicalized_name": "poetry-dynamic-versioning",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0"
+      },
+      {
+        "key": "dunamai==1.23.0",
+        "req_type": "install",
+        "req": "dunamai<2.0.0,>=1.21.0"
+      },
+      {
+        "key": "jinja2==3.1.5",
+        "req_type": "install",
+        "req": "jinja2<4,>=2.11.1"
+      },
+      {
+        "key": "tomlkit==0.13.2",
+        "req_type": "install",
+        "req": "tomlkit>=0.4"
+      }
+    ]
+  },
+  "tomlkit==0.13.2": {
+    "download_url": "https://files.pythonhosted.org/packages/b1/09/a439bec5888f00a54b8b9f05fa94d7f901d6735ef4e55dcec9bc37b5d8fa/tomlkit-0.13.2.tar.gz#sha256=fff5fe59a87295b278abd31bec92c15d9bc4a06885ab12bcea52c71119392e79",
+    "pre_built": false,
+    "version": "0.13.2",
+    "canonicalized_name": "tomlkit",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0a9"
+      }
+    ]
+  },
+  "dunamai==1.23.0": {
+    "download_url": "https://files.pythonhosted.org/packages/06/4e/a5c8c337a1d9ac0384298ade02d322741fb5998041a5ea74d1cd2a4a1d47/dunamai-1.23.0.tar.gz#sha256=a163746de7ea5acb6dacdab3a6ad621ebc612ed1e528aaa8beedb8887fccd2c4",
+    "pre_built": false,
+    "version": "1.23.0",
+    "canonicalized_name": "dunamai",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging>=20.9"
+      }
+    ]
+  },
+  "pandas-stubs==2.2.3.241126": {
+    "download_url": "https://files.pythonhosted.org/packages/90/86/93c545d149c3e1fe1c4c55478cc3a69859d0ea3467e1d9892e9eb28cb1e7/pandas_stubs-2.2.3.241126.tar.gz#sha256=cf819383c6d9ae7d4dabf34cd47e1e45525bb2f312e6ad2939c2c204cb708acd",
+    "pre_built": false,
+    "version": "2.2.3.241126",
+    "canonicalized_name": "pandas-stubs",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy>=1.23.5"
+      },
+      {
+        "key": "types-pytz==2024.2.0.20241221",
+        "req_type": "install",
+        "req": "types-pytz>=2022.1.1"
+      }
+    ]
+  },
+  "types-pytz==2024.2.0.20241221": {
+    "download_url": "https://files.pythonhosted.org/packages/54/26/516311b02b5a215e721155fb65db8a965d061372e388d6125ebce8d674b0/types_pytz-2024.2.0.20241221.tar.gz#sha256=06d7cde9613e9f7504766a0554a270c369434b50e00975b3a4a0f6eed0f2c1a9",
+    "pre_built": false,
+    "version": "2024.2.0.20241221",
+    "canonicalized_name": "types-pytz",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "lm-eval==0.4.7": {
+    "download_url": "https://files.pythonhosted.org/packages/53/c9/b5d03d5b2bf6819008e377844999fbd04ab00dff0c43728957f1c90a53c5/lm_eval-0.4.7.tar.gz#sha256=dcbef8722f363f58cfba36b6d783fc6bb17924b24b8da1684bf1ac835866208d",
+    "pre_built": false,
+    "version": "0.4.7",
+    "canonicalized_name": "lm-eval",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      },
+      {
+        "key": "accelerate==1.3.0",
+        "req_type": "install",
+        "req": "accelerate>=0.26.0"
+      },
+      {
+        "key": "datasets==3.2.0",
+        "req_type": "install",
+        "req": "datasets>=2.16.0"
+      },
+      {
+        "key": "dill==0.3.9",
+        "req_type": "install",
+        "req": "dill"
+      },
+      {
+        "key": "evaluate==0.4.3",
+        "req_type": "install",
+        "req": "evaluate>=0.4.0"
+      },
+      {
+        "key": "evaluate==0.4.3",
+        "req_type": "install",
+        "req": "evaluate"
+      },
+      {
+        "key": "jsonlines==4.0.0",
+        "req_type": "install",
+        "req": "jsonlines"
+      },
+      {
+        "key": "more-itertools==10.6.0",
+        "req_type": "install",
+        "req": "more_itertools"
+      },
+      {
+        "key": "numexpr==2.10.2",
+        "req_type": "install",
+        "req": "numexpr"
+      },
+      {
+        "key": "peft==0.14.0",
+        "req_type": "install",
+        "req": "peft>=0.2.0"
+      },
+      {
+        "key": "pybind11==2.13.6",
+        "req_type": "install",
+        "req": "pybind11>=2.6.2"
+      },
+      {
+        "key": "pytablewriter==1.2.1",
+        "req_type": "install",
+        "req": "pytablewriter"
+      },
+      {
+        "key": "rouge-score==0.1.2",
+        "req_type": "install",
+        "req": "rouge-score>=0.0.4"
+      },
+      {
+        "key": "sacrebleu==2.5.1",
+        "req_type": "install",
+        "req": "sacrebleu>=1.5.0"
+      },
+      {
+        "key": "scikit-learn==1.6.1",
+        "req_type": "install",
+        "req": "scikit-learn>=0.24.1"
+      },
+      {
+        "key": "sqlitedict==2.1.0",
+        "req_type": "install",
+        "req": "sqlitedict"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "install",
+        "req": "torch>=1.8"
+      },
+      {
+        "key": "tqdm-multiprocess==0.0.11",
+        "req_type": "install",
+        "req": "tqdm-multiprocess"
+      },
+      {
+        "key": "transformers==4.48.1",
+        "req_type": "install",
+        "req": "transformers>=4.1"
+      },
+      {
+        "key": "word2number==1.1",
+        "req_type": "install",
+        "req": "word2number"
+      },
+      {
+        "key": "zstandard==0.23.0",
+        "req_type": "install",
+        "req": "zstandard"
+      }
+    ]
+  },
+  "word2number==1.1": {
+    "download_url": "https://files.pythonhosted.org/packages/4a/29/a31940c848521f0725f0df6b25dca8917f13a2025b0e8fcbe5d0457e45e6/word2number-1.1.zip#sha256=70e27a5d387f67b04c71fbb7621c05930b19bfd26efd6851e6e0f9969dcde7d0",
+    "pre_built": false,
+    "version": "1.1",
+    "canonicalized_name": "word2number",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "tqdm-multiprocess==0.0.11": {
+    "download_url": "https://files.pythonhosted.org/packages/b4/1e/de81bd0f6cb2b61d6ee7ccbf304d99a42a0f53879481536dfb3288ee9a87/tqdm-multiprocess-0.0.11.tar.gz#sha256=a74002a1222ea9cbe8cdc9bd460108c6009be359621fbee9b92d0515d4d180f7",
+    "pre_built": false,
+    "version": "0.0.11",
+    "canonicalized_name": "tqdm-multiprocess",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "colorama==0.4.6",
+        "req_type": "install",
+        "req": "colorama"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm"
+      }
+    ]
+  },
+  "colorama==0.4.6": {
+    "download_url": "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz#sha256=08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
+    "pre_built": false,
+    "version": "0.4.6",
+    "canonicalized_name": "colorama",
+    "edges": [
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling>=0.25.1"
+      }
+    ]
+  },
+  "sqlitedict==2.1.0": {
+    "download_url": "https://files.pythonhosted.org/packages/12/9a/7620d1e9dcb02839ed6d4b14064e609cdd7a8ae1e47289aa0456796dd9ca/sqlitedict-2.1.0.tar.gz#sha256=03d9cfb96d602996f1d4c2db2856f1224b96a9c431bdd16e78032a72940f9e8c",
+    "pre_built": false,
+    "version": "2.1.0",
+    "canonicalized_name": "sqlitedict",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "sacrebleu==2.5.1": {
+    "download_url": "https://files.pythonhosted.org/packages/01/14/8526cf8a5b912b618e7d6ed319a5b1876788bebba1f9a660e1291832c1cc/sacrebleu-2.5.1.tar.gz#sha256=1a088cc1c74ffaff0759c3191a85db09eecfa7a52e09be244e319d8d64e2fb11",
+    "pre_built": false,
+    "version": "2.5.1",
+    "canonicalized_name": "sacrebleu",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=64"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm>=8"
+      },
+      {
+        "key": "colorama==0.4.6",
+        "req_type": "install",
+        "req": "colorama"
+      },
+      {
+        "key": "lxml==5.3.0",
+        "req_type": "install",
+        "req": "lxml"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy>=1.17"
+      },
+      {
+        "key": "portalocker==3.1.1",
+        "req_type": "install",
+        "req": "portalocker"
+      },
+      {
+        "key": "regex==2024.11.6",
+        "req_type": "install",
+        "req": "regex"
+      },
+      {
+        "key": "tabulate==0.9.0",
+        "req_type": "install",
+        "req": "tabulate>=0.8.9"
+      }
+    ]
+  },
+  "portalocker==3.1.1": {
+    "download_url": "https://files.pythonhosted.org/packages/ac/91/8bfe23e1f7f630f2061ef38b5225d9fda9068d6a30fcbc187951e678e630/portalocker-3.1.1.tar.gz#sha256=ec20f6dda2ad9ce89fa399a5f31f4f1495f515958f0cb7ca6543cef7bb5a749e",
+    "pre_built": false,
+    "version": "3.1.1",
+    "canonicalized_name": "portalocker",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools-scm"
+      }
+    ]
+  },
+  "pytablewriter==1.2.1": {
+    "download_url": "https://files.pythonhosted.org/packages/f6/a1/617730f290f04d347103ab40bf67d317df6691b14746f6e1ea039fb57062/pytablewriter-1.2.1.tar.gz#sha256=7bd0f4f397e070e3b8a34edcf1b9257ccbb18305493d8350a5dbc9957fced959",
+    "pre_built": false,
+    "version": "1.2.1",
+    "canonicalized_name": "pytablewriter",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=64"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm>=8"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-backend",
+        "req": "setuptools>=38.3.0"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-sdist",
+        "req": "setuptools>=38.3.0"
+      },
+      {
+        "key": "dataproperty==1.1.0",
+        "req_type": "install",
+        "req": "DataProperty<2,>=1.1.0"
+      },
+      {
+        "key": "mbstrdecoder==1.1.4",
+        "req_type": "install",
+        "req": "mbstrdecoder<2,>=1.0.0"
+      },
+      {
+        "key": "pathvalidate==3.2.3",
+        "req_type": "install",
+        "req": "pathvalidate<4,>=2.3.0"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "install",
+        "req": "setuptools>=38.3.0"
+      },
+      {
+        "key": "tabledata==1.3.4",
+        "req_type": "install",
+        "req": "tabledata<2,>=1.3.1"
+      },
+      {
+        "key": "tcolorpy==0.1.7",
+        "req_type": "install",
+        "req": "tcolorpy<1,>=0.0.5"
+      },
+      {
+        "key": "typepy==1.3.4",
+        "req_type": "install",
+        "req": "typepy[datetime]<2,>=1.3.2"
+      }
+    ]
+  },
+  "typepy==1.3.4": {
+    "download_url": "https://files.pythonhosted.org/packages/79/59/4c39942077d7de285f762a91024dbda731be693591732977358f77d120fb/typepy-1.3.4.tar.gz#sha256=89c1f66de6c6133209c43a94d23431d320ba03ef5db18f241091ea594035d9de",
+    "pre_built": false,
+    "version": "1.3.4",
+    "canonicalized_name": "typepy",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=64"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm>=8"
+      },
+      {
+        "key": "mbstrdecoder==1.1.4",
+        "req_type": "install",
+        "req": "mbstrdecoder<2,>=1.0.0"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging; extra == \"datetime\""
+      },
+      {
+        "key": "python-dateutil==2.9.0.post0",
+        "req_type": "install",
+        "req": "python-dateutil<3.0.0,>=2.8.0; extra == \"datetime\""
+      },
+      {
+        "key": "pytz==2024.2",
+        "req_type": "install",
+        "req": "pytz>=2018.9; extra == \"datetime\""
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=64"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm>=8"
+      },
+      {
+        "key": "mbstrdecoder==1.1.4",
+        "req_type": "install",
+        "req": "mbstrdecoder<2,>=1.0.0"
+      }
+    ]
+  },
+  "mbstrdecoder==1.1.4": {
+    "download_url": "https://files.pythonhosted.org/packages/31/ab/05ae008357c8bdb6245ebf8a101d99f26c096e0ea20800b318153da23796/mbstrdecoder-1.1.4.tar.gz#sha256=8105ef9cf6b7d7d69fe7fd6b68a2d8f281ca9b365d7a9b670be376b2e6c81b21",
+    "pre_built": false,
+    "version": "1.1.4",
+    "canonicalized_name": "mbstrdecoder",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=64"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm>=8"
+      },
+      {
+        "key": "chardet==5.2.0",
+        "req_type": "install",
+        "req": "chardet<6,>=3.0.4"
+      }
+    ]
+  },
+  "chardet==5.2.0": {
+    "download_url": "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz#sha256=1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7",
+    "pre_built": false,
+    "version": "5.2.0",
+    "canonicalized_name": "chardet",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      }
+    ]
+  },
+  "tcolorpy==0.1.7": {
+    "download_url": "https://files.pythonhosted.org/packages/80/cc/44f2d81d8f9093aad81c3467a5bf5718d2b5f786e887b6e4adcfc17ec6b9/tcolorpy-0.1.7.tar.gz#sha256=0fbf6bf238890bbc2e32662aa25736769a29bf6d880328f310c910a327632614",
+    "pre_built": false,
+    "version": "0.1.7",
+    "canonicalized_name": "tcolorpy",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=64"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm>=8"
+      }
+    ]
+  },
+  "tabledata==1.3.4": {
+    "download_url": "https://files.pythonhosted.org/packages/b2/35/171c8977162f1163368406deddde4c59673b62bd0cb2f34948a02effb075/tabledata-1.3.4.tar.gz#sha256=e9649cab129d718f3bff4150083b77f8a78c30f6634a30caf692b10fdc60cb97",
+    "pre_built": false,
+    "version": "1.3.4",
+    "canonicalized_name": "tabledata",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=64"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm>=8"
+      },
+      {
+        "key": "dataproperty==1.1.0",
+        "req_type": "install",
+        "req": "DataProperty<2,>=1.0.1"
+      },
+      {
+        "key": "typepy==1.3.4",
+        "req_type": "install",
+        "req": "typepy<2,>=1.2.0"
+      }
+    ]
+  },
+  "dataproperty==1.1.0": {
+    "download_url": "https://files.pythonhosted.org/packages/0b/81/8c8b64ae873cb9014815214c07b63b12e3b18835780fb342223cfe3fe7d8/dataproperty-1.1.0.tar.gz#sha256=b038437a4097d1a1c497695c3586ea34bea67fdd35372b9a50f30bf044d77d04",
+    "pre_built": false,
+    "version": "1.1.0",
+    "canonicalized_name": "dataproperty",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=64"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm>=8"
+      },
+      {
+        "key": "mbstrdecoder==1.1.4",
+        "req_type": "install",
+        "req": "mbstrdecoder<2,>=1.0.0"
+      },
+      {
+        "key": "typepy==1.3.4",
+        "req_type": "install",
+        "req": "typepy[datetime]<2,>=1.3.2"
+      }
+    ]
+  },
+  "pathvalidate==3.2.3": {
+    "download_url": "https://files.pythonhosted.org/packages/92/87/c7a2f51cc62df0495acb0ed2533a7c74cc895e569a1b020ee5f6e9fa4e21/pathvalidate-3.2.3.tar.gz#sha256=59b5b9278e30382d6d213497623043ebe63f10e29055be4419a9c04c721739cb",
+    "pre_built": false,
+    "version": "3.2.3",
+    "canonicalized_name": "pathvalidate",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=64"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm>=8"
+      }
+    ]
+  },
+  "numexpr==2.10.2": {
+    "download_url": "https://files.pythonhosted.org/packages/21/67/c7415cf04ebe418193cfd6595ae03e3a64d76dac7b9c010098b39cc7992e/numexpr-2.10.2.tar.gz#sha256=b0aff6b48ebc99d2f54f27b5f73a58cb92fde650aeff1b397c71c8788b4fff1a",
+    "pre_built": false,
+    "version": "2.10.2",
+    "canonicalized_name": "numexpr",
+    "edges": [
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "build-system",
+        "req": "numpy>=2.0.0"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy>=1.23.0"
+      }
+    ]
+  },
+  "more-itertools==10.6.0": {
+    "download_url": "https://files.pythonhosted.org/packages/88/3b/7fa1fe835e2e93fd6d7b52b2f95ae810cf5ba133e1845f726f5a992d62c2/more-itertools-10.6.0.tar.gz#sha256=2cd7fad1009c31cc9fb6a035108509e6547547a7a738374f10bd49a09eb3ee3b",
+    "pre_built": false,
+    "version": "10.6.0",
+    "canonicalized_name": "more-itertools",
+    "edges": [
+      {
+        "key": "flit-core==3.10.1",
+        "req_type": "build-system",
+        "req": "flit_core<4,>=3.2"
+      }
+    ]
+  },
+  "jsonlines==4.0.0": {
+    "download_url": "https://files.pythonhosted.org/packages/35/87/bcda8e46c88d0e34cad2f09ee2d0c7f5957bccdb9791b0b934ec84d84be4/jsonlines-4.0.0.tar.gz#sha256=0c6d2c09117550c089995247f605ae4cf77dd1533041d366351f6f298822ea74",
+    "pre_built": false,
+    "version": "4.0.0",
+    "canonicalized_name": "jsonlines",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "attrs==25.1.0",
+        "req_type": "install",
+        "req": "attrs>=19.2.0"
+      }
+    ]
+  },
+  "evaluate==0.4.3": {
+    "download_url": "https://files.pythonhosted.org/packages/5a/a0/10a56e0939ece94c54276e81459cb4101f46f0e9a6f54fc31a35f64e8854/evaluate-0.4.3.tar.gz#sha256=3a5700cf83aabee9549264e1e5666f116367c61dbd4d38352015e859a5e2098d",
+    "pre_built": false,
+    "version": "0.4.3",
+    "canonicalized_name": "evaluate",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "datasets==3.2.0",
+        "req_type": "install",
+        "req": "datasets>=2.0.0"
+      },
+      {
+        "key": "dill==0.3.9",
+        "req_type": "install",
+        "req": "dill"
+      },
+      {
+        "key": "fsspec==2024.12.0",
+        "req_type": "install",
+        "req": "fsspec[http]>=2021.05.0"
+      },
+      {
+        "key": "huggingface-hub==0.30.1",
+        "req_type": "install",
+        "req": "huggingface-hub>=0.7.0"
+      },
+      {
+        "key": "multiprocess==0.70.16",
+        "req_type": "install",
+        "req": "multiprocess"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy>=1.17"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging"
+      },
+      {
+        "key": "pandas==2.2.3",
+        "req_type": "install",
+        "req": "pandas"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests>=2.19.0"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm>=4.62.1"
+      },
+      {
+        "key": "xxhash==3.5.0",
+        "req_type": "install",
+        "req": "xxhash"
+      }
+    ]
+  },
+  "haystack-ai==2.9.0": {
+    "download_url": "https://files.pythonhosted.org/packages/bd/6e/7a326c0ada7e53bafe9049a8d9aca5a7827923b7b9beed28a990157bba51/haystack_ai-2.9.0.tar.gz#sha256=ffaf32a8d1a3b15e5f6dc9277670f7167d2651f8c0c778178649b20c693f3dcd",
+    "pre_built": false,
+    "version": "2.9.0",
+    "canonicalized_name": "haystack-ai",
+    "edges": [
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling>=1.8.0"
+      },
+      {
+        "key": "haystack-experimental==0.5.0",
+        "req_type": "install",
+        "req": "haystack-experimental"
+      },
+      {
+        "key": "jinja2==3.1.5",
+        "req_type": "install",
+        "req": "jinja2"
+      },
+      {
+        "key": "lazy-imports==0.4.0",
+        "req_type": "install",
+        "req": "lazy-imports"
+      },
+      {
+        "key": "more-itertools==10.6.0",
+        "req_type": "install",
+        "req": "more-itertools"
+      },
+      {
+        "key": "networkx==3.4.2",
+        "req_type": "install",
+        "req": "networkx"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy"
+      },
+      {
+        "key": "openai==1.65.5",
+        "req_type": "install",
+        "req": "openai>=1.56.1"
+      },
+      {
+        "key": "pandas==2.2.3",
+        "req_type": "install",
+        "req": "pandas"
+      },
+      {
+        "key": "posthog==3.10.0",
+        "req_type": "install",
+        "req": "posthog"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic"
+      },
+      {
+        "key": "python-dateutil==2.9.0.post0",
+        "req_type": "install",
+        "req": "python-dateutil"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests"
+      },
+      {
+        "key": "tenacity==9.0.0",
+        "req_type": "install",
+        "req": "tenacity!=8.4.0"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions>=4.7"
+      }
+    ]
+  },
+  "posthog==3.10.0": {
+    "download_url": "https://files.pythonhosted.org/packages/12/d0/834621a426b808512a7945ab983015f08bd44b9e6635d8e5da49ee01362a/posthog-3.10.0.tar.gz#sha256=c07113c0558fde279d0462010e4ad87b6a2a76cb970cae0122d5a31d629fc27b",
+    "pre_built": false,
+    "version": "3.10.0",
+    "canonicalized_name": "posthog",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "backoff==2.2.1",
+        "req_type": "install",
+        "req": "backoff>=1.10.0"
+      },
+      {
+        "key": "monotonic==1.6",
+        "req_type": "install",
+        "req": "monotonic>=1.5"
+      },
+      {
+        "key": "python-dateutil==2.9.0.post0",
+        "req_type": "install",
+        "req": "python-dateutil>2.1"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests<3.0,>=2.7"
+      },
+      {
+        "key": "six==1.17.0",
+        "req_type": "install",
+        "req": "six>=1.5"
+      }
+    ]
+  },
+  "monotonic==1.6": {
+    "download_url": "https://files.pythonhosted.org/packages/ea/ca/8e91948b782ddfbd194f323e7e7d9ba12e5877addf04fb2bf8fca38e86ac/monotonic-1.6.tar.gz#sha256=3a55207bcfed53ddd5c5bae174524062935efed17792e9de2ad0205ce9ad63f7",
+    "pre_built": false,
+    "version": "1.6",
+    "canonicalized_name": "monotonic",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "backoff==2.2.1": {
+    "download_url": "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz#sha256=03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba",
+    "pre_built": false,
+    "version": "2.2.1",
+    "canonicalized_name": "backoff",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0"
+      }
+    ]
+  },
+  "lazy-imports==0.4.0": {
+    "download_url": "https://files.pythonhosted.org/packages/af/07/6236eec8d2c547407626139440e927e2554473d2b516f8df9820786d3246/lazy_imports-0.4.0.tar.gz#sha256=c3d9e4e295e6118588f58c6710d152bb2836e0276f790a120ee4ab608829cece",
+    "pre_built": false,
+    "version": "0.4.0",
+    "canonicalized_name": "lazy-imports",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "haystack-experimental==0.5.0": {
+    "download_url": "https://files.pythonhosted.org/packages/0a/bd/12b689428e424886637be9de22aac3006e284d188bcc06a630e904c5edba/haystack_experimental-0.5.0.tar.gz#sha256=10e91a7a2a2ea64a84e29715d535ecc8ee0ab3050a8d016d25c2a74481538cf7",
+    "pre_built": false,
+    "version": "0.5.0",
+    "canonicalized_name": "haystack-experimental",
+    "edges": [
+      {
+        "key": "hatch-vcs==0.4.0",
+        "req_type": "build-system",
+        "req": "hatch-vcs"
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling>=1.8.0"
+      },
+      {
+        "key": "haystack-ai==2.9.0",
+        "req_type": "install",
+        "req": "haystack-ai"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic"
+      }
+    ]
+  },
+  "filelock==3.18.0": {
+    "download_url": "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz#sha256=adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2",
+    "pre_built": false,
+    "version": "3.18.0",
+    "canonicalized_name": "filelock",
+    "edges": [
+      {
+        "key": "hatch-vcs==0.4.0",
+        "req_type": "build-system",
+        "req": "hatch-vcs>=0.4"
+      },
+      {
+        "key": "hatchling==1.27.0",
+        "req_type": "build-system",
+        "req": "hatchling>=1.27"
+      }
+    ]
+  },
+  "click-didyoumean==0.3.1": {
+    "download_url": "https://files.pythonhosted.org/packages/30/ce/217289b77c590ea1e7c24242d9ddd6e249e52c795ff10fac2c50062c48cb/click_didyoumean-0.3.1.tar.gz#sha256=4f82fdff0dbe64ef8ab2279bd6aa3f6a99c3b28c05aa09cbfc07c9d7fbb5a463",
+    "pre_built": false,
+    "version": "0.3.1",
+    "canonicalized_name": "click-didyoumean",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0"
+      },
+      {
+        "key": "click==8.1.8",
+        "req_type": "install",
+        "req": "click>=7"
+      }
+    ]
+  },
+  "boto3==1.36.6": {
+    "download_url": "https://files.pythonhosted.org/packages/ec/31/f6189fcb81156cd2e7f7616e4c95958a47e53c12253c5e86a9dcc1a529c1/boto3-1.36.6.tar.gz#sha256=b36feae061dc0793cf311468956a0a9e99215ce38bc99a1a4e55a5b105f16297",
+    "pre_built": false,
+    "version": "1.36.6",
+    "canonicalized_name": "boto3",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "botocore==1.36.6",
+        "req_type": "install",
+        "req": "botocore<1.37.0,>=1.36.6"
+      },
+      {
+        "key": "jmespath==1.0.1",
+        "req_type": "install",
+        "req": "jmespath<2.0.0,>=0.7.1"
+      },
+      {
+        "key": "s3transfer==0.11.2",
+        "req_type": "install",
+        "req": "s3transfer<0.12.0,>=0.11.0"
+      }
+    ]
+  },
+  "s3transfer==0.11.2": {
+    "download_url": "https://files.pythonhosted.org/packages/62/45/2323b5928f86fd29f9afdcef4659f68fa73eaa5356912b774227f5cf46b5/s3transfer-0.11.2.tar.gz#sha256=3b39185cb72f5acc77db1a58b6e25b977f28d20496b6e58d6813d75f464d632f",
+    "pre_built": false,
+    "version": "0.11.2",
+    "canonicalized_name": "s3transfer",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "botocore==1.36.6",
+        "req_type": "install",
+        "req": "botocore<2.0a.0,>=1.36.0"
+      }
+    ]
+  },
+  "botocore==1.36.6": {
+    "download_url": "https://files.pythonhosted.org/packages/b0/b6/bd1a28becf386a70ca41aa6b76b0d65d03aed81d39fac662d1f97754ffca/botocore-1.36.6.tar.gz#sha256=4864c53d638da191a34daf3ede3ff1371a3719d952cc0c6bd24ce2836a38dd77",
+    "pre_built": false,
+    "version": "1.36.6",
+    "canonicalized_name": "botocore",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "jmespath==1.0.1",
+        "req_type": "install",
+        "req": "jmespath<2.0.0,>=0.7.1"
+      },
+      {
+        "key": "python-dateutil==2.9.0.post0",
+        "req_type": "install",
+        "req": "python-dateutil<3.0.0,>=2.1"
+      },
+      {
+        "key": "urllib3==2.3.0",
+        "req_type": "install",
+        "req": "urllib3!=2.2.0,<3,>=1.25.4; python_version >= \"3.10\""
+      }
+    ]
+  },
+  "jmespath==1.0.1": {
+    "download_url": "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz#sha256=90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe",
+    "pre_built": false,
+    "version": "1.0.1",
+    "canonicalized_name": "jmespath",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "vllm==0.6.4.post1": {
+    "download_url": "https://github.com/opendatahub-io/vllm/archive/refs/tags/v0.6.4.post1_1.tar.gz",
+    "pre_built": false,
+    "version": "0.6.4.post1",
+    "canonicalized_name": "vllm",
+    "edges": [
+      {
+        "key": "jinja2==3.1.5",
+        "req_type": "build-system",
+        "req": "jinja2"
+      },
+      {
+        "key": "ninja==1.11.1.1",
+        "req_type": "build-system",
+        "req": "ninja"
+      },
+      {
+        "key": "numpy==1.26.4",
+        "req_type": "build-system",
+        "req": "numpy<2.0.0"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "build-system",
+        "req": "packaging"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=61"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools-scm>=8.0"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "build-system",
+        "req": "torch==2.5.1"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      },
+      {
+        "key": "aiohttp==3.11.11",
+        "req_type": "install",
+        "req": "aiohttp"
+      },
+      {
+        "key": "compressed-tensors==0.8.0",
+        "req_type": "install",
+        "req": "compressed-tensors==0.8.0"
+      },
+      {
+        "key": "einops==0.8.0",
+        "req_type": "install",
+        "req": "einops"
+      },
+      {
+        "key": "fastapi==0.115.7",
+        "req_type": "install",
+        "req": "fastapi!=0.113.*,!=0.114.0,>=0.107.0; python_version >= \"3.9\""
+      },
+      {
+        "key": "filelock==3.17.0",
+        "req_type": "install",
+        "req": "filelock>=3.10.4"
+      },
+      {
+        "key": "gguf==0.10.0",
+        "req_type": "install",
+        "req": "gguf==0.10.0"
+      },
+      {
+        "key": "importlib-metadata==8.6.1",
+        "req_type": "install",
+        "req": "importlib_metadata"
+      },
+      {
+        "key": "lm-format-enforcer==0.10.9",
+        "req_type": "install",
+        "req": "lm-format-enforcer<0.11,>=0.10.9"
+      },
+      {
+        "key": "mistral-common==1.5.2",
+        "req_type": "install",
+        "req": "mistral_common[opencv]>=1.5.0"
+      },
+      {
+        "key": "msgspec==0.19.0",
+        "req_type": "install",
+        "req": "msgspec"
+      },
+      {
+        "key": "numpy==1.26.4",
+        "req_type": "install",
+        "req": "numpy<2.0.0"
+      },
+      {
+        "key": "nvidia-ml-py==12.570.86",
+        "req_type": "install",
+        "req": "nvidia-ml-py>=12.560.30"
+      },
+      {
+        "key": "openai==1.65.5",
+        "req_type": "install",
+        "req": "openai>=1.45.0"
+      },
+      {
+        "key": "outlines==0.0.46",
+        "req_type": "install",
+        "req": "outlines<0.1,>=0.0.43"
+      },
+      {
+        "key": "partial-json-parser==0.2.1.1.post5",
+        "req_type": "install",
+        "req": "partial-json-parser"
+      },
+      {
+        "key": "pillow==11.1.0",
+        "req_type": "install",
+        "req": "pillow"
+      },
+      {
+        "key": "prometheus-fastapi-instrumentator==7.0.2",
+        "req_type": "install",
+        "req": "prometheus-fastapi-instrumentator>=7.0.0"
+      },
+      {
+        "key": "prometheus-client==0.21.1",
+        "req_type": "install",
+        "req": "prometheus_client>=0.18.0"
+      },
+      {
+        "key": "protobuf==5.29.3",
+        "req_type": "install",
+        "req": "protobuf"
+      },
+      {
+        "key": "psutil==6.1.1",
+        "req_type": "install",
+        "req": "psutil"
+      },
+      {
+        "key": "py-cpuinfo==9.0.0",
+        "req_type": "install",
+        "req": "py-cpuinfo"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic>=2.9"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml"
+      },
+      {
+        "key": "pyzmq==26.2.0",
+        "req_type": "install",
+        "req": "pyzmq"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests>=2.26.0"
+      },
+      {
+        "key": "sentencepiece==0.2.0",
+        "req_type": "install",
+        "req": "sentencepiece"
+      },
+      {
+        "key": "tiktoken==0.8.0",
+        "req_type": "install",
+        "req": "tiktoken>=0.6.0"
+      },
+      {
+        "key": "tokenizers==0.21.0",
+        "req_type": "install",
+        "req": "tokenizers>=0.19.1"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "install",
+        "req": "torch==2.5.1"
+      },
+      {
+        "key": "torchvision==0.20.1",
+        "req_type": "install",
+        "req": "torchvision==0.20.1"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm"
+      },
+      {
+        "key": "transformers==4.48.1",
+        "req_type": "install",
+        "req": "transformers>=4.45.2"
+      },
+      {
+        "key": "triton==3.1.0",
+        "req_type": "install",
+        "req": "triton==3.1.0"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing_extensions>=4.10"
+      },
+      {
+        "key": "uvicorn==0.34.0",
+        "req_type": "install",
+        "req": "uvicorn[standard]"
+      },
+      {
+        "key": "xformers==0.0.28.post3",
+        "req_type": "install",
+        "req": "xformers==0.0.28.post3; platform_system == \"Linux\" and platform_machine == \"x86_64\""
+      }
+    ]
+  },
+  "xformers==0.0.28.post3": {
+    "download_url": "https://files.pythonhosted.org/packages/00/d8/7301b2044e29b384b6ec009ed37002f4df48906a2a772654e8386fa3b730/xformers-0.0.28.post3.tar.gz#sha256=c7a2392c874dfd8f38b73e14492baf048a4f50f77ddf522bfcf6ebf5ee84d567",
+    "pre_built": false,
+    "version": "0.0.28.post3",
+    "canonicalized_name": "xformers",
+    "edges": [
+      {
+        "key": "numpy==1.26.4",
+        "req_type": "build-system",
+        "req": "numpy<2.0.0"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "build-system",
+        "req": "torch"
+      },
+      {
+        "key": "numpy==1.26.4",
+        "req_type": "install",
+        "req": "numpy<2.0.0"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "install",
+        "req": "torch>=2.4"
+      }
+    ]
+  },
+  "triton==3.1.0": {
+    "download_url": "https://github.com/triton-lang/triton/archive/refs/heads/release/3.1.x.tar.gz",
+    "pre_built": false,
+    "version": "3.1.0",
+    "canonicalized_name": "triton",
+    "edges": [
+      {
+        "key": "ninja==1.11.1.1",
+        "req_type": "build-system",
+        "req": "ninja>=1.11.1"
+      },
+      {
+        "key": "pybind11==2.13.6",
+        "req_type": "build-system",
+        "req": "pybind11>=2.11.1"
+      },
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "build-system",
+        "req": "torch"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      },
+      {
+        "key": "filelock==3.17.0",
+        "req_type": "install",
+        "req": "filelock"
+      }
+    ]
+  },
+  "pyzmq==26.2.0": {
+    "download_url": "https://files.pythonhosted.org/packages/fd/05/bed626b9f7bb2322cdbbf7b4bd8f54b1b617b0d2ab2d3547d6e39428a48e/pyzmq-26.2.0.tar.gz#sha256=070672c258581c8e4f640b5159297580a9974b026043bd4ab0470be9ed324f1f",
+    "pre_built": false,
+    "version": "26.2.0",
+    "canonicalized_name": "pyzmq",
+    "edges": [
+      {
+        "key": "cython==3.0.11",
+        "req_type": "build-system",
+        "req": "cython>=3.0.0; implementation_name != \"pypy\""
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "build-system",
+        "req": "packaging"
+      },
+      {
+        "key": "scikit-build-core==0.10.7",
+        "req_type": "build-system",
+        "req": "scikit-build-core"
+      },
+      {
+        "key": "ninja==1.11.1.1",
+        "req_type": "build-backend",
+        "req": "ninja>=1.5"
+      },
+      {
+        "key": "ninja==1.11.1.1",
+        "req_type": "build-sdist",
+        "req": "ninja>=1.5"
+      }
+    ]
+  },
+  "protobuf==5.29.3": {
+    "download_url": "https://files.pythonhosted.org/packages/f7/d1/e0a911544ca9993e0f17ce6d3cc0932752356c1b0a834397f28e63479344/protobuf-5.29.3.tar.gz#sha256=5da0f41edaf117bde316404bad1a486cb4ededf8e4a54891296f648e8e076620",
+    "pre_built": false,
+    "version": "5.29.3",
+    "canonicalized_name": "protobuf",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "prometheus-client==0.21.1": {
+    "download_url": "https://files.pythonhosted.org/packages/62/14/7d0f567991f3a9af8d1cd4f619040c93b68f09a02b6d0b6ab1b2d1ded5fe/prometheus_client-0.21.1.tar.gz#sha256=252505a722ac04b0456be05c05f75f45d760c2911ffc45f2a06bcaed9f3ae3fb",
+    "pre_built": false,
+    "version": "0.21.1",
+    "canonicalized_name": "prometheus-client",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "prometheus-fastapi-instrumentator==7.0.2": {
+    "download_url": "https://files.pythonhosted.org/packages/c4/01/e3ccb464ba9bf6c001ad85652e6fc7e63098c2685275a682cabc8e7871b8/prometheus_fastapi_instrumentator-7.0.2.tar.gz#sha256=8a4d8fb13dbe19d2882ac6af9ce236e4e1f98dc48e3fa44fe88d8e23ac3c953f",
+    "pre_built": false,
+    "version": "7.0.2",
+    "canonicalized_name": "prometheus-fastapi-instrumentator",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=2.0"
+      },
+      {
+        "key": "prometheus-client==0.21.1",
+        "req_type": "install",
+        "req": "prometheus-client<1.0.0,>=0.8.0"
+      },
+      {
+        "key": "starlette==0.45.3",
+        "req_type": "install",
+        "req": "starlette<1.0.0,>=0.30.0"
+      }
+    ]
+  },
+  "partial-json-parser==0.2.1.1.post5": {
+    "download_url": "https://files.pythonhosted.org/packages/27/9c/9c366aed65acb40a97842ce1375a87b27ea37d735fc9717f7729bae3cc00/partial_json_parser-0.2.1.1.post5.tar.gz#sha256=992710ac67e90b367921d52727698928040f7713ba7ecb33b96371ea7aec82ca",
+    "pre_built": false,
+    "version": "0.2.1.1.post5",
+    "canonicalized_name": "partial-json-parser",
+    "edges": [
+      {
+        "key": "pdm-backend==2.4.3",
+        "req_type": "build-system",
+        "req": "pdm-backend"
+      }
+    ]
+  },
+  "outlines==0.0.46": {
+    "download_url": "https://files.pythonhosted.org/packages/8d/90/4c63b1b99960905ee2dd0c1b6d8bf059bf000619ccdb2ad89b41bb30efeb/outlines-0.0.46.tar.gz#sha256=cd272418a268e0a25b7189180dfdcf9fe1b99f50ac1dfb9ffd83c896c5b3fa3c",
+    "pre_built": false,
+    "version": "0.0.46",
+    "canonicalized_name": "outlines",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=45"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm[toml]>=6.2"
+      },
+      {
+        "key": "cloudpickle==3.1.1",
+        "req_type": "install",
+        "req": "cloudpickle"
+      },
+      {
+        "key": "datasets==3.2.0",
+        "req_type": "install",
+        "req": "datasets"
+      },
+      {
+        "key": "diskcache==5.6.3",
+        "req_type": "install",
+        "req": "diskcache"
+      },
+      {
+        "key": "interegular==0.3.3",
+        "req_type": "install",
+        "req": "interegular"
+      },
+      {
+        "key": "jinja2==3.1.5",
+        "req_type": "install",
+        "req": "jinja2"
+      },
+      {
+        "key": "jsonschema==4.23.0",
+        "req_type": "install",
+        "req": "jsonschema"
+      },
+      {
+        "key": "lark==1.2.2",
+        "req_type": "install",
+        "req": "lark"
+      },
+      {
+        "key": "nest-asyncio==1.6.0",
+        "req_type": "install",
+        "req": "nest-asyncio"
+      },
+      {
+        "key": "numba==0.60.0",
+        "req_type": "install",
+        "req": "numba"
+      },
+      {
+        "key": "numpy==1.26.4",
+        "req_type": "install",
+        "req": "numpy<2.0.0"
+      },
+      {
+        "key": "pyairports==2.1.1",
+        "req_type": "install",
+        "req": "pyairports"
+      },
+      {
+        "key": "pycountry==24.6.1",
+        "req_type": "install",
+        "req": "pycountry"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic>=2.0"
+      },
+      {
+        "key": "referencing==0.36.2",
+        "req_type": "install",
+        "req": "referencing"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions"
+      }
+    ]
+  },
+  "pycountry==24.6.1": {
+    "download_url": "https://files.pythonhosted.org/packages/76/57/c389fa68c50590881a75b7883eeb3dc15e9e73a0fdc001cdd45c13290c92/pycountry-24.6.1.tar.gz#sha256=b61b3faccea67f87d10c1f2b0fc0be714409e8fcdcc1315613174f6466c10221",
+    "pre_built": false,
+    "version": "24.6.1",
+    "canonicalized_name": "pycountry",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0"
+      }
+    ]
+  },
+  "pyairports==2.1.1": {
+    "download_url": "https://files.pythonhosted.org/packages/be/56/6e46904a6a408e5fbc9f6a345ed94bfb73bdb5251ce39bb60b6bf023c0ed/pyairports-2.1.1.tar.gz#sha256=3d60a727fce4da81b9c6393ea8ae0b33d67b37ece344dffc863f749e3ad62bcd",
+    "pre_built": false,
+    "version": "2.1.1",
+    "canonicalized_name": "pyairports",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "lark==1.2.2": {
+    "download_url": "https://files.pythonhosted.org/packages/af/60/bc7622aefb2aee1c0b4ba23c1446d3e30225c8770b38d7aedbfb65ca9d5a/lark-1.2.2.tar.gz#sha256=ca807d0162cd16cef15a8feecb862d7319e7a09bdb13aef927968e45040fed80",
+    "pre_built": false,
+    "version": "1.2.2",
+    "canonicalized_name": "lark",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=61.2.0"
+      }
+    ]
+  },
+  "interegular==0.3.3": {
+    "download_url": "https://files.pythonhosted.org/packages/dc/9d/8b6dde58a028a3962ce17e84d5fe73758df61378e00ef8ac3d85da34b0ff/interegular-0.3.3.tar.gz#sha256=d9b697b21b34884711399ba0f0376914b81899ce670032486d0d048344a76600",
+    "pre_built": false,
+    "version": "0.3.3",
+    "canonicalized_name": "interegular",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "cloudpickle==3.1.1": {
+    "download_url": "https://files.pythonhosted.org/packages/52/39/069100b84d7418bc358d81669d5748efb14b9cceacd2f9c75f550424132f/cloudpickle-3.1.1.tar.gz#sha256=b216fa8ae4019d5482a8ac3c95d8f6346115d8835911fd4aefd1a445e4242c64",
+    "pre_built": false,
+    "version": "3.1.1",
+    "canonicalized_name": "cloudpickle",
+    "edges": [
+      {
+        "key": "flit-core==3.10.1",
+        "req_type": "build-system",
+        "req": "flit_core"
+      }
+    ]
+  },
+  "msgspec==0.19.0": {
+    "download_url": "https://files.pythonhosted.org/packages/cf/9b/95d8ce458462b8b71b8a70fa94563b2498b89933689f3a7b8911edfae3d7/msgspec-0.19.0.tar.gz#sha256=604037e7cd475345848116e89c553aa9a233259733ab51986ac924ab1b976f8e",
+    "pre_built": false,
+    "version": "0.19.0",
+    "canonicalized_name": "msgspec",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      }
+    ]
+  },
+  "mistral-common==1.5.2": {
+    "download_url": "https://files.pythonhosted.org/packages/dc/db/14b3acba21c21e4fbff96d40dc0271d50b3e47c9559797baade6bc1b71b9/mistral_common-1.5.2.tar.gz#sha256=9d1157b1376c49d35abfc743dbe0084f2ca37b3a5abd03e741276a1bc66c852f",
+    "pre_built": false,
+    "version": "1.5.2",
+    "canonicalized_name": "mistral-common",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core"
+      },
+      {
+        "key": "jsonschema==4.23.0",
+        "req_type": "install",
+        "req": "jsonschema<5.0.0,>=4.21.1"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy>=1.25; python_version >= \"3.9\""
+      },
+      {
+        "key": "opencv-python-headless==4.11.0.86",
+        "req_type": "install",
+        "req": "opencv-python-headless<5.0.0,>=4.0.0; extra == \"opencv\""
+      },
+      {
+        "key": "pillow==10.4.0",
+        "req_type": "install",
+        "req": "pillow<11.0.0,>=10.3.0"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic<3.0,>=2.7"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests<3.0.0,>=2.0.0"
+      },
+      {
+        "key": "sentencepiece==0.2.0",
+        "req_type": "install",
+        "req": "sentencepiece==0.2.0"
+      },
+      {
+        "key": "tiktoken==0.7.0",
+        "req_type": "install",
+        "req": "tiktoken<0.8.0,>=0.7.0"
+      },
+      {
+        "key": "typing-extensions==4.12.2",
+        "req_type": "install",
+        "req": "typing-extensions<5.0.0,>=4.11.0"
+      }
+    ]
+  },
+  "tiktoken==0.7.0": {
+    "download_url": "https://files.pythonhosted.org/packages/c4/4a/abaec53e93e3ef37224a4dd9e2fc6bb871e7a538c2b6b9d2a6397271daf4/tiktoken-0.7.0.tar.gz#sha256=1077266e949c24e0291f6c350433c6f0971365ece2b173a23bc3b9f9defef6b6",
+    "pre_built": false,
+    "version": "0.7.0",
+    "canonicalized_name": "tiktoken",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=62.4"
+      },
+      {
+        "key": "setuptools-rust==1.10.2",
+        "req_type": "build-system",
+        "req": "setuptools-rust>=1.5.2"
+      },
+      {
+        "key": "wheel==0.45.1",
+        "req_type": "build-system",
+        "req": "wheel"
+      },
+      {
+        "key": "regex==2024.11.6",
+        "req_type": "install",
+        "req": "regex>=2022.1.18"
+      },
+      {
+        "key": "requests==2.32.3",
+        "req_type": "install",
+        "req": "requests>=2.26.0"
+      }
+    ]
+  },
+  "lm-format-enforcer==0.10.9": {
+    "download_url": "https://files.pythonhosted.org/packages/73/5d/401ffb7a8895e0f3206345e96c52b428c81e4a2af049d426023cb9cb0cdb/lm_format_enforcer-0.10.9.tar.gz#sha256=3e0bfeaf9fac9f69c8947da554db9a19a76d0be6e85075055f2c70d0aca420da",
+    "pre_built": false,
+    "version": "0.10.9",
+    "canonicalized_name": "lm-format-enforcer",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.1.0"
+      },
+      {
+        "key": "interegular==0.3.3",
+        "req_type": "install",
+        "req": "interegular>=0.3.2"
+      },
+      {
+        "key": "packaging==24.2",
+        "req_type": "install",
+        "req": "packaging"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic>=1.10.8"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml"
+      }
+    ]
+  },
+  "importlib-metadata==8.6.1": {
+    "download_url": "https://files.pythonhosted.org/packages/33/08/c1395a292bb23fd03bdf572a1357c5a733d3eecbab877641ceacab23db6e/importlib_metadata-8.6.1.tar.gz#sha256=310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580",
+    "pre_built": false,
+    "version": "8.6.1",
+    "canonicalized_name": "importlib-metadata",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=61.2"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm[toml]>=3.4.1"
+      },
+      {
+        "key": "zipp==3.21.0",
+        "req_type": "install",
+        "req": "zipp>=3.20"
+      }
+    ]
+  },
+  "zipp==3.21.0": {
+    "download_url": "https://files.pythonhosted.org/packages/3f/50/bad581df71744867e9468ebd0bcd6505de3b275e06f202c2cb016e3ff56f/zipp-3.21.0.tar.gz#sha256=2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4",
+    "pre_built": false,
+    "version": "3.21.0",
+    "canonicalized_name": "zipp",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=61.2"
+      },
+      {
+        "key": "setuptools-scm==8.1.0",
+        "req_type": "build-system",
+        "req": "setuptools_scm[toml]>=3.4.1"
+      }
+    ]
+  },
+  "gguf==0.10.0": {
+    "download_url": "https://files.pythonhosted.org/packages/0e/c4/a159e9f842b0e8b8495b2689af6cf3426f002cf01207ca8134db82fc4088/gguf-0.10.0.tar.gz#sha256=52a30ef26328b419ffc47d9269fc580c238edf1c8a19b5ea143c323e04a038c1",
+    "pre_built": false,
+    "version": "0.10.0",
+    "canonicalized_name": "gguf",
+    "edges": [
+      {
+        "key": "poetry-core==2.0.1",
+        "req_type": "build-system",
+        "req": "poetry-core>=1.0.0"
+      },
+      {
+        "key": "numpy==2.2.2",
+        "req_type": "install",
+        "req": "numpy>=1.17"
+      },
+      {
+        "key": "pyyaml==6.0.2",
+        "req_type": "install",
+        "req": "pyyaml>=5.1"
+      },
+      {
+        "key": "tqdm==4.67.1",
+        "req_type": "install",
+        "req": "tqdm>=4.27"
+      }
+    ]
+  },
+  "compressed-tensors==0.8.0": {
+    "download_url": "https://files.pythonhosted.org/packages/0a/96/4d04fd0cbd23710551c50ce996d9f087b5d68dad85b3a1a80ac5cdc32770/compressed_tensors-0.8.0-py3-none-any.whl#sha256=5f0cd41d72f4838218475c97706a5792f5e0f97c68fd3fb1f56092dd82895604",
+    "pre_built": false,
+    "version": "0.8.0",
+    "canonicalized_name": "compressed-tensors",
+    "edges": [
+      {
+        "key": "setuptools==75.8.0",
+        "req_type": "build-system",
+        "req": "setuptools>=40.8.0"
+      },
+      {
+        "key": "pydantic==2.9.2",
+        "req_type": "install",
+        "req": "pydantic>=2.0"
+      },
+      {
+        "key": "torch==2.5.1",
+        "req_type": "install",
+        "req": "torch>=1.7.0"
+      },
+      {
+        "key": "transformers==4.48.1",
+        "req_type": "install",
+        "req": "transformers"
+      }
+    ]
+  }
+}

--- a/e2e/test_graph_to_constraints.sh
+++ b/e2e/test_graph_to_constraints.sh
@@ -16,7 +16,7 @@ if fromager graph to-constraints; then
 fi
 
 # Test that the command fails when given a graph with dependency conflicts
-if fromager graph to-constraints "$SCRIPTDIR/graph-with-dependency-conflict.json" -o "$OUTDIR/constraints.txt"; then
+if fromager -v graph to-constraints "$SCRIPTDIR/graph-with-dependency-conflict.json" -o "$OUTDIR/constraints.txt"; then
     echo "Command should have failed when given a graph with dependency conflicts, instead got:" 1>&2
     grep docling "$OUTDIR/constraints.txt" 1>&2
     pass=false

--- a/e2e/test_graph_to_constraints.sh
+++ b/e2e/test_graph_to_constraints.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# -*- indent-tabs-mode: nil; tab-width: 2; sh-indentation: 2; -*-
+
+# Test that the fromager graph to-constraints command fails when given
+# a graph with dependency conflicts.
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$SCRIPTDIR/common.sh"
+
+pass=true
+
+# Test that the command fails when no input file is specified
+if fromager graph to-constraints; then
+    echo "Command should have failed when no input file is specified" 1>&2
+    pass=false
+fi
+
+# Test that the command fails when given a graph with dependency conflicts
+if fromager graph to-constraints "$SCRIPTDIR/graph-with-dependency-conflict.json" -o "$OUTDIR/constraints.txt"; then
+    echo "Command should have failed when given a graph with dependency conflicts, instead got:" 1>&2
+    grep docling "$OUTDIR/constraints.txt" 1>&2
+    pass=false
+fi
+
+$pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,3 +141,4 @@ reportUnknownMemberType = false
 reportUnusedParameter = false
 reportAny = false
 reportImplicitOverride = false
+reportAttributeAccessIssue = false  # adding our own private property on click commands

--- a/src/fromager/commands/bootstrap.py
+++ b/src/fromager/commands/bootstrap.py
@@ -6,6 +6,8 @@ from packaging.requirements import Requirement
 from packaging.utils import NormalizedName
 from packaging.version import Version
 
+from fromager.dependency_graph import DependencyNode
+
 from .. import (
     bootstrapper,
     context,
@@ -218,21 +220,25 @@ def write_constraints_file(
 ) -> bool:
     # Look for potential conflicts by tracking how many different versions of
     # each package are needed.
-    conflicts = graph.get_install_dependency_versions()
+    conflicts: dict[NormalizedName, list[DependencyNode]] = (
+        graph.get_install_dependency_versions()
+    )
     ret = True
-    conflicting_deps = set()
+    conflicting_deps: set[NormalizedName] = set()
 
     # Map for already resolved versions for a given dependency Eg: {"a": "0.4"}
     resolved: dict[NormalizedName, Version] = {}
 
     # List of unresolved dependencies
-    unresolved_dependencies = sorted(conflicts.items())
+    unresolved_dependencies: list[tuple[NormalizedName, list[DependencyNode]]] = sorted(
+        conflicts.items()
+    )
 
     dep_name: NormalizedName
 
     # Loop over dependencies and resolve dependencies with single version first. This will shrink the unresolved_dependencies to begin with.
     for dep_name, nodes in unresolved_dependencies[:]:
-        versions = [node.version for node in nodes]
+        versions: list[Version] = [node.version for node in nodes]
         if len(versions) == 0:
             # This should never happen.
             raise ValueError(f"No versions of {dep_name} supported")
@@ -243,14 +249,16 @@ def write_constraints_file(
             resolved[dep_name] = versions[0]
             # Remove from unresolved dependencies list
             unresolved_dependencies.remove((dep_name, nodes))
-    multiple_versions = dict(unresolved_dependencies)
+    multiple_versions: dict[NormalizedName, list[DependencyNode]] = dict(
+        unresolved_dependencies
+    )
 
     # Below this point we have built multiple versions of the same thing, so
     # we need to try to determine if any one of those versions meets all of
     # the requirements.
 
     # Flag to see if something is resolved
-    resolved_something = True
+    resolved_something: bool = True
 
     # Outer while loop to resolve remaining dependencies with multiple versions
     while unresolved_dependencies and resolved_something:
@@ -261,16 +269,20 @@ def write_constraints_file(
             usable_versions: dict[Version, list[Version]] = {}
             # Track how many total users of a requirement (by name) there are so we
             # can tell later if any version can be used by all of them.
-            user_counter = 0
+            user_counter: int = 0
             # Which parent requirements can use which versions of the dependency we
             # are working on?
-            dep_versions = [node.version for node in nodes]
+            dep_versions: list[Version] = [node.version for node in nodes]
             # Loop over the nodes list
             for node in nodes:
-                parent_edges = node.get_incoming_install_edges()
+                parent_edges: list[dependency_graph.DependencyEdge] = (
+                    node.get_incoming_install_edges()
+                )
                 # Loop over parent_edges list
                 for parent_edge in parent_edges:
-                    parent_name = parent_edge.destination_node.canonicalized_name
+                    parent_name: NormalizedName = (
+                        parent_edge.destination_node.canonicalized_name
+                    )
                     # Condition to select the right version.
                     # We check whether parent_name is already in resolved dict and the version associated with that
                     # is not the version of the destination node
@@ -281,7 +293,7 @@ def write_constraints_file(
                     ):
                         continue
                     # Loop to find the usable versions
-                    for matching_version in parent_edge.req.specifier.filter(
+                    for matching_version in parent_edge.req.specifier.filter(  # type: ignore
                         dep_versions
                     ):
                         usable_versions.setdefault(matching_version, []).append(
@@ -293,7 +305,7 @@ def write_constraints_file(
             # and output that if we find it. Otherwise, include a warning and report
             # all versions so a human reading the file can make their own decision
             # about how to resolve the conflict.
-            for v, users in reversed(sorted(usable_versions.items())):
+            for v, users in reversed(sorted(usable_versions.items())):  # type: ignore
                 if len(users) != user_counter:
                     logger.debug(
                         "%s: version %s is useable by %d of %d consumers, skipping it",
@@ -303,7 +315,9 @@ def write_constraints_file(
                         user_counter,
                     )
                     continue
-                version_strs = [str(v) for v in reversed(sorted(dep_versions))]
+                version_strs: list[str] = [
+                    str(v) for v in reversed(sorted(dep_versions))
+                ]
                 logger.debug(
                     "%s: selecting %s from multiple candidates %s",
                     dep_name,
@@ -323,7 +337,7 @@ def write_constraints_file(
                 break
 
     # Write resolved versions to constraints file
-    for dep_name, resolved_version in sorted(resolved.items()):
+    for dep_name, resolved_version in sorted(resolved.items()):  # type: ignore
         if dep_name in multiple_versions:
             version_strs = [
                 str(node.version)
@@ -336,7 +350,7 @@ def write_constraints_file(
 
     # No single version could be used, so go ahead and print all the
     # versions with a warning message
-    for dep_name, nodes in unresolved_dependencies:
+    for dep_name, nodes in unresolved_dependencies:  # type: ignore
         ret = False
         logger.error("%s: no single version meets all requirements", dep_name)
         output.write(f"# ERROR: no single version of {dep_name} met all requirements\n")

--- a/src/fromager/commands/graph.py
+++ b/src/fromager/commands/graph.py
@@ -41,12 +41,18 @@ def graph():
 @click.pass_obj
 def to_constraints(wkctx: context.WorkContext, graph_file: str, output: pathlib.Path):
     "Convert a graph file to a constraints file."
-    graph = DependencyGraph.from_file(graph_file)
+    graph: DependencyGraph = DependencyGraph.from_file(graph_file)
+    ret: bool = True
     if output:
         with open(output, "w") as f:
-            bootstrap.write_constraints_file(graph, f)
+            ret = bootstrap.write_constraints_file(graph, f)
     else:
-        bootstrap.write_constraints_file(graph, sys.stdout)
+        ret = bootstrap.write_constraints_file(graph, sys.stdout)
+
+    if not ret:
+        raise ValueError(
+            "Failed to write constraints file - no valid set of installation dependencies could be generated"
+        )
 
 
 @graph.command()


### PR DESCRIPTION
Fix an issue with the `graph to-constraints` command and constraints.txt
generation in `bootstrap` where we were ignoring pinned versions in
top level dependencies if that same package was also a dependency of
something else. If we have conflicting versions in that case there is no
way to resolve them and we should report an error.

Co-authored-by: Claude 3.7 Sonnet <claude-3-7-sonnet@anthropic.com>
Signed-off-by: Doug Hellmann <dhellmann@redhat.com>