### PR TITLE
Add CSV and JSON export to list-overrides --details

### DIFF
--- a/src/fromager/commands/list_overrides.py
+++ b/src/fromager/commands/list_overrides.py
@@ -1,11 +1,14 @@
+import csv
+import json
 import pathlib
+import sys
 
 import click
 import rich
 from packaging.version import Version
 from rich.table import Table
 
-from fromager import context
+from fromager import clickext, context
 from fromager.packagesettings import PatchMap
 
 
@@ -16,28 +19,50 @@ from fromager.packagesettings import PatchMap
     default=False,
     help="Show more details about the overrides.",
 )
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "csv", "json"], case_sensitive=False),
+    default="table",
+    help="Output format for detailed view (requires --details, default: table)",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=clickext.ClickPath(),
+    help="Output file to create (requires --details, default: stdout)",
+)
 @click.pass_obj
 def list_overrides(
     wkctx: context.WorkContext,
     details: bool,
+    output_format: str,
+    output: pathlib.Path | None,
 ) -> None:
     """List all of the packages with overrides in the current configuration."""
+    # Warn if format/output options are used without --details
+    if not details:
+        if output_format != "table":
+            click.echo(
+                "Warning: --format option is ignored when --details is not used",
+                err=True,
+            )
+        if output is not None:
+            click.echo(
+                "Warning: --output option is ignored when --details is not used",
+                err=True,
+            )
+
     overridden_packages = sorted(wkctx.settings.list_overrides())
     if not details:
         for name in overridden_packages:
             print(name)
         return
 
-    table = Table(title="Package Overrides")
-    table.add_column("Package", justify="left", no_wrap=True)
-    table.add_column("Version", justify="left", no_wrap=True)
-    table.add_column("Patches", justify="left", no_wrap=True)
-
+    # Collect data for export
     variants = sorted(wkctx.settings.all_variants())
-    for v in variants:
-        table.add_column(v, justify="left", no_wrap=True)
-
-    table.add_column("Plugin", justify="left")
+    variant_names = [str(v) for v in variants]
+    export_data = []
 
     for name in overridden_packages:
         pbi = wkctx.settings.package_build_info(name)
