### PR TITLE
Fix: Pass config settings to hooks

### DIFF
--- a/e2e/matplotlib_settings/cython.yaml
+++ b/e2e/matplotlib_settings/cython.yaml
@@ -1,0 +1,4 @@
+# speed up tests
+variants:
+  cpu:
+    pre_built: True

--- a/e2e/matplotlib_settings/matplotlib.yaml
+++ b/e2e/matplotlib_settings/matplotlib.yaml
@@ -1,0 +1,7 @@
+changelog:
+  "3.10.3":
+    - "Build matplotlib with system packages"
+config_settings:
+  setup-args:
+    - "-Dsystem-freetype=true"
+    - "-Dsystem-qhull=true"

--- a/e2e/matplotlib_settings/meson-python.yaml
+++ b/e2e/matplotlib_settings/meson-python.yaml
@@ -1,0 +1,4 @@
+# speed up tests
+variants:
+  cpu:
+    pre_built: True

--- a/e2e/matplotlib_settings/meson.yaml
+++ b/e2e/matplotlib_settings/meson.yaml
@@ -1,0 +1,4 @@
+# speed up tests
+variants:
+  cpu:
+    pre_built: True

--- a/e2e/matplotlib_settings/numpy.yaml
+++ b/e2e/matplotlib_settings/numpy.yaml
@@ -1,0 +1,4 @@
+# speed up tests
+variants:
+  cpu:
+    pre_built: True

--- a/e2e/test_bootstrap_sdist_only.sh
+++ b/e2e/test_bootstrap_sdist_only.sh
@@ -10,6 +10,9 @@
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$SCRIPTDIR/common.sh"
 
+DIST=stevedore
+VER=5.2.0
+
 # passing settings to bootstrap but should have 0 effect on it
 fromager \
   --log-file="$OUTDIR/bootstrap.log" \
@@ -18,7 +21,7 @@ fromager \
   --wheels-repo="$OUTDIR/wheels-repo" \
   --work-dir="$OUTDIR/work-dir" \
   --settings-dir="$SCRIPTDIR/changelog_settings" \
-  bootstrap --sdist-only 'stevedore==5.2.0'
+  bootstrap --sdist-only "$DIST==$VER"
 
 find "$OUTDIR/wheels-repo/" -name '*.whl'
 find "$OUTDIR/sdists-repo/" -name '*.tar.gz'

