### PR TITLE
feat: Add annotation support for packages and variants

### DIFF
--- a/tests/testdata/context/overrides/settings/test_pkg.yaml
+++ b/tests/testdata/context/overrides/settings/test_pkg.yaml
@@ -1,3 +1,6 @@
+annotations:
+    fromager.test.value: somevalue
+    fromager.test.override: variant override
 build_dir: python
 build_options:
     build_ext_parallel: true
@@ -38,11 +41,15 @@ resolver_dist:
     ignore_platform: true
 variants:
     cpu:
+        annotations:
+            fromager.test.override: cpu override
         env:
             EGG: "spam ${EGG}"
             EGG_AGAIN: "$EGG"
         wheel_server_url: https://wheel.test/simple
     rocm:
+        annotations:
+            fromager.test.override: amd override
         env:
             SPAM: ""
         pre_built: True


### PR DESCRIPTION
The new annoation features can be used to attach abitrary metadata to package and variant settings. The feature is inspired by Kubernetes, https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ Annotations are read-only mappings `Mapping[str, str]`.

Annotations can hold all sorts of information. Use cases include simple settings for downstream plugins or project metadata.

```yaml
annotations:
  "downstream.maintainer": "Platform Team"
  "wheeltag.purelib": "false"
variants:
  cuda:
    annotations:
      "downstream.maintainer": "CUDA Accelerator Team"
```