@@ -68,16 +93,16 @@ def list_overrides(
                     plugin_hooks.append(hook)
         plugin_hooks_str = ", ".join(plugin_hooks)
 
-        variant_info: list[str] = []
+        variant_info: dict[str, str] = {}
         for v in variants:
             v_info = ps.variants.get(v)
             if v_info:
                 if v_info.pre_built:
-                    variant_info.append("pre-built")
+                    variant_info[str(v)] = "pre-built"
                 else:
-                    variant_info.append("yes")
+                    variant_info[str(v)] = "yes"
             else:
-                variant_info.append("")
+                variant_info[str(v)] = ""
 
         all_patches: PatchMap = pbi.get_all_patches()
         global_patches: list[pathlib.Path] = all_patches.get(None, [])
@@ -87,22 +112,18 @@ def list_overrides(
             [v for v in all_patches.keys() if v is not None]
         )
 
-        row: list[str] = []
-        patches_str: str = ""
-
         if not all_pkg_versions:
             # This package has overrides, but none are version-specific.
             patches_str = str(num_global_patches) if num_global_patches else ""
-            row = (
-                [
-                    name,
-                    "",  # Version
-                    patches_str,
-                ]
-                + variant_info
-                + [plugin_hooks_str]
-            )
-            table.add_row(*row)
+            row_data = {
+                "package": name,
+                "version": "",
+                "patches": patches_str,
+                "plugin_hooks": plugin_hooks_str,
+            }
+            # Add variant information
+            row_data.update(variant_info)
+            export_data.append(row_data)
         else:
             # This package has version-specific overrides.
             for version in all_pkg_versions:
@@ -110,15 +131,76 @@ def list_overrides(
                 total_patches: int = num_global_patches + len(version_patches)
                 patches_str = str(total_patches) if total_patches else ""
 
-                row = (
-                    [
-                        name,
-                        str(version),
-                        patches_str,
-                    ]
-                    + variant_info
-                    + [plugin_hooks_str]
-                )
-                table.add_row(*row)
+                row_data = {
+                    "package": name,
+                    "version": str(version),
+                    "patches": patches_str,
+                    "plugin_hooks": plugin_hooks_str,
+                }
+                # Add variant information
+                row_data.update(variant_info)
+                export_data.append(row_data)
+
+    # Handle different output formats
+    match output_format:
+        case "json":
+            _export_json(export_data, output)
+        case "csv":
+            _export_csv(export_data, variant_names, output)
+        case "table":
+            _export_table(export_data, variant_names)
+        case _:
+            raise ValueError(f"Invalid output format: {output_format}")
+
+
+def _export_json(data: list[dict], output: pathlib.Path | None) -> None:
+    """Export data as JSON."""
+    if output:
+        with open(output, "w") as outfile:
+            json.dump(data, outfile, indent=2)
+    else:
+        json.dump(data, sys.stdout, indent=2)
+
+
+def _export_csv(
+    data: list[dict], variants: list[str], output: pathlib.Path | None
+) -> None:
+    """Export data as CSV."""
+    # Define field names in the order we want them
+    fieldnames = ["package", "version", "patches"] + variants + ["plugin_hooks"]
+
+    if output:
+        with open(output, "w", newline="") as outfile:
+            writer = csv.DictWriter(
+                outfile, fieldnames=fieldnames, quoting=csv.QUOTE_NONNUMERIC
+            )
+            writer.writeheader()
+            writer.writerows(data)
+    else:
+        writer = csv.DictWriter(
+            sys.stdout, fieldnames=fieldnames, quoting=csv.QUOTE_NONNUMERIC
+        )
+        writer.writeheader()
+        writer.writerows(data)
+
+
+def _export_table(data: list[dict], variants: list[str]) -> None:
+    """Export data as Rich table (original behavior)."""
+    table = Table(title="Package Overrides")
+    table.add_column("Package", justify="left", no_wrap=True)
+    table.add_column("Version", justify="left", no_wrap=True)
+    table.add_column("Patches", justify="left", no_wrap=True)
+
+    for v in variants:
+        table.add_column(v, justify="left", no_wrap=True)
+
+    table.add_column("Plugin", justify="left")
+
+    # Define column keys in the same order as CSV exporter
+    column_keys = ["package", "version", "patches"] + variants + ["plugin_hooks"]
+
+    for row_data in data:
+        row = [row_data.get(key, "") for key in column_keys]
+        table.add_row(*row)
 
     rich.get_console().print(table)

--- a/tests/test_list_overrides.py
+++ b/tests/test_list_overrides.py
@@ -1,0 +1,253 @@
+import json
+import pathlib
+import re
+
+from click.testing import CliRunner
+
+from fromager.__main__ import main as fromager
+
+
+def _extract_json_from_output(output: str) -> str:
+    """Extract JSON content from output that may contain log messages."""
+    # Find JSON array in the output
+    json_match = re.search(r"\[\s*\{.*\}\s*\]", output, re.DOTALL)
+    if json_match:
+        return json_match.group(0)
+    return "[]"
+
+
+def _extract_csv_from_output(output: str) -> str:
+    """Extract CSV content from output that may contain log messages."""
+    lines = output.strip().split("\n")
+    # Find lines that look like CSV (contain quotes and commas)
+    csv_lines = [line for line in lines if '"' in line and "," in line]
+    return "\n".join(csv_lines)
+
+
+def test_list_overrides_basic(
+    testdata_path: pathlib.Path, cli_runner: CliRunner
+) -> None:
+    """Test basic list-overrides functionality without --details."""
+    settings_file = testdata_path / "context" / "overrides" / "settings.yaml"
+    patches_dir = testdata_path / "context" / "overrides" / "patches"
+
+    result = cli_runner.invoke(
+        fromager,
+        [
+            "--settings-file",
+            str(settings_file),
+            "--patches-dir",
+            str(patches_dir),
+            "list-overrides",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "test-other-pkg" in result.stdout
+    assert "test-pkg" in result.stdout
+    assert "test-pkg-library" in result.stdout
+
+
+def test_list_overrides_details_table(
+    testdata_path: pathlib.Path, cli_runner: CliRunner
+) -> None:
+    """Test list-overrides --details with table format (default)."""
+    settings_file = testdata_path / "context" / "overrides" / "settings.yaml"
+    patches_dir = testdata_path / "context" / "overrides" / "patches"
+
+    result = cli_runner.invoke(
+        fromager,
+        [
+            "--settings-file",
+            str(settings_file),
+            "--patches-dir",
+            str(patches_dir),
+            "list-overrides",
+            "--details",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Package Overrides" in result.stdout
+    assert "test-other-pkg" in result.stdout
+    assert "test-pkg" in result.stdout
+    assert "test-pkg-library" in result.stdout
+
+
+def test_list_overrides_details_json(
+    testdata_path: pathlib.Path, cli_runner: CliRunner
+) -> None:
+    """Test list-overrides --details --format json."""
+    settings_file = testdata_path / "context" / "overrides" / "settings.yaml"
+    patches_dir = testdata_path / "context" / "overrides" / "patches"
+
+    result = cli_runner.invoke(
+        fromager,
+        [
+            "--settings-file",
+            str(settings_file),
+            "--patches-dir",
+            str(patches_dir),
+            "list-overrides",
+            "--details",
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0
+
+    # Extract JSON from output (filtering out log messages)
+    json_output = _extract_json_from_output(result.stdout)
+    data = json.loads(json_output)
+    assert isinstance(data, list)
+    assert len(data) == 3
+
+    # Check that we have the expected packages
+    packages = [item["package"] for item in data]
+    assert "test-other-pkg" in packages
+    assert "test-pkg" in packages
+    assert "test-pkg-library" in packages
+
+    # Check structure of first item
+    first_item = data[0]
+    assert "package" in first_item
+    assert "version" in first_item
+    assert "patches" in first_item
+    assert "plugin_hooks" in first_item
+    assert "rocm" in first_item  # variant column
+
+
+def test_list_overrides_details_csv(
+    testdata_path: pathlib.Path, cli_runner: CliRunner
+) -> None:
+    """Test list-overrides --details --format csv."""
+    settings_file = testdata_path / "context" / "overrides" / "settings.yaml"
+    patches_dir = testdata_path / "context" / "overrides" / "patches"
+
+    result = cli_runner.invoke(
+        fromager,
+        [
+            "--settings-file",
+            str(settings_file),
+            "--patches-dir",
+            str(patches_dir),
+            "list-overrides",
+            "--details",
+            "--format",
+            "csv",
+        ],
+    )
+    assert result.exit_code == 0
+
+    # Extract CSV from output (filtering out log messages)
+    csv_output = _extract_csv_from_output(result.stdout)
+    lines = csv_output.strip().split("\n")
+    assert len(lines) == 4  # header + 3 data rows
+
+    # Check header
+    header = lines[0]
+    assert '"package"' in header
+    assert '"version"' in header
+    assert '"patches"' in header
+    assert '"plugin_hooks"' in header
+    assert '"rocm"' in header  # variant column
+
+    # Check data rows
+    assert any("test-other-pkg" in line for line in lines[1:])
+    assert any("test-pkg" in line for line in lines[1:])
+    assert any("test-pkg-library" in line for line in lines[1:])
+
+
+def test_list_overrides_output_file(
+    testdata_path: pathlib.Path, cli_runner: CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """Test list-overrides with output file."""
+    settings_file = testdata_path / "context" / "overrides" / "settings.yaml"
+    patches_dir = testdata_path / "context" / "overrides" / "patches"
+    output_file = tmp_path / "output.json"
+
+    result = cli_runner.invoke(
+        fromager,
+        [
+            "--settings-file",
+            str(settings_file),
+            "--patches-dir",
+            str(patches_dir),
+            "list-overrides",
+            "--details",
+            "--format",
+            "json",
+            "--output",
+            str(output_file),
+        ],
+    )
+    assert result.exit_code == 0
+    # stdout may contain log messages, but should not contain the JSON data
+    assert "test-other-pkg" not in result.stdout
+    assert "test-pkg" not in result.stdout
+    assert "test-pkg-library" not in result.stdout
+
+    # Check that file was created and contains valid JSON
+    assert output_file.exists()
+    data = json.loads(output_file.read_text())
+    assert isinstance(data, list)
+    assert len(data) == 3
+
+
+def test_list_overrides_format_option_help(cli_runner: CliRunner) -> None:
+    """Test that the format option shows the correct choices in help."""
+    result = cli_runner.invoke(
+        fromager,
+        ["list-overrides", "--help"],
+    )
+    assert result.exit_code == 0
+    assert "--format [table|csv|json]" in result.stdout
+    assert "requires --details" in result.stdout
+
+
+def test_list_overrides_warnings_without_details(
+    testdata_path: pathlib.Path, cli_runner: CliRunner
+) -> None:
+    """Test that warnings are shown when using format/output without details."""
+    settings_file = testdata_path / "context" / "overrides" / "settings.yaml"
+    patches_dir = testdata_path / "context" / "overrides" / "patches"
+
+    # Test format warning
+    result = cli_runner.invoke(
+        fromager,
+        [
+            "--settings-file",
+            str(settings_file),
+            "--patches-dir",
+            str(patches_dir),
+            "list-overrides",
+            "--format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert (
+        "Warning: --format option is ignored when --details is not used"
+        in result.output
+    )
+    assert "test-other-pkg" in result.output
+
+    # Test output warning
+    result = cli_runner.invoke(
+        fromager,
+        [
+            "--settings-file",
+            str(settings_file),
+            "--patches-dir",
+            str(patches_dir),
+            "list-overrides",
+            "--output",
+            "test.txt",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert (
+        "Warning: --output option is ignored when --details is not used"
+        in result.output
+    )
+    assert "test-other-pkg" in result.output


### PR DESCRIPTION
This commit adds the options to export list-overrides --details in CSV and JSON format

Further, it adds unit tests for the same as well

Fixes https://github.com/python-wheel-build/fromager/issues/692