### PR TITLE
feat: Add option to ignore wheel platform in resolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 /work-dir*/
 /test-venv/
 /venv*/
+/.venv/
 /build/
 **/*.egg-info/
 /src/fromager/version.py

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -165,6 +165,7 @@ def default_resolve_source(
         include_sdists=pbi.resolver_include_sdists,
         include_wheels=pbi.resolver_include_wheels,
         req_type=req_type,
+        ignore_platform=pbi.resolver_ignore_platform,
     )
     return url, version
 

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -428,6 +428,8 @@ def resolve_prebuilt_wheel(
                 include_sdists=False,
                 include_wheels=True,
                 req_type=req_type,
+                # pre-built wheels must match platform
+                ignore_platform=False,
             )
         except Exception:
             continue

--- a/tests/test_packagesettings.py
+++ b/tests/test_packagesettings.py
@@ -15,6 +15,7 @@ from fromager.packagesettings import (
     GitOptions,
     Package,
     PackageSettings,
+    ResolverDist,
     SettingsFile,
     Variant,
     substitute_template,
@@ -67,8 +68,9 @@ FULL_EXPECTED: dict[str, typing.Any] = {
     },
     "resolver_dist": {
         "include_sdists": True,
-        "include_wheels": False,
+        "include_wheels": True,
         "sdist_server_url": "https://sdist.test/egg",
+        "ignore_platform": True,
     },
     "variants": {
         "cpu": {
@@ -119,6 +121,7 @@ EMPTY_EXPECTED: dict[str, typing.Any] = {
         "sdist_server_url": None,
         "include_sdists": True,
         "include_wheels": False,
+        "ignore_platform": False,
     },
     "variants": {},
 }
@@ -266,7 +269,8 @@ def test_pbi_test_pkg(testdata_context: context.WorkContext) -> None:
         == "test-pkg-1.0.2.tar.gz"
     )
     assert pbi.resolver_include_sdists is True
-    assert pbi.resolver_include_wheels is False
+    assert pbi.resolver_include_wheels is True
+    assert pbi.resolver_ignore_platform is True
     assert (
         pbi.resolver_sdist_server_url("https://pypi.org/simple")
         == "https://sdist.test/egg"
@@ -630,3 +634,8 @@ build_options:
 
     custom_pbi = settings.package_build_info("exclusive-pkg")
     assert custom_pbi.exclusive_build is True
+
+
+def test_resolver_dist_validator():
+    with pytest.raises(pydantic.ValidationError):
+        ResolverDist(include_wheels=False, ignore_platform=True)

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -40,8 +40,9 @@ def test_default_download_source_from_settings(
         req=req,
         sdist_server_url=sdist_server_url,
         include_sdists=True,
-        include_wheels=False,
+        include_wheels=True,
         req_type=None,
+        ignore_platform=True,
     )
 
     sources.default_download_source(
@@ -86,6 +87,7 @@ def test_default_download_source_with_predefined_resolve_dist(
         include_sdists=False,
         include_wheels=True,
         req_type=None,
+        ignore_platform=False,
     )
 
 

--- a/tests/testdata/context/overrides/settings/test_pkg.yaml
+++ b/tests/testdata/context/overrides/settings/test_pkg.yaml
@@ -33,7 +33,8 @@ project_override:
 resolver_dist:
     sdist_server_url: https://sdist.test/egg
     include_sdists: true
-    include_wheels: false
+    include_wheels: true
+    ignore_platform: true
 variants:
     cpu:
         env:


### PR DESCRIPTION
A package can now ignore the upstream wheels' platforms when looking up distributions without an sdist on PyPI. The option only applies to packages that have `resolver_dist.include_wheels` enabled.

The flag allows to package versions that neither provide a sdist nor a binary wheel for the current platform, e.g. Torch builds on ppc64le. Torch does neither upload sdists nor does it provide ppc64le wheels on PyPI.

Fixes: #556