--- a/src/fromager/dependencies.py
+++ b/src/fromager/dependencies.py
@@ -138,13 +138,16 @@ def default_get_build_backend_dependencies(
     Defaults to result of hook call
     :meth:`~pyproject_hooks.BuildBackendHookCaller.get_requires_for_build_wheel`
     """
+    pbi = ctx.package_build_info(req)
     hook_caller = get_build_backend_hook_caller(
         ctx=ctx,
         req=req,
         build_dir=build_dir,
         override_environ=extra_environ,
     )
-    return hook_caller.get_requires_for_build_wheel()
+    return hook_caller.get_requires_for_build_wheel(
+        config_settings=pbi.config_settings,
+    )
 
 
 def get_build_sdist_dependencies(
@@ -195,13 +198,16 @@ def default_get_build_sdist_dependencies(
     Defaults to result of hook call
     :meth:`~pyproject_hooks.BuildBackendHookCaller.get_requires_for_build_wheel`
     """
+    pbi = ctx.package_build_info(req)
     hook_caller = get_build_backend_hook_caller(
         ctx=ctx,
         req=req,
         build_dir=build_dir,
         override_environ=extra_environ,
     )
-    return hook_caller.get_requires_for_build_wheel()
+    return hook_caller.get_requires_for_build_wheel(
+        config_settings=pbi.config_settings,
+    )
 
 
 def get_install_dependencies_of_sdist(
@@ -227,7 +233,10 @@ def get_install_dependencies_of_sdist(
         build_env=build_env,
     )
     with tempfile.TemporaryDirectory() as tmp_dir:
-        distinfo_name = hook_caller.prepare_metadata_for_build_wheel(tmp_dir)
+        distinfo_name = hook_caller.prepare_metadata_for_build_wheel(
+            tmp_dir,
+            config_settings=pbi.config_settings,
+        )
         metadata_file = pathlib.Path(tmp_dir) / distinfo_name / "METADATA"
         # ignore minor metadata issues
         metadata = parse_metadata(metadata_file, validate=False)

--- a/src/fromager/packagesettings.py
+++ b/src/fromager/packagesettings.py
@@ -310,10 +310,17 @@ class PackageSettings(pydantic.BaseModel):
     changelog: VariantChangelog = Field(default_factory=dict)
     """Changelog entries"""
 
-    config_settings: list[str] = Field(default_factory=list)
+    config_settings: dict[str, list[str]] = Field(default_factory=dict)
     """PEP 517 arbitrary configuration for wheel builds
 
     https://peps.python.org/pep-0517/#config-settings
+
+    ::
+
+       config_settings:
+         setup-args:
+           - "-Dsystem-freetype=true"
+           - "-Dsystem-qhull=true"
     """
 
     env: EnvVars = Field(default_factory=dict)
@@ -757,7 +764,7 @@ class PackageBuildInfo:
         return self._ps.build_options.build_ext_parallel
 
     @property
-    def config_settings(self) -> list[str]:
+    def config_settings(self) -> dict[str, list[str]]:
         return self._ps.config_settings
 
     @property

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -268,7 +268,7 @@ def _get_version_from_package_metadata(
     )
     metadata_dir_base = hook_caller.prepare_metadata_for_build_wheel(
         metadata_directory=source_dir.parent,
-        config_settings={},
+        config_settings=pbi.config_settings,
     )
     metadata_filename = source_dir.parent / metadata_dir_base / "METADATA"
     with open(metadata_filename, "rb") as f:
@@ -753,7 +753,10 @@ def pep517_build_sdist(
         build_dir=build_dir,
         override_environ=extra_environ,
     )
-    sdist_filename = hook_caller.build_sdist(ctx.sdists_builds)
+    sdist_filename = hook_caller.build_sdist(
+        ctx.sdists_builds,
+        config_settings=pbi.config_settings,
+    )
     return ctx.sdists_builds / sdist_filename
 
 

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -350,8 +350,9 @@ def default_build_wheel(
     # config settings needs pip >= 24.0 to work. Fromager uses `virtualenv``
     # package to create virtual envs, which comes with recent pip. Stdlib's
     # `venv` comes with rather old pip.
-    for cs in pbi.config_settings:
-        cmd.append(f"--config-settings={cs}")
+    for key, values in pbi.config_settings.items():
+        for value in values:
+            cmd.append(f"--config-settings={key}={value}")
     cmd.append(os.fspath(build_dir))
 
     with tempfile.TemporaryDirectory() as dir_name:

--- a/tests/test_packagesettings.py
+++ b/tests/test_packagesettings.py
@@ -35,9 +35,12 @@ FULL_EXPECTED: dict[str, typing.Any] = {
         Version("1.0.1"): ["fixed bug"],
         Version("1.0.2"): ["more bugs", "rebuild"],
     },
-    "config_settings": [
-        "setup-args=-Dsystem-freetype=true",
-    ],
+    "config_settings": {
+        "setup-args": [
+            "-Dsystem-freetype=true",
+            "-Dsystem-qhull=true",
+        ],
+    },
     "download_source": {
         "destination_filename": "${canonicalized_name}-${version}.tar.gz",
         "url": "https://egg.test/${canonicalized_name}/v${version}.tar.gz",
@@ -89,7 +92,7 @@ EMPTY_EXPECTED: dict[str, typing.Any] = {
         "memory_per_job_gb": 1.0,
     },
     "changelog": {},
-    "config_settings": [],
+    "config_settings": {},
     "env": {},
     "download_source": {
         "url": None,

--- a/tests/testdata/context/overrides/settings/test_pkg.yaml
+++ b/tests/testdata/context/overrides/settings/test_pkg.yaml
@@ -10,7 +10,9 @@ changelog:
         - more bugs
         - rebuild
 config_settings:
-    - setup-args=-Dsystem-freetype=true
+  setup-args:
+    - "-Dsystem-freetype=true"
+    - "-Dsystem-qhull=true"
 env:
     EGG: spam
     EGG_AGAIN: "$EGG"


### PR DESCRIPTION
Pass `config_settings` to all hooks. This fixes sdist-only mode for `matplotlib`. The settings are now passed to
`prepare_metadata_for_build_wheel` and meson no longer attempts to download freetype when getting build metadata.

This change is backwards incompatible. `config_settings` is now a mapping of strings to list of strings. Before it was just a list of strings.

I'm including my `e2e/matplotlib_settings` files for future testing.