### PR TITLE
Adding documentation around building the project

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -30,4 +30,65 @@ writing to INFO level to show what is starting and stopping, respectively.
 Detailed messages should be logged to DEBUG level so they will not appear on the
 console by default.
 
+## Building the project
+
+The project uses [Hatch](https://hatch.pypa.io/) as its build system with [hatchling](https://hatch.pypa.io/latest/plugins/builder/wheel/) as the build backend. The build configuration is defined in `pyproject.toml`.
+
+### Development installation
+
+For development, you can install the project in editable mode:
+
+```bash
+# You can spawn a shell within an environment by using the hatch shell command.
+# It installs the project in editable/development mode.
+hatch shell
+
+# Check if fromager is installed and available in the path
+which fromager
+```
+
+Note: When a package is installed in editable/development mode, you can make changes to its source code directly. These changes are immediately reflected in your Python environment without needing to reinstall the package.
+
+### Quick build
+
+To build the project (both source distribution and wheel), use:
+
+```bash
+hatch build
+```
+
+This will create both `.tar.gz` (source distribution) and `.whl` (wheel) files in the `dist/` directory.
+
+You can build specific formats by using `hatch build -t wheel` or `hatch build -t sdist`.
+
+Alternatively, you can use the standard `build` module (which is included in the `[project.optional-dependencies.build]` section):
+
+```bash
+# Install build dependencies first
+pip install build twine
+
+# Build the project
+python -m build
+```
+
+### Package validation
+
+To validate the built packages, you can use the package linting script:
+
+```bash
+hatch run lint:pkglint
+```
+
+This command will:
+
+1. Build the project using `python -m build`
+2. Check the built packages with `twine check dist/*.tar.gz dist/*.whl`
+3. Validate Python version consistency between `pyproject.toml` and GitHub Actions workflows
+
+The validation will fail if:
+
+- The package metadata is malformed
+- Required files are missing from the distribution
+- Python version requirements are inconsistent across configuration files
+
 ### Building documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,12 +197,10 @@ reportAttributeAccessIssue = false  # adding our own private property on click c
 # No specific python version here, so it uses the active Python by default.
 dependencies = []
 
-[[tool.hatch.envs.default.matrix]]
-python = ["3.11", "3.12", "3.13"]
-
 [tool.hatch.envs.test]
 features = ["test"]
 # {args:tests} allows passing arguments to specify which tests to run
+
 [tool.hatch.envs.test.scripts]
 test = "python -m coverage run -m pytest --log-level DEBUG -vv {args:tests}"
 coverage-report = ["coverage combine", "coverage report --format=markdown"]


### PR DESCRIPTION
Fixes #652

Modified the pyproject.toml as it was causing teh hatch build command to fail
as multiple python versions were part of the default environment.

Also the matrix belongs on specific environments (like test) where multi-version
behavior is actually needed, not on the default environment which should be
simple and predictable. 

```
$ hatch build

Unknown environment: default 
```