### PR TITLE
fix: add `MAX_JOBS` to env substitution mapping

### DIFF
--- a/src/fromager/packagesettings.py
+++ b/src/fromager/packagesettings.py
@@ -773,6 +773,9 @@ class PackageBuildInfo:
             "MAX_JOBS": str(jobs),
         }
 
+        # make MAX_JOBS available to substitution
+        template_env.update(extra_environ)
+
         # add VIRTUAL_ENV and update PATH, so templates can use the values
         if build_env is not None:
             venv_environ = build_env.get_venv_environ(template_env=template_env)

--- a/tests/test_packagesettings.py
+++ b/tests/test_packagesettings.py
@@ -54,6 +54,7 @@ FULL_EXPECTED: dict[str, typing.Any] = {
         "SPAM": "alot $EXTRA",
         "QUOTES": "A\"BC'$$EGG",
         "DEF": "${DEF:-default}",
+        "EXTRA_MAX_JOBS": "${MAX_JOBS}",
     },
     "git_options": {
         "submodules": False,
@@ -166,6 +167,7 @@ def test_pbi_test_pkg_extra_environ(
         "CMAKE_BUILD_PARALLEL_LEVEL": "1",
         "MAKEFLAGS": "-j1",
         "MAX_JOBS": "1",
+        "EXTRA_MAX_JOBS": "1",
     }
 
     pbi = testdata_context.settings.package_build_info(TEST_PKG)

--- a/tests/testdata/context/overrides/settings/test_pkg.yaml
+++ b/tests/testdata/context/overrides/settings/test_pkg.yaml
@@ -19,6 +19,7 @@ env:
     SPAM: "alot $EXTRA"
     QUOTES: "A\"BC'$$EGG"
     DEF: "${DEF:-default}"
+    EXTRA_MAX_JOBS: "${MAX_JOBS}"
 download_source:
     url: https://egg.test/${canonicalized_name}/v${version}.tar.gz
     destination_filename: ${canonicalized_name}-${version}.tar.gz


### PR DESCRIPTION
Allow `env` variables to use `${MAX_JOBS}` as a substitution value.