### PR TITLE
fix: exclude virtualenv 20.33.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "stevedore",
     "tomlkit",
     "tqdm",
-    "virtualenv",
+    "virtualenv!=20.33.0",
     "wheel",
 ]
 

--- a/src/fromager/build_environment.py
+++ b/src/fromager/build_environment.py
@@ -164,6 +164,7 @@ class BuildEnvironment:
                 sys.executable,
                 "-m",
                 "virtualenv",
+                "--verbose",
                 "--python",
                 sys.executable,
                 "--pip=bundle",


### PR DESCRIPTION
There is a known issue in this version of virtualenv that breaks it for several use cases, including the way we use it in tests.

https://github.com/pypa/virtualenv/issues/2930