### PR TITLE
fix: use get_wheel_server_urls() in build command

### DIFF
--- a/src/fromager/bootstrapper.py
+++ b/src/fromager/bootstrapper.py
@@ -825,7 +825,9 @@ class Bootstrapper:
             wheel_url, resolved_version = cached_resolution
             logger.debug(f"resolved from previous bootstrap to {resolved_version}")
         else:
-            servers = wheels.get_wheel_server_urls(self.ctx, req)
+            servers = wheels.get_wheel_server_urls(
+                self.ctx, req, cache_wheel_server_url=resolver.PYPI_SERVER_URL
+            )
             wheel_url, resolved_version = wheels.resolve_prebuilt_wheel(
                 ctx=self.ctx, req=req, wheel_server_urls=servers, req_type=req_type
             )


### PR DESCRIPTION
The build commands like `build-sequence` were not using `pbi.wheel_server_url`. Under some conditions they were using wheels from an upstream server or requirement URL instead of the configured package wheel server.

The `wheels.get_wheel_server_urls()` handles this case correctly, but the current implementation is not usable for build command.

Refactor code:

- modify `get_wheel_server_urls()` to accept a cache wheel server url instead of a hard-coded URL.
- pass `cache_wheel_server_url` instead of `wheel_server_urls` in build commands
- use `get_wheel_server_urls()` in build commands

Fixes: #704