### PR TITLE
fix: use unique file name for build log

### DIFF
--- a/src/fromager/commands/build.py
+++ b/src/fromager/commands/build.py
@@ -359,9 +359,7 @@ def _build(
     per_wheel_logger = logging.getLogger("")
 
     module_name = overrides.pkgname_to_override_module(req.name)
-    log_filename = module_name + "_current.log"
-
-    wheel_log = wkctx.logs_dir / log_filename
+    wheel_log = wkctx.logs_dir / f"{module_name}_{resolved_version}.log"
 
     file_handler = logging.FileHandler(str(wheel_log), mode="w")
     per_wheel_logger.addHandler(file_handler)


### PR DESCRIPTION
The build command was using `{package}_current.log` to store the build log for *package*. This clashes when parallel build was building two versions of a package at the same time. In my test case, it was building two versions of setuptools in parallel.

The command now uses `{name}-{version}.log`.