### PR TITLE
FIX: resolver unquotes URL file names

### DIFF
--- a/src/fromager/resolver.py
+++ b/src/fromager/resolver.py
@@ -14,7 +14,7 @@ from collections.abc import Iterable
 from operator import attrgetter
 from platform import python_version
 from re import Match
-from urllib.parse import quote, urljoin, urlparse
+from urllib.parse import quote, unquote, urljoin, urlparse
 
 import html5lib
 import resolvelib
@@ -169,7 +169,8 @@ def get_project_from_pypi(
         candidate_url = urljoin(simple_index_url, i.attrib["href"])
         py_req = i.attrib.get("data-requires-python")
         path = urlparse(candidate_url).path
-        filename = path.rsplit("/", 1)[-1]
+        # file names are URL quoted, "1.0%2Blocal" -> "1.0+local"
+        filename = unquote(path.rsplit("/", 1)[-1])
         found_candidates.add(filename)
         if DEBUG_RESOLVER:
             logger.debug("%s: candidate %r -> %r", project, candidate_url, filename)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -21,6 +21,8 @@ _hydra_core_simple_response = """
 <br/>
 <a href="https://files.pythonhosted.org/packages/c6/50/e0edd38dcd63fb26a8547f13d28f7a008bc4a3fd4eb4ff030673f22ad41a/hydra_core-1.2.2-py3-none-any.whl#sha256=fa0238a9e31df3373b35b0bfb672c34cc92718d21f81311d8996a16de1141d8b" data-dist-info-metadata="sha256=399046cbf9ae7ebab8dfd009e2b4f748212c710a0e75ca501a72bbb2d456e2e7" data-core-metadata="sha256=399046cbf9ae7ebab8dfd009e2b4f748212c710a0e75ca501a72bbb2d456e2e7">hydra_core-1.2.2-py3-none-any.whl</a>
 <br/>
+<a href="https://files.pythonhosted.org/packages/c6/50/e0edd38dcd63fb26a8547f13d28f7a008bc4a3fd4eb4ff030673f22ad41a/hydra_core-1.3.1%2Blocal-py3-none-any.whl">hydra_core-1.3.1+local-py3-none-any.whl</a>
+<br/>
 <a href="https://files.pythonhosted.org/packages/6d/8e/07e42bc434a847154083b315779b0a81d567154504624e181caf2c71cd98/hydra-core-1.3.2.tar.gz#sha256=8a878ed67216997c3e9d88a8e72e7b4767e81af37afb4ea3334b269a4390a824">hydra-core-1.3.2.tar.gz</a>
 <br/>
 <a href="https://files.pythonhosted.org/packages/c6/50/e0edd38dcd63fb26a8547f13d28f7a008bc4a3fd4eb4ff030673f22ad41a/hydra_core-1.3.2-1-py3-none-any.whl#sha256=fa0238a9e31df3373b35b0bfb672c34cc92718d21f81311d8996a16de1141d8b" data-dist-info-metadata="sha256=399046cbf9ae7ebab8dfd009e2b4f748212c710a0e75ca501a72bbb2d456e2e7" data-core-metadata="sha256=399046cbf9ae7ebab8dfd009e2b4f748212c710a0e75ca501a72bbb2d456e2e7">hydra_core-1.3.2-1-py3-none-any.whl</a>
@@ -151,6 +153,28 @@ def test_provider_choose_wheel_prereleases():
             == "https://files.pythonhosted.org/packages/c6/50/e0edd38dcd63fb26a8547f13d28f7a008bc4a3fd4eb4ff030673f22ad41a/hydra_core-2.0.0a1-py3-none-any.whl"
         )
         assert str(candidate.version) == "2.0.0a1"
+
+
+def test_provider_choose_wheel_local():
+    with requests_mock.Mocker() as r:
+        r.get(
+            "https://pypi.org/simple/hydra-core/",
+            text=_hydra_core_simple_response,
+        )
+
+        provider = resolver.PyPIProvider(include_sdists=False)
+        reporter = resolvelib.BaseReporter()
+        rslvr = resolvelib.Resolver(provider, reporter)
+
+        result = rslvr.resolve([Requirement("hydra-core==1.3.1+local")])
+        assert "hydra-core" in result.mapping
+
+        candidate = result.mapping["hydra-core"]
+        assert (
+            candidate.url
+            == "https://files.pythonhosted.org/packages/c6/50/e0edd38dcd63fb26a8547f13d28f7a008bc4a3fd4eb4ff030673f22ad41a/hydra_core-1.3.1%2Blocal-py3-none-any.whl"
+        )
+        assert str(candidate.version) == "1.3.1+local"
 
 
 def test_provider_choose_sdist():


### PR DESCRIPTION
Some package indexes URL quote the file name in the anchor `href` attribute. The local version separate `+` is quoted as `%2B`. The resolver now unquotes the file name to support local versions.

Example from https://download.pytorch.org/whl/torch/

`<a href="/whl/cpu-cxx11-abi/torch-2.7.0%2Bcpu.cxx11.abi-cp312-cp312-linux_x86_64.whl#sha256=e6ad883fd92777031e66e24a27bc6fef06a335710d19f51309a2517cb2e31434" data-dist-info-metadata="sha256=ed31c6355e0a97e4cbb894cff24897d9418dc360462003b6bc4534b993ae0690" data-core-metadata="sha256=ed31c6355e0a97e4cbb894cff24897d9418dc360462003b6bc4534b993ae0690">torch-2.7.0+cpu.cxx11.abi-cp312-cp312-linux_x86_64.whl</a><br/>`