### PR TITLE
perf: cache Python requirement match

### DIFF
--- a/src/fromager/commands/bootstrap.py
+++ b/src/fromager/commands/bootstrap.py
@@ -17,6 +17,7 @@ from .. import (
     metrics,
     progress,
     requirements_file,
+    resolver,
     server,
 )
 from ..log import requirement_ctxvar
@@ -195,6 +196,8 @@ def bootstrap(
                 raise ValueError(
                     f"Could not produce a pip compatible constraints file. Please review {constraints_filename} for more details"
                 )
+
+    logger.info("match_py_req LRU cache: %r", resolver.match_py_req.cache_info())
 
     metrics.summarize(wkctx, "Bootstrapping")
 


### PR DESCRIPTION
SpecifierSet parsing and matching takes a non-trivial amount of time. A bootstrap run can spend over 10% of its time in parsing and matching Python version requirements.

The resolver now uses an LRU cache for parsing and matching a Python version requirement.

From my test run with about 370 packages:
```
match_py_req LRU cache: CacheInfo(hits=331462, misses=1110, maxsize=200, currsize=126)
```

Fixes: #742