### PR TITLE
fix: pre-built wheels have no Fromager built tag

### DIFF
--- a/src/fromager/packagesettings.py
+++ b/src/fromager/packagesettings.py
@@ -731,6 +731,7 @@ class PackageBuildInfo:
         return sdist_root_dir
 
     def get_changelog(self, version: Version) -> list[str]:
+        """Get changelog for a version"""
         # ignore local version for changelog entries
         version = Version(version.public)
         pv = typing.cast(PackageVersion, version)
@@ -747,6 +748,9 @@ class PackageBuildInfo:
            the build tag from changelog, e.g. version `1.0.3+local.suffix`
            uses `1.0.3`.
         """
+        if self.pre_built:
+            # pre-built wheels have no built tag
+            return ()
         pv = typing.cast(PackageVersion, version)
         release = len(self.get_changelog(pv))
         if release == 0:

--- a/tests/testdata/context/overrides/settings/test_prebuilt_pkg.yaml
+++ b/tests/testdata/context/overrides/settings/test_prebuilt_pkg.yaml
@@ -1,0 +1,6 @@
+changelog:
+    "1.0.1":
+        - onboard
+variants:
+    cpu:
+      pre_built: true


### PR DESCRIPTION
Pre-built wheels come directly from PyPI or other package indexes. They do not haev a build tag based on the global changelog or package changelog.

The change is necessary to fix handling of pre-built wheels in `_is_wheel_built()` function of the build commands.