### PR TITLE
feat: use uv to manage build environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,8 @@ dependencies = [
     "stevedore",
     "tomlkit",
     "tqdm",
-    "virtualenv!=20.33.0",
     "wheel",
+    "uv",
 ]
 
 [project.optional-dependencies]

--- a/src/fromager/context.py
+++ b/src/fromager/context.py
@@ -66,6 +66,7 @@ class WorkContext:
         self.wheel_server_dir = self.wheels_repo / "simple"
         self.work_dir = pathlib.Path(work_dir).absolute()
         self.graph_file = self.work_dir / "graph.json"
+        self.uv_cache = self.work_dir / "uv-cache"
         self.wheel_server_url = ""
         self.logs_dir = self.work_dir / "logs"
         self.cleanup = cleanup
@@ -151,6 +152,7 @@ class WorkContext:
             self.wheels_downloads,
             self.wheels_prebuilt,
             self.wheels_build,
+            self.uv_cache,
             self.logs_dir,
         ]:
             if not p.exists():

--- a/src/fromager/dependencies.py
+++ b/src/fromager/dependencies.py
@@ -355,6 +355,7 @@ def get_build_backend_hook_caller(
     build_dir: pathlib.Path,
     override_environ: dict[str, typing.Any],
     build_env: build_environment.BuildEnvironment,
+    log_filename: str | None = None,
 ) -> pyproject_hooks.BuildBackendHookCaller:
     """Create pyproject_hooks build backend caller"""
 
