### PR TITLE
feat: validate name and version of sdist and wheel

### DIFF
--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -230,7 +230,9 @@ Source hooks
 .. autofromagerhook:: default_build_sdist
 
     The ``build_sdist()`` function is responsible for creating a new source
-    distribution from the prepared source tree and placing it in ``ctx.sdists_build``.
+    distribution from the prepared source tree and placing it in
+    ``ctx.sdists_build``.  The dist name and version of the sdist file must
+    match the ``Requirement`` and ``Version``.
 
     The arguments are the ``WorkContext``, the ``Requirement`` being evaluated, and the
     `Path` to the root of the source tree.
@@ -247,8 +249,8 @@ Wheel hooks
 
     The ``build_wheel()`` function is responsible for creating a wheel from
     the prepared source tree and placing it in ``ctx.wheels_build``. The
-    default implementation invokes ``pip wheel`` in a temporary directory
-    and passes the path to the source tree as argument.
+    default implementation uses :pep:`517` pyproject hook.  The dist name
+    and version of the wheel must match the ``Requirement`` and ``Version``.
 
     The arguments are the ``WorkContext``, the ``Path`` to a virtualenv
     prepared with the build dependencies, a ``dict`` with extra environment

--- a/src/fromager/context.py
+++ b/src/fromager/context.py
@@ -56,15 +56,15 @@ class WorkContext:
             self.constraints.load_constraints_file(constraints_file)
         else:
             self.input_constraints_uri = None
-        self.sdists_repo = pathlib.Path(sdists_repo).absolute()
+        self.sdists_repo = pathlib.Path(sdists_repo).resolve()
         self.sdists_downloads = self.sdists_repo / "downloads"
         self.sdists_builds = self.sdists_repo / "builds"
-        self.wheels_repo = pathlib.Path(wheels_repo).absolute()
+        self.wheels_repo = pathlib.Path(wheels_repo).resolve()
         self.wheels_build_base = self.wheels_repo / "build"
         self.wheels_downloads = self.wheels_repo / "downloads"
         self.wheels_prebuilt = self.wheels_repo / "prebuilt"
         self.wheel_server_dir = self.wheels_repo / "simple"
-        self.work_dir = pathlib.Path(work_dir).absolute()
+        self.work_dir = pathlib.Path(work_dir).resolve()
         self.graph_file = self.work_dir / "graph.json"
         self.uv_cache = self.work_dir / "uv-cache"
         self.wheel_server_url = ""

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -187,3 +187,31 @@ def test_patch_sources_apply_only_unversioned(
         version=Version("0.6.0"),
     )
     apply_patch.assert_called_once_with(req, unversioned_patch_file, source_root_dir)
+
+
+@pytest.mark.parametrize(
+    "dist_name,version_string,sdist_filename,okay",
+    [
+        ("mypkg", "1.2", "mypkg-1.2.tar.gz", True),
+        ("mypkg", "1.2", "unknown-1.2.tar.gz", False),
+        ("mypkg", "1.2", "mypkg-1.2.1.tar.gz", False),
+        ("oslo.messaging", "14.7.0", "oslo.messaging-14.7.0.tar.gz", True),
+        ("cython", "3.0.10", "Cython-3.0.10.tar.gz", True),
+        # parse_sdist_filename() accepts a dash in the name
+        ("fromage_test", "9.9.9", "fromage-test-9.9.9.tar.gz", True),
+        ("fromage-test", "9.9.9", "fromage-test-9.9.9.tar.gz", True),
+        ("fromage_test", "9.9.9", "fromage_test-9.9.9.tar.gz", True),
+        ("ruamel-yaml", "0.18.6", "ruamel.yaml-0.18.6.tar.gz", True),
+    ],
+)
+def test_validate_sdist_file(
+    dist_name: str, version_string: str, sdist_filename: pathlib.Path, okay: bool
+) -> None:
+    req = Requirement(dist_name)
+    version = Version(version_string)
+    sdist_file = pathlib.Path(sdist_filename)
+    if okay:
+        sources.validate_sdist_filename(req, version, sdist_file)
+    else:
+        with pytest.raises(ValueError):
+            sources.validate_sdist_filename(req, version, sdist_file)

--- a/tests/test_wheels.py
+++ b/tests/test_wheels.py
@@ -215,3 +215,45 @@ def test_add_extra_metadata_blocks_path_traversal(
             sdist_root_dir=sdist_dir,
             wheel_file=wheel_file,
         )
+
+
+@pytest.mark.parametrize(
+    "dist_name,version_string,wheel_filename,okay",
+    [
+        ("mypkg", "1.2", "mypkg-1.2-py2.py3-none-any.whl", True),
+        ("mypkg", "1.2", "unknown-1.2-py2.py3-none-any.whl", False),
+        ("mypkg", "1.2", "mypkg-1.2.1-py2.py3-none-any.whl", False),
+        (
+            "oslo.messaging",
+            "14.7.0",
+            "oslo.messaging-14.7.0-py2.py3-none-any.whl",
+            True,
+        ),
+        ("cython", "3.0.10", "Cython-3.0.10-cp311-cp311-linux_aarch64.whl", True),
+        (
+            "fromage_test",
+            "9.9.9",
+            "fromage_test-9.9.9-cp311-cp311-linux_aarch64.whl",
+            True,
+        ),
+        # parse_wheel_filename() does NOT accept a dash in the name
+        (
+            "fromage_test",
+            "9.9.9",
+            "fromage-test-9.9.9-cp311-cp311-linux_aarch64.whl",
+            False,
+        ),
+        ("ruamel-yaml", "0.18.6", "ruamel.yaml-0.18.6-py3-none-any.whl", True),
+    ],
+)
+def test_validate_wheel_file(
+    dist_name: str, version_string: str, wheel_filename: str, okay: bool
+) -> None:
+    req = Requirement(dist_name)
+    version = Version(version_string)
+    wheel_file = pathlib.Path(wheel_filename)
+    if okay:
+        wheels.validate_wheel_filename(req, version, wheel_file)
+    else:
+        with pytest.raises(ValueError):
+            wheels.validate_wheel_filename(req, version, wheel_file)


### PR DESCRIPTION
Fromager now validates the dist name and dist version part of sdist and wheel files. The canonicalized dist name must match the canonicalized requirement name. The public version versions must match, too. Validation is performed in `build_sdist`, `build_wheel`, and `default_get_install_dependencies_of_sdist` steps. The latter covers bootstrap in sdist-only mode.

The new checks prevent invalid and broken packages, e.g. `unknown-0.0` wheel or a wheel that has wrong version number.