### PR TITLE
feat: Add --test-mode for resilient bootstrap with failure handling

### DIFF
--- a/src/fromager/commands/graph.py
+++ b/src/fromager/commands/graph.py
@@ -125,7 +125,7 @@ def _find_customized_nodes(
     """Filter nodes to find only those with customizations."""
     customized_nodes: list[DependencyNode] = []
     for node in nodes:
-        pbi = wkctx.settings.package_build_info(node.canonicalized_name)
+        pbi = wkctx.package_build_info(node.canonicalized_name)
         if node.canonicalized_name != ROOT and pbi.has_customizations:
             customized_nodes.append(node)
     return customized_nodes
@@ -161,7 +161,7 @@ def _find_customized_dependencies_for_node(
                 continue
 
             child = edge.destination_node
-            child_pbi = wkctx.settings.package_build_info(child.canonicalized_name)
+            child_pbi = wkctx.package_build_info(child.canonicalized_name)
             new_path = path + [current_node.key]
 
             # Use the first requirement we encounter in the path
@@ -277,7 +277,7 @@ def write_dot(
         if not name:
             node_type.append("toplevel")
         else:
-            pbi = wkctx.settings.package_build_info(name)
+            pbi = wkctx.package_build_info(name)
             all_patches: PatchMap = pbi.get_all_patches()
 
             if node.pre_built:

--- a/src/fromager/commands/list_overrides.py
+++ b/src/fromager/commands/list_overrides.py
@@ -65,7 +65,7 @@ def list_overrides(
     export_data = []
 
     for name in overridden_packages:
-        pbi = wkctx.settings.package_build_info(name)
+        pbi = wkctx.package_build_info(name)
         ps = wkctx.settings.package_setting(name)
 
         plugin_hooks: list[str] = []

--- a/src/fromager/context.py
+++ b/src/fromager/context.py
@@ -164,7 +164,7 @@ class WorkContext:
             name = package.name
         else:
             name = package
-        return self.settings.package_build_info(name)
+        return self.settings.package_build_info(name, self)
 
     def setup(self) -> None:
         # The work dir must already exist, so don't try to create it.

--- a/src/fromager/hooks.py
+++ b/src/fromager/hooks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import pathlib
 import typing
+from importlib import metadata
 
 from packaging.requirements import Requirement
 from stevedore import extension, hook
@@ -39,7 +40,7 @@ def _get_hooks(name: str) -> hook.HookManager:
 def log_hooks() -> None:
     # We load the hooks differently here because we want all of them when
     # normally we would load them by name.
-    _mgr = extension.ExtensionManager(
+    _mgr: extension.ExtensionManager[typing.Any] = extension.ExtensionManager(
         namespace="fromager.hooks",
         invoke_on_load=False,
         on_load_failure_callback=_die_on_plugin_load_failure,
@@ -56,9 +57,9 @@ def log_hooks() -> None:
 
 
 def _die_on_plugin_load_failure(
-    mgr: hook.HookManager,
-    ep: extension.Extension,
-    err: Exception,
+    mgr: hook.HookManager[typing.Any],
+    ep: metadata.EntryPoint,
+    err: BaseException,
 ) -> typing.NoReturn:
     raise RuntimeError(f"failed to load overrides for {ep.name}") from err
 

--- a/src/fromager/overrides.py
+++ b/src/fromager/overrides.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 _mgr = None
 
 
-def _get_extensions() -> extension.ExtensionManager:
+def _get_extensions() -> extension.ExtensionManager[typing.Any]:
     global _mgr
     if _mgr is None:
         _mgr = extension.ExtensionManager(
@@ -30,9 +30,9 @@ def _get_extensions() -> extension.ExtensionManager:
 
 
 def _die_on_plugin_load_failure(
-    mgr: extension.ExtensionManager,
-    ep: extension.Extension,
-    err: Exception,
+    mgr: extension.ExtensionManager[typing.Any],
+    ep: metadata.EntryPoint,
+    err: BaseException,
 ) -> None:
     raise RuntimeError(f"failed to load overrides for {ep.name}") from err
 

--- a/tests/test_bootstrap_test_mode.py
+++ b/tests/test_bootstrap_test_mode.py
@@ -1,0 +1,91 @@
+"""Tests for bootstrap --test-mode functionality.
+
+Tests for test mode failure tracking and BuildResult.
+"""
+
+from unittest import mock
+
+import pytest
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+from fromager import bootstrapper
+from fromager.context import WorkContext
+
+
+class MockBuildError(Exception):
+    """Mock exception for simulating build failures."""
+
+    pass
+
+
+def test_test_mode_tracks_complete_failures(tmp_context: WorkContext) -> None:
+    """Test that test mode tracks failures with full context when both build and fallback fail."""
+    bt = bootstrapper.Bootstrapper(tmp_context, test_mode=True)
+
+    # Mock to always fail
+    def mock_build_wheel_and_sdist(req, version, pbi, build_sdist_only):
+        raise MockBuildError(f"Build failed for {req.name}")
+
+    with mock.patch.object(
+        bt, "_build_wheel_and_sdist", side_effect=mock_build_wheel_and_sdist
+    ):
+        req = Requirement("broken-package==1.0")
+        version = Version("1.0")
+        pbi = tmp_context.package_build_info(req)
+
+        result = bt._build_package(req, version, pbi, build_sdist_only=False)
+
+        # Verify complete failure is tracked with full context
+        assert result.failed
+        assert result.req == req
+        assert result.resolved_version == version
+        assert result.exception_type == "MockBuildError"
+        assert result.exception_message is not None
+        assert "Build failed for broken-package" in result.exception_message
+
+        # Verify failure is in failed_builds list
+        assert len(bt.failed_builds) == 1
+        failed_build = bt.failed_builds[0]
+        assert failed_build.req is not None
+        assert failed_build.req.name == "broken-package"
+
+
+def test_normal_mode_still_fails_fast(tmp_context: WorkContext) -> None:
+    """Test that normal mode (test_mode=False) still raises exceptions immediately."""
+    bt = bootstrapper.Bootstrapper(tmp_context, test_mode=False)
+
+    def mock_build_wheel_and_sdist(req, version, pbi, build_sdist_only):
+        raise MockBuildError(f"Build failed for {req.name}")
+
+    with mock.patch.object(
+        bt, "_build_wheel_and_sdist", side_effect=mock_build_wheel_and_sdist
+    ):
+        req = Requirement("failing-package==1.0")
+        version = Version("1.0")
+        pbi = tmp_context.package_build_info(req)
+
+        # Should raise immediately in normal mode
+        with pytest.raises(MockBuildError, match="Build failed for failing-package"):
+            bt._build_package(req, version, pbi, build_sdist_only=False)
+
+
+def test_build_result_captures_exception_context() -> None:
+    """Test that BuildResult.failure() properly captures exception context."""
+    req = Requirement("test-package>=1.0")
+    version = Version("1.2.3")
+    exception = ValueError("Something went wrong")
+
+    result = bootstrapper.BuildResult.failure(
+        req=req, resolved_version=version, exception=exception
+    )
+
+    # Verify all context is captured
+    assert result.failed
+    assert result.req == req
+    assert result.resolved_version == version
+    assert result.exception is exception
+    assert result.exception_type == "ValueError"
+    assert result.exception_message == "Something went wrong"
+    assert result.wheel_filename is None
+    assert result.sdist_filename is None

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -17,5 +17,7 @@ def test_bootstrap_parallel_options() -> None:
     # graph_file internally.
     expected.discard("sdist_only")
     expected.discard("graph_file")
+    # test_mode is not supported in bootstrap-parallel (serial mode only)
+    expected.discard("test_mode")
 
     assert set(get_option_names(bootstrap.bootstrap_parallel)) == expected

--- a/tests/test_graph_commands.py
+++ b/tests/test_graph_commands.py
@@ -273,15 +273,13 @@ def test_find_transitive_customized_dependency() -> None:
 
     # Mock context: only package-c is customized
     mock_ctx = Mock()
-    mock_settings = Mock()
 
     def mock_pbi(name: str) -> Mock:
         pbi = Mock()
         pbi.has_customizations = name == "package-c"
         return pbi
 
-    mock_settings.package_build_info = mock_pbi
-    mock_ctx.settings = mock_settings
+    mock_ctx.package_build_info = mock_pbi
 
     # Test
     node_a = graph.nodes["package-a==1.0.0"]
@@ -376,15 +374,13 @@ def test_cycle_prevention_no_infinite_loop() -> None:
 
     # Mock context: only package-c is customized
     mock_ctx = Mock()
-    mock_settings = Mock()
 
     def mock_pbi(name: str) -> Mock:
         pbi = Mock()
         pbi.has_customizations = name == "package-c"
         return pbi
 
-    mock_settings.package_build_info = mock_pbi
-    mock_ctx.settings = mock_settings
+    mock_ctx.package_build_info = mock_pbi
 
     # Test: Should not hang or raise error
     node_a = graph.nodes["package-a==1.0.0"]
@@ -431,15 +427,13 @@ def test_requirement_preservation_through_chain() -> None:
 
     # Mock context: only package-c is customized
     mock_ctx = Mock()
-    mock_settings = Mock()
 
     def mock_pbi(name: str) -> Mock:
         pbi = Mock()
         pbi.has_customizations = name == "package-c"
         return pbi
 
-    mock_settings.package_build_info = mock_pbi
-    mock_ctx.settings = mock_settings
+    mock_ctx.package_build_info = mock_pbi
 
     # Test
     node_a = graph.nodes["package-a==1.0.0"]


### PR DESCRIPTION
Add --test-mode flag that enables resilient bootstrapping by marking failed
packages as pre-built and continuing until all packages are processed. Uses
optimal n+1 retry logic with comprehensive failure reporting including exception
types, messages, and per-package context.

Benefits:
- Discover all build failures in one run rather than stopping on first failure
- Support mixed source/binary dependency workflows
- Better error context for debugging failed builds
- Cleaner API boundaries between configuration and runtime context


Fixes #713

Co-developed-with: Cursor IDE with Claude 4.0 Sonnet

Command prompts: https://gist.github.com/LalatenduMohanty/762baf9999a09ef3d2d3e63220b9c52e