### PR TITLE
Fixing the logline in graph.py

### DIFF
--- a/src/fromager/commands/graph.py
+++ b/src/fromager/commands/graph.py
@@ -61,7 +61,7 @@ def to_constraints(wkctx: context.WorkContext, graph_file: str, output: pathlib.
         ret = bootstrap.write_constraints_file(graph, sys.stdout)
         if not ret:
             raise ValueError(
-                "Failed to write constraints file - no valid set of installation dependencies could be generated"
+                "Failed to generate constraints - no single version set satisfies all requirements"
             )
 
 


### PR DESCRIPTION
The old log is inaccurate as it is writing to stdout, not to the constraints.txt file

Fixes #670