### PR TITLE
Adding common hatch commands to docs/develop.md

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -5,16 +5,30 @@
 The unit tests and linter now use [Hatch](https://hatch.pypa.io/) and a
 recent version of Python (as defined in `pyproject.toml` under `project.requires-python`).
 
-To run all default checks and tests (linters, unit tests, etc.), you can typically run `hatch run`.
-To execute specific environments or scripts defined in `pyproject.toml`, use the command `hatch run <env_name>:<script_name>`.
-For instance, linters might be run with `hatch run lint:check`, and unit tests with `hatch run test:test`.
-Consult the `[tool.hatch.envs]` and `[tool.hatch.matrix]` sections in `pyproject.toml` for a comprehensive list of available environments, scripts, and their configurations.
+**Available Hatch Commands:**
 
-## End-to-end tests
+• **Testing:**
 
-The `e2e` directory contains test scripts that run in pipelines in CI
-to test behaviors of the entire system. Each script includes a comment
-at the top explaining what the test is trying to demonstrate.
+- `hatch run test:test` - Run unit tests with coverage
+- `hatch run test:test tests/test_bootstrapper.py` - Run specific test files
+- `hatch run test:test -k "test_metadata"` - Run tests with custom args
+- `hatch run test:coverage-report` - Generate coverage report
+
+• **Linting & Code Quality:**
+
+- `hatch run lint:check` - Run all linting checks (ruff + mergify)
+- `hatch run lint:fix` - Auto-fix ruff issues (formatting + import sorting)
+- `hatch run lint:pkglint` - Package-level linting (build + twine check)
+
+• **Type Checking:**
+
+- `hatch run mypy:check` - Run mypy type checking
+
+• **End-to-End Testing:**
+
+- `hatch run e2e:setup-cov` - Setup coverage for subprocesses
+- `hatch run e2e:run [command]` - Run any command in e2e environment
+  - Example: `hatch run e2e:run ./e2e/test_build.sh`
 
 ## Logging
 
@@ -92,3 +106,5 @@ The validation will fail if:
 - Python version requirements are inconsistent across configuration files
 
 ### Building documentation
+
+- `hatch run docs:build` - Build Sphinx documentation


### PR DESCRIPTION
The project has migrated to hatch CLI from tox recently. So it will be useful to list the common hatch commands as contributors might not be familier with hatch CLI fixes #659