### PR TITLE
chore: improve fromager --version

### DIFF
--- a/src/fromager/__main__.py
+++ b/src/fromager/__main__.py
@@ -3,7 +3,6 @@
 import logging
 import pathlib
 import sys
-from importlib.metadata import version as get_version
 
 import click
 
@@ -32,7 +31,10 @@ else:
 
 
 @click.group()
-@click.version_option(version=get_version("fromager"), prog_name="fromager")
+@click.version_option(
+    package_name="fromager",
+    prog_name="fromager",
+)
 @click.option(
     "-v",
     "--verbose",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,3 +33,9 @@ def test_migrate_config(
         expected_txt = expected.joinpath(filename).read_text()
         output_txt = output.joinpath(filename).read_text()
         assert output_txt == expected_txt
+
+
+def test_fromager_version(cli_runner: CliRunner) -> None:
+    result = cli_runner.invoke(fromager, ["--version"])
+    assert result.exit_code == 0
+    assert result.stdout.startswith("fromager, version")


### PR DESCRIPTION
Let Click call `importlib.metadata.version` on demand. The dist-info metadata is only located and parsed when needed.

Add a simple test for `fromager --version`.