### PR TITLE
feat(graph): Improve `why` command output

### DIFF
--- a/src/fromager/commands/bootstrap.py
+++ b/src/fromager/commands/bootstrap.py
@@ -374,9 +374,14 @@ def write_constraints_file(
             output.write(f"{dep_name}=={node.version}\n")
 
     for dep_name in conflicting_deps:
-        logger.error("finding why %s was being used", dep_name)
         for node in graph.get_nodes_by_name(dep_name):
-            find_why(graph, node, -1, 1, [])
+            find_why(
+                graph=graph,
+                node=node,
+                max_depth=-1,
+                depth=0,
+                req_type=[],
+            )
 
     return ret
 


### PR DESCRIPTION
The `graph why` command is a tool for developers to understand the
dependency graph. This change improves its output to be more useful and
clearer.

The output now includes the requirement specifier from the parent package
along with the parent package name. This makes it easier to understand
not just which package is pulling in a dependency, but which version or
range of versions it requires.

The output for top-level dependencies specified on the command line or
in a requirements file is also improved to clearly label them as such.

Cycle detection is included to prevent infinite loops and make it clear
where circular dependencies exist.