@@ -376,6 +377,7 @@ def get_build_backend_hook_caller(
             cwd=cwd,
             extra_environ=extra_environ,
             network_isolation=ctx.network_isolation,
+            log_filename=log_filename,
         )
 
     pyproject_toml = get_pyproject_contents(build_dir)

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -20,6 +20,7 @@ from packaging.utils import BuildTag, canonicalize_name, parse_wheel_filename
 from packaging.version import Version
 
 from . import (
+    dependencies,
     external_commands,
     metrics,
     overrides,
@@ -319,6 +320,37 @@ def build_wheel(
     return wheel
 
 
+def pep517_build_wheel(
+    ctx: context.WorkContext,
+    build_env: build_environment.BuildEnvironment,
+    extra_environ: dict[str, str],
+    req: Requirement,
+    sdist_root_dir: pathlib.Path,
+    version: Version,
+    build_dir: pathlib.Path,
+) -> pathlib.Path:
+    """Use the PEP 517 API to build a wheel distribution"""
+    logger.debug(f"building wheel in {build_dir} with {extra_environ}")
+
+    hook_caller = dependencies.get_build_backend_hook_caller(
+        ctx=ctx,
+        req=req,
+        build_dir=build_dir,
+        override_environ=extra_environ,
+        build_env=build_env,
+        log_filename=str(sdist_root_dir.parent / "build.log"),
+    )
+
+    pbi = ctx.package_build_info(req)
+    wheel_filename = hook_caller.build_wheel(
+        str(ctx.wheels_build),
+        config_settings=pbi.config_settings,
+    )
+    logger.debug("built wheel %s", wheel_filename)
+
+    return ctx.wheels_build / wheel_filename
+
+
 def default_build_wheel(
     ctx: context.WorkContext,
     build_env: build_environment.BuildEnvironment,
@@ -328,42 +360,15 @@ def default_build_wheel(
     version: Version,
     build_dir: pathlib.Path,
 ) -> None:
-    logger.debug(f"building wheel in {build_dir} with {extra_environ}")
-    pbi = ctx.package_build_info(req)
-
-    cmd = [
-        os.fspath(build_env.python),
-        "-m",
-        "pip",
-        "-vvv",
-        "--disable-pip-version-check",
-        "wheel",
-        "--no-build-isolation",
-        "--only-binary",
-        ":all:",
-        "--wheel-dir",
-        os.fspath(ctx.wheels_build),
-        "--no-deps",
-        "--index-url",
-        ctx.wheel_server_url,  # probably redundant, but just in case
-        "--log",
-        os.fspath(build_dir.parent / "build.log"),
-    ]
-    # config settings needs pip >= 24.0 to work. Fromager uses `virtualenv``
-    # package to create virtual envs, which comes with recent pip. Stdlib's
-    # `venv` comes with rather old pip.
-    for key, values in pbi.config_settings.items():
-        for value in values:
-            cmd.append(f"--config-settings={key}={value}")
-    cmd.append(os.fspath(build_dir))
-
-    with tempfile.TemporaryDirectory() as dir_name:
-        build_env.run(
-            cmd,
-            cwd=dir_name,
-            extra_environ=extra_environ,
-            network_isolation=ctx.network_isolation,
-        )
+    pep517_build_wheel(
+        ctx=ctx,
+        build_env=build_env,
+        extra_environ=extra_environ,
+        req=req,
+        sdist_root_dir=sdist_root_dir,
+        version=version,
+        build_dir=build_dir,
+    )
 
 
 def download_wheel(

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -309,6 +309,9 @@ def build_wheel(
             f"Expected 1 built wheel in {ctx.wheels_build}, got {len(wheels)}"
         )
 
+    # invalidate uv's cache
+    build_env.clean_cache(req)
+
     wheel = add_extra_metadata_to_wheels(
         ctx=ctx,
         req=req,

--- a/tests/test_build_environment.py
+++ b/tests/test_build_environment.py
@@ -42,30 +42,42 @@ def test_missing_dependency_format(
 
 def test_missing_dependency_pattern():
     msg = textwrap.dedent("""
-        Looking in indexes: http://192.168.0.201:9999/simple
-        Looking in links: /Users/dhellmann/.pip/wheelhouse
-        Processing /Users/dhellmann/.pip/wheelhouse/pbr-6.0.0-py2.py3-none-any.whl (from -r /Users/dhellmann/Devel/fromager/fromager/e2e-output/work-dir/stevedore-5.2.0/build-3.12.0/requirements.txt (line 1))
-        ERROR: Could not find a version that satisfies the requirement setuptools>=40.8.0 (from versions: 11.3.1, 14.0)
-        ERROR: No matching distribution found for setuptools>=40.8.0
+        DEBUG uv 0.8.4
+        DEBUG Searching for default Python interpreter in virtual environments
+        DEBUG Found `cpython-3.13.5-linux-x86_64-gnu` at `.../.venv/bin/python3` (active virtual environment)
+        DEBUG Using Python 3.13.5 environment at: .venv
+        DEBUG Acquired lock for `.venv`
+        DEBUG At least one requirement is not satisfied: fromager==1.0
+        DEBUG Using request timeout of 30s
+        DEBUG Solving with installed Python version: 3.13.5
+        DEBUG Solving with target Python version: >=3.13.5
+        DEBUG Adding direct dependency: fromager>=1.0, <1.0+
+        DEBUG Found fresh response for: https://pypi.org/simple/fromager/
+        DEBUG Searching for a compatible version of fromager (>=1.0, <1.0+)
+        DEBUG No compatible version found for: fromager
+        x No solution found when resolving dependencies:
+        ╰─▶ Because there is no version of fromager==1.0 and you require fromager==1.0, we can conclude that your requirements are unsatisfiable.
         """)
-    match = build_environment._pip_missing_dependency_pattern.search(msg)
+    match = build_environment._uv_missing_dependency_pattern.search(msg)
     assert match is not None
 
 
 def test_missing_dependency_pattern_resolution_impossible():
     msg = textwrap.dedent("""
-    Looking in indexes: http://10.1.0.116:9999/simple
-    ERROR: Cannot install setuptools>=40.8.0 because these package versions have conflicting dependencies.
-
-    The conflict is caused by:
-        The user requested setuptools>=40.8.0
-        The user requested (constraint) setuptools<72.0.0
-
-    To fix this you could try to:
-    1. loosen the range of package versions you've specified
-    2. remove package versions to allow pip to attempt to solve the dependency conflict
-
-    ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
+        DEBUG uv 0.8.4
+        DEBUG Searching for default Python interpreter in virtual environments
+        DEBUG Found `cpython-3.13.5-linux-x86_64-gnu` at `.../.venv/bin/python3` (active virtual environment)
+        DEBUG Using Python 3.13.5 environment at: .venv
+        DEBUG Acquired lock for `.venv`
+        DEBUG At least one requirement is not satisfied: fromager==2.0
+        DEBUG Using request timeout of 30s
+        DEBUG Solving with installed Python version: 3.13.5
+        DEBUG Solving with target Python version: >=3.13.5
+        DEBUG Adding direct dependency: fromager>=1.0, <1.0+
+        DEBUG Adding direct dependency: fromager>=2.0, <2.0+
+        DEBUG Found fresh response for: https://pypi.org/simple/fromager/
+        x No solution found when resolving dependencies:
+        ╰─▶ Because you require fromager==1.0 and fromager==2.0, we can conclude that your requirements are unsatisfiable.
     """)
-    match = build_environment._pip_missing_dependency_pattern.search(msg)
+    match = build_environment._uv_missing_dependency_pattern.search(msg)
     assert match is not None

--- a/tests/test_packagesettings.py
+++ b/tests/test_packagesettings.py
@@ -289,6 +289,11 @@ def test_pbi_test_pkg_extra_environ(
             "DEF": "default",
             "PATH": f"{build_env.path / 'bin'}:/sbin:/bin",
             "VIRTUAL_ENV": str(build_env.path),
+            "UV_CACHE_DIR": str(testdata_context.uv_cache),
+            "UV_NATIVE_TLS": "true",
+            "UV_NO_MANAGED_PYTHON": "true",
+            "UV_PYTHON": str(build_env.python),
+            "UV_PYTHON_DOWNLOADS": "never",
         }
         | parallel
     )

--- a/tests/test_wheels.py
+++ b/tests/test_wheels.py
@@ -26,9 +26,11 @@ def test_invalid_wheel_file_exception(
         wheels._download_wheel_check(req, fake_dir, fake_url)
 
 
-@patch("fromager.build_environment.BuildEnvironment.run")
+@patch("pyproject_hooks.BuildBackendHookCaller.build_wheel")
 def test_default_build_wheel(
-    mock_run: Mock, tmp_path: pathlib.Path, testdata_context: context.WorkContext
+    mock_build_wheel: Mock,
+    tmp_path: pathlib.Path,
+    testdata_context: context.WorkContext,
 ) -> None:
     req = Requirement("test_pkg")
     build_env = build_environment.BuildEnvironment(
@@ -48,9 +50,12 @@ def test_default_build_wheel(
         build_dir=tmp_path,
     )
 
-    mock_run.assert_called_once()
-    cmd = mock_run.call_args[0][0]
-    assert "--config-settings=setup-args=-Dsystem-freetype=true" in cmd
+    mock_build_wheel.assert_called_once_with(
+        str(testdata_context.wheels_build),
+        config_settings={
+            "setup-args": ["-Dsystem-freetype=true", "-Dsystem-qhull=true"]
+        },
+    )
 
 
 @patch("fromager.external_commands.run")


### PR DESCRIPTION
The build environment is now managed with `uv` instead of `virtualenv` and `pip`. `uv venv` creates an almost empty virtual env without `pip` command. `uv pip install` uses a faster resolver, parallel downloads, and several caches. Wheels are unpacked in a cache directory and "installed" by hardlinking files. These tricks speed up bootstrapping and building substantially.

In downstream I have measured 4:30 minutes instead of 11 minutes for a bootstrap-parallel run with all wheels in the cache index.

Use PEP 517 API and pyproject `BuildBackendHookCaller` instead of `pip wheel` to build wheels. Fromager no longer needs pip in a build environment to build a package.