### PR TITLE
fix: quiet update_wheel_mirror

### DIFF
--- a/src/fromager/server.py
+++ b/src/fromager/server.py
@@ -92,5 +92,3 @@ def update_wheel_mirror(ctx: context.WorkContext) -> None:
             logger.debug("linking %s -> %s into local index", wheel.name, relpath)
             simple_dest_filename.parent.mkdir(parents=True, exist_ok=True)
             simple_dest_filename.symlink_to(relpath)
-        else:
-            logger.debug("already have %s", simple_dest_filename)


### PR DESCRIPTION
update_wheel_mirror() logs the name of every wheel in the mirror every time any wheel is added. This makes the logs excessively long and hard to read. This update makes the log only contain information about action taken.