### PR TITLE
Fix Git URL handling for bootstrap from URL requirements

### DIFF
--- a/e2e/test_bootstrap_git_url.sh
+++ b/e2e/test_bootstrap_git_url.sh
@@ -10,7 +10,6 @@ GIT_REPO_URL="https://github.com/python-wheel-build/stevedore-test-repo.git"
 
 fromager \
   --debug \
-  --verbose \
   --log-file="$OUTDIR/bootstrap.log" \
   --error-log-file="$OUTDIR/fromager-errors.log" \
   --sdists-repo="$OUTDIR/sdists-repo" \

--- a/e2e/test_bootstrap_git_url.sh
+++ b/e2e/test_bootstrap_git_url.sh
@@ -6,10 +6,11 @@
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$SCRIPTDIR/common.sh"
 
-GIT_REPO_URL="https://opendev.org/openstack/stevedore.git"
+GIT_REPO_URL="https://github.com/python-wheel-build/stevedore-test-repo.git"
 
 fromager \
   --debug \
+  --verbose \
   --log-file="$OUTDIR/bootstrap.log" \
   --error-log-file="$OUTDIR/fromager-errors.log" \
   --sdists-repo="$OUTDIR/sdists-repo" \

--- a/e2e/test_bootstrap_git_url_tag.sh
+++ b/e2e/test_bootstrap_git_url_tag.sh
@@ -9,7 +9,6 @@ source "$SCRIPTDIR/common.sh"
 GIT_REPO_URL="https://github.com/python-wheel-build/stevedore-test-repo.git"
 
 fromager \
-  --verbose \
   --debug \
   --log-file="$OUTDIR/bootstrap.log" \
   --error-log-file="$OUTDIR/fromager-errors.log" \

--- a/e2e/test_bootstrap_git_url_tag.sh
+++ b/e2e/test_bootstrap_git_url_tag.sh
@@ -6,9 +6,10 @@
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$SCRIPTDIR/common.sh"
 
-GIT_REPO_URL="https://opendev.org/openstack/stevedore.git"
+GIT_REPO_URL="https://github.com/python-wheel-build/stevedore-test-repo.git"
 
 fromager \
+  --verbose \
   --debug \
   --log-file="$OUTDIR/bootstrap.log" \
   --error-log-file="$OUTDIR/fromager-errors.log" \

--- a/src/fromager/bootstrapper.py
+++ b/src/fromager/bootstrapper.py
@@ -742,8 +742,19 @@ class Bootstrapper:
     ) -> Version:
         pbi = self.ctx.package_build_info(req)
         build_dir = pbi.build_dir(source_dir)
-        logger.info("generating metadata to get version")
 
+        logger.info(
+            "preparing build dependencies so we can access the metadata to get the version"
+        )
+        build_dependencies = self._prepare_build_dependencies(req, source_dir)
+        build_environment.BuildEnvironment(
+            ctx=self.ctx,
+            parent_dir=source_dir.parent,
+            build_requirements=build_dependencies,
+            req=req,
+        )
+
+        logger.info("generating metadata to get version")
         hook_caller = dependencies.get_build_backend_hook_caller(
             ctx=self.ctx,
             req=req,


### PR DESCRIPTION
# Fix Git URL handling for bootstrap from URL requirements

This pull request addresses issue #632 by improving how Fromager handles requirements specified with Git URLs during the bootstrap process. The changes consolidate Git URL processing logic in the bootstrapper and ensure build dependencies are properly resolved before extracting version metadata.

## Changes

### Commits

- Move git url handling to bootstrapper  
  Moves source resolution for requirements with git URLs into the bootstrapper, consolidating logic that was previously split between the sources module and bootstrapper. This ensures build dependencies are available before processing metadata.

- Move version resolution to method in bootstrapper  
  Extracts version resolution logic into a reusable method in the bootstrapper to eliminate code duplication between bootstrap command and bootstrapper class.

- Process build dependencies before getting version from metadata  
  Ensures build dependencies are installed before attempting to access package metadata for version extraction when bootstrapping Git URL requirements.

## Summary

The key improvements include:

1. **Consolidated Git URL handling**: Moved all Git URL processing logic from `sources.py` to `bootstrapper.py` for better organization and dependency management
2. **Improved version resolution**: Created a reusable `resolve_version()` method to eliminate code duplication
3. **Fixed build dependency ordering**: Ensures build dependencies are processed before extracting version metadata from Git repositories
4. **Updated test configuration**: Simplified test scripts by using a dedicated test repository and removing verbose logging

### Files Modified

- `src/fromager/bootstrapper.py` - Added Git URL handling and version resolution methods
- `src/fromager/sources.py` - Removed Git URL processing logic (moved to bootstrapper)
- `src/fromager/commands/bootstrap.py` - Updated to use new version resolution method
- `e2e/test_bootstrap_git_url.sh` - Updated test repository URL and logging flags
- `e2e/test_bootstrap_git_url_tag.sh` - Updated test repository URL and logging flags

This refactoring improves the reliability of bootstrapping packages from Git URLs by ensuring proper dependency resolution order and consolidating related functionality.