### PR TITLE
fix: pin pbr in conflicting requirements test

### DIFF
--- a/e2e/test_bootstrap_conflicting_requirements.sh
+++ b/e2e/test_bootstrap_conflicting_requirements.sh
@@ -10,6 +10,11 @@
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$SCRIPTDIR/common.sh"
 
+# expected pbr version
+constraints_file=$(mktemp)
+trap "rm -f $constraints_file" EXIT
+echo "pbr==6.1.1" > "$constraints_file"
+
 # passing settings to bootstrap but should have 0 effect on it
 fromager \
   --log-file="$OUTDIR/bootstrap.log" \
@@ -18,6 +23,7 @@ fromager \
   --wheels-repo="$OUTDIR/wheels-repo" \
   --work-dir="$OUTDIR/work-dir" \
   --settings-dir="$SCRIPTDIR/changelog_settings" \
+  --constraints-file="$constraints_file" \
   bootstrap 'stevedore==5.2.0' 'stevedore==4.0.0' || true
 
 pass=true

--- a/e2e/test_bootstrap_constraints.sh
+++ b/e2e/test_bootstrap_constraints.sh
@@ -11,6 +11,7 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$SCRIPTDIR/common.sh"
 
 constraints_file=$(mktemp)
+trap "rm -f $constraints_file" EXIT
 echo "stevedore==4.0.0" > "$constraints_file"
 
 # passing settings to bootstrap but should have 0 effect on it


### PR DESCRIPTION
The test case is checking for a specific version of pbr. The test was passing for a long time -- until pbr upstream releases a new version. Pin the expected version with a constraint.