### PR TITLE
fix: Reduce log level for LRU cache info

### DIFF
--- a/src/fromager/commands/bootstrap.py
+++ b/src/fromager/commands/bootstrap.py
@@ -197,7 +197,7 @@ def bootstrap(
                     f"Could not produce a pip compatible constraints file. Please review {constraints_filename} for more details"
                 )
 
-    logger.info("match_py_req LRU cache: %r", resolver.match_py_req.cache_info())
+    logger.debug("match_py_req LRU cache: %r", resolver.match_py_req.cache_info())
 
     metrics.summarize(wkctx, "Bootstrapping")
 


### PR DESCRIPTION
Log cache hits with `debug` instead of `info` level.

See: https://github.com/python-wheel-build/fromager/pull/743