### PR TITLE
Fix regression in unpack dir handling

### DIFF
--- a/src/fromager/dependencies.py
+++ b/src/fromager/dependencies.py
@@ -36,11 +36,12 @@ def get_build_system_dependencies(
 
     build_system_req_file = sdist_root_dir.parent / BUILD_SYSTEM_REQ_FILE_NAME
     if build_system_req_file.exists():
-        logger.info(
-            f"loading build system dependencies from {build_system_req_file.name}"
-        )
+        logger.info(f"loading build system dependencies from {build_system_req_file}")
         return _read_requirements_file(build_system_req_file)
 
+    logger.debug(
+        f"file {build_system_req_file} does not exist, getting dependencies from hook"
+    )
     orig_deps = overrides.find_and_invoke(
         req.name,
         "get_build_system_dependencies",
@@ -102,11 +103,12 @@ def get_build_backend_dependencies(
 
     build_backend_req_file = sdist_root_dir.parent / BUILD_BACKEND_REQ_FILE_NAME
     if build_backend_req_file.exists():
-        logger.info(
-            f"loading build backend dependencies from {build_backend_req_file.name}"
-        )
+        logger.info(f"loading build backend dependencies from {build_backend_req_file}")
         return _read_requirements_file(build_backend_req_file)
 
+    logger.debug(
+        f"file {build_backend_req_file} does not exist, getting dependencies from hook"
+    )
     extra_environ = pbi.get_extra_environ(build_env=build_env)
     orig_deps = overrides.find_and_invoke(
         req.name,
@@ -166,11 +168,12 @@ def get_build_sdist_dependencies(
 
     build_sdist_req_file = sdist_root_dir.parent / BUILD_SDIST_REQ_FILE_NAME
     if build_sdist_req_file.exists():
-        logger.info(
-            f"loading build sdist dependencies from {build_sdist_req_file.name}"
-        )
+        logger.info(f"loading build sdist dependencies from {build_sdist_req_file}")
         return _read_requirements_file(build_sdist_req_file)
 
+    logger.debug(
+        f"file {build_sdist_req_file} does not exist, getting dependencies from hook"
+    )
     extra_environ = pbi.get_extra_environ(build_env=build_env)
     orig_deps = overrides.find_and_invoke(
         req.name,


### PR DESCRIPTION
Commit 11c7502 modified the location of the unpack directory to ensure that `_unpack_metadata_from_wheel()` was not removing the Python build env. This caused a regression because sometimes the files ended up in the wrong directory.

Revert the change to `Bootstrapper._create_unpack_dir()`. The `_unpack_metadata_from_wheel()` now removes just its own files, not the entire directory.