### PR TITLE
fix handling of existing packages during build

### DIFF
--- a/e2e/test_build_order.sh
+++ b/e2e/test_build_order.sh
@@ -85,7 +85,7 @@ if ! grep -q "skipping builds for versions of packages available" "$log"; then
   echo "Did not find message indicating builds would be skipped" 1>&2
   pass=false
 fi
-if ! grep -q "${DIST}-${VERSION}: found existing wheel" "$log"; then
+if ! grep -q "${DIST}-${VERSION}: using existing wheel" "$log"; then
   echo "Did not find message indicating build of stevedore was skipped" 1>&2
   pass=false
 fi
@@ -109,7 +109,7 @@ if ! grep -q "skipping builds for versions of packages available" "$log"; then
   echo "Did not find message indicating builds would be skipped" 1>&2
   pass=false
 fi
-if ! grep -q "${DIST}-${VERSION}: found existing wheel" "$log"; then
+if ! grep -q "${DIST}-${VERSION}: using existing wheel" "$log"; then
   echo "Did not find message indicating build of stevedore was skipped" 1>&2
   pass=false
 fi

--- a/e2e/test_build_parallel.sh
+++ b/e2e/test_build_parallel.sh
@@ -69,7 +69,7 @@ if ! fromager \
   pass=false
 fi
 
-if ! grep -q "setuptools-80.8.0: found existing wheel" "$log"; then
+if ! grep -q "setuptools-80.8.0: using existing wheel" "$log"; then
   echo "Did not find message indicating build of setuptools was skipped" 1>&2
   pass=false
 fi
@@ -91,7 +91,7 @@ fi
 
 find "$OUTDIR/wheels-repo/"
 
-if grep -q "${DIST}-${VERSION}: found existing wheel" "$log"; then
+if grep -q "${DIST}-${VERSION}: using existing wheel" "$log"; then
   echo "Found message indicating build of $DIST was skipped" 1>&2
   pass=false
 fi
@@ -136,7 +136,7 @@ if ! grep -q "skipping builds for versions of packages available" "$log"; then
   echo "Did not find message indicating builds would be skipped" 1>&2
   pass=false
 fi
-if ! grep -q "${DIST}-${VERSION}: found existing wheel" "$log"; then
+if ! grep -q "${DIST}-${VERSION}: using existing wheel" "$log"; then
   echo "Did not find message indicating build of $DIST was skipped" 1>&2
   pass=false
 fi
@@ -160,7 +160,7 @@ if ! grep -q "skipping builds for versions of packages available" "$log"; then
   echo "Did not find message indicating builds would be skipped" 1>&2
   pass=false
 fi
-if ! grep -q "${DIST}-${VERSION}: found existing wheel" "$log"; then
+if ! grep -q "${DIST}-${VERSION}: using existing wheel" "$log"; then
   echo "Did not find message indicating build of $DIST was skipped" 1>&2
   pass=false
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,7 @@ reportUnusedParameter = false
 reportAny = false
 reportImplicitOverride = false
 reportAttributeAccessIssue = false  # adding our own private property on click commands
+reportImplicitStringConcatenation = false
 
 [tool.hatch.envs.default]
 # No specific python version here, so it uses the active Python by default.

--- a/src/fromager/commands/build.py
+++ b/src/fromager/commands/build.py
@@ -379,10 +379,6 @@ def _build(
             dist_version=str(resolved_version),
             wheel_filename=wheel_filename,
         )
-        server.update_wheel_mirror(wkctx)
-        # After we update the wheel mirror, the built file has
-        # moved to a new directory.
-        wheel_filename = wkctx.wheels_downloads / wheel_filename.name
 
     # If we get here and still don't have a wheel filename, then we need to
     # build the wheel.


### PR DESCRIPTION
The _is_wheel_built function was returning a boolean to indicate to the
caller whether the filename returned should be used. Change the function
to return a Path or None, so the caller only has to check the one
return value.

Return the full path to where we downloaded the wheel, or return None if
we do not download one. Add more logging to make it easier to follow
what is happening, especially when the candidate is not usable.

Log more information about what we are doing when we decide to download
a wheel vs. recognize that the wheel is present on the local server.

Update the e2e tests that look for specific log messages to match the
new patterns.

Remove duplicate calls to `update_wheel_mirror()` in `_build()`. At best they
are redundant, at worst they could change state twice.