### PR TITLE
FIX - Handle filenames with quoted characters

### DIFF
--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -9,7 +9,7 @@ import shutil
 import tarfile
 import typing
 import zipfile
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 import resolvelib
 from packaging.requirements import Requirement
@@ -222,7 +222,7 @@ def download_url(
     basename = (
         destination_filename
         if destination_filename
-        else os.path.basename(urlparse(url).path)
+        else unquote(os.path.basename(urlparse(url).path))
     )
     outfile = pathlib.Path(destination_dir) / basename
     logger.debug(

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -10,7 +10,7 @@ import tempfile
 import textwrap
 import typing
 import zipfile
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 import elfdeps
 import tomlkit
@@ -372,7 +372,9 @@ def download_wheel(
     wheel_url: str,
     output_directory: pathlib.Path,
 ) -> pathlib.Path:
-    wheel_filename = output_directory / os.path.basename(urlparse(wheel_url).path)
+    wheel_filename = output_directory / unquote(
+        os.path.basename(urlparse(wheel_url).path)
+    )
     if not wheel_filename.exists():
         logger.info(f"downloading pre-built wheel {wheel_url}")
         wheel_filename = _download_wheel_check(req, output_directory, wheel_url)


### PR DESCRIPTION
This is a follow-up to #636 to handle file names for wheels and sdists.

Resolves #644