### PR TITLE
Ignore local version suffix for patches and changelog

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -276,6 +276,13 @@ For version `1.0.3` and variant `rocm`, Fromager would only apply
 Added support for variant-specific patches.
 ```
 
+```{versionchanged} 0.54.0
+
+Fromager ignores local version suffix of a package to determinate the
+version-specific patch directories, e.g. version `1.0.3+local.suffix`
+becomes `1.0.3`.
+```
+
 ## `project_override` section
 
 The `project_override` configures the `pyproject.toml` auto-fixer. It can

--- a/src/fromager/packagesettings.py
+++ b/src/fromager/packagesettings.py
@@ -621,6 +621,8 @@ class PackageBuildInfo:
 
     def get_patches(self, version: Version) -> list[pathlib.Path]:
         """Get patches for a version (and unversioned patches)"""
+        # ignore local version for patches
+        version = Version(version.public)
         patchfiles: list[pathlib.Path] = []
         patchmap = self.get_all_patches()
         # unversioned patches
@@ -729,13 +731,22 @@ class PackageBuildInfo:
         return sdist_root_dir
 
     def get_changelog(self, version: Version) -> list[str]:
+        # ignore local version for changelog entries
+        version = Version(version.public)
         pv = typing.cast(PackageVersion, version)
         variant_changelog = self._variant_changelog
         package_changelog = self._ps.changelog.get(pv, [])
         return variant_changelog + package_changelog
 
     def build_tag(self, version: Version) -> BuildTag:
-        """Build tag for version's changelog and this variant"""
+        """Build tag for version's changelog and this variant
+
+        .. versionchanged 0.54.0::
+
+           Fromager ignores local version suffix of a package to determinate
+           the build tag from changelog, e.g. version `1.0.3+local.suffix`
+           uses `1.0.3`.
+        """
         pv = typing.cast(PackageVersion, version)
         release = len(self.get_changelog(pv))
         if release == 0:

--- a/tests/test_packagesettings.py
+++ b/tests/test_packagesettings.py
@@ -309,6 +309,7 @@ def test_pbi_test_pkg_patches(testdata_context: context.WorkContext) -> None:
         patch005,
         patch010,
     ]
+    assert pbi.get_patches(Version("1.0.2+local")) == pbi.get_patches(Version("1.0.2"))
     assert pbi.get_patches(Version("1.0.1")) == [
         patch004,
         patch010,
@@ -407,6 +408,7 @@ def test_global_changelog(testdata_context: context.WorkContext) -> None:
     assert pbi.build_tag(Version("0.99")) == ()
     assert pbi.build_tag(Version("1.0.1")) == (1, "")
     assert pbi.build_tag(Version("1.0.2")) == (2, "")
+    assert pbi.build_tag(Version("1.0.2+local")) == pbi.build_tag(Version("1.0.2"))
     assert pbi.build_tag(Version("2.0.0")) == ()
 
     testdata_context.settings.variant = Variant("rocm")
@@ -415,6 +417,7 @@ def test_global_changelog(testdata_context: context.WorkContext) -> None:
     assert pbi.build_tag(Version("0.99")) == (1, "")
     assert pbi.build_tag(Version("1.0.1")) == (2, "")
     assert pbi.build_tag(Version("1.0.2")) == (3, "")
+    assert pbi.build_tag(Version("1.0.2+local")) == pbi.build_tag(Version("1.0.2"))
     assert pbi.build_tag(Version("2.0.0")) == (1, "")
 
 


### PR DESCRIPTION
Fromager now ignores the local version suffix of a package's version when it looks for patch directories and changelog entries. The local version part is the part of the version after the `+`, e.g. `1.0.3+local.suffix` has public version `1.0.3` and local version `local.suffix`.