### PR TITLE
linter: check for duplicates, check for optional deps in constraints

### DIFF
--- a/e2e/test_lint_requirements.sh
+++ b/e2e/test_lint_requirements.sh
@@ -22,10 +22,24 @@ if fromager lint-requirements; then
     pass=false
 fi;
 
-# Test to demonstrate that command reports error for invalid / bad input files
+# Test to demonstrate that command reports error for invalid / bad requirements
 
 if fromager lint-requirements "$SCRIPTDIR/validate_inputs/constraints.txt" "$SCRIPTDIR/validate_inputs/invalid-requirements.txt"; then
     echo "invalid input files should have been recognized by the command" 1>&2
+    pass=false
+fi;
+
+# Test to demonstrate that command reports error for invalid / bad constraints
+
+if fromager lint-requirements "$SCRIPTDIR/validate_inputs/invalid-constraints.txt" "$SCRIPTDIR/validate_inputs/requirements.txt"; then
+    echo "invalid input files should have been recognized by the command" 1>&2
+    pass=false
+fi;
+
+# Test to demonstrate that command reports error for duplicate entries in files
+
+if fromager lint-requirements "$SCRIPTDIR/validate_inputs/constraints.txt" "$SCRIPTDIR/validate_inputs/duplicate-requirements.txt"; then
+    echo "duplicate entries in files should have been recognized by the command" 1>&2
     pass=false
 fi;
 

--- a/e2e/validate_inputs/duplicate-requirements.txt
+++ b/e2e/validate_inputs/duplicate-requirements.txt
@@ -1,0 +1,5 @@
+# This requirements file contains duplicates entries on purpose 
+# to test the lint-requirements. Do not attempt to fix this file
+stevedore==5.2.0
+kfp==2.11.0
+stevedore==5.2.1

--- a/e2e/validate_inputs/invalid-constraints.txt
+++ b/e2e/validate_inputs/invalid-constraints.txt
@@ -1,0 +1,3 @@
+# This constraints file is invalid on purpose to test the lint-requirements 
+# command of fromager. Do not attempt to fix this file
+vllm[tensorizer]==0.9.4

--- a/src/fromager/commands/lint_requirements.py
+++ b/src/fromager/commands/lint_requirements.py
@@ -1,4 +1,5 @@
 import logging
+import pathlib
 import sys
 
 import click
@@ -11,9 +12,9 @@ logger = logging.getLogger(__name__)
 
 @click.command()
 @click.argument(
-    "input_files_path", nargs=-1, required=True, type=click.Path(exists=False)
+    "input_files_path", nargs=-1, required=True, type=click.Path(exists=False, path_type=pathlib.Path)
 )
-def lint_requirements(input_files_path: list[click.Path]) -> None:
+def lint_requirements(input_files_path: list[pathlib.Path]) -> None:
     """
     Command to lint the constraints.txt and requirements.txt files
     This command takes a single wildcard path string for constraints.txt and requirements.txt.
@@ -27,10 +28,16 @@ def lint_requirements(input_files_path: list[click.Path]) -> None:
     flag = True
 
     for path in input_files_path:
-        parsed_lines = requirements_file.parse_requirements_file(str(path))
+        parsed_lines = requirements_file.parse_requirements_file(path)
+        unique_entries: set[str] = set()
         for line in parsed_lines:
             try:
-                Requirement(line)
+                requirement = Requirement(line)
+                if requirement.name in unique_entries:
+                    raise InvalidRequirement("Duplicate entry")
+                unique_entries.add(requirement.name)
+                if requirement.extras and path.name.endswith("constraints.txt"):
+                    raise InvalidRequirement("Constraints files cannot contain extra dependencies")
             except InvalidRequirement as err:
                 logger.error(f"{path}: {line}: {err}")
                 flag = False


### PR DESCRIPTION
Add lint-requirements check for duplicates in in requirements and constraints files and check that constraints don't contain optional dependencies.

Fixes #546
Fixes #547