### PR TITLE
refactor: improve constraint file error reporting with detailed confl…

### DIFF
--- a/src/fromager/commands/bootstrap.py
+++ b/src/fromager/commands/bootstrap.py
@@ -23,7 +23,7 @@ from .. import (
 from ..log import requirement_ctxvar
 from ..requirements_file import RequirementType
 from .build import build_parallel
-from .graph import find_why
+from .graph import find_why, show_explain_duplicates
 
 # Map child_name==child_version to list of (parent_name==parent_version, Requirement)
 ReverseRequirements = dict[str, list[tuple[str, Requirement]]]
@@ -401,6 +401,11 @@ def write_constraints_file(
                     depth=0,
                     req_type=[],
                 )
+
+        # Show the report that explains which rules match which versions
+        # of any duplicates.
+        print("\nSome packages have multiple version based on different requirements:")
+        show_explain_duplicates(graph)
 
         return ret
 

--- a/src/fromager/commands/graph.py
+++ b/src/fromager/commands/graph.py
@@ -221,7 +221,10 @@ def write_dot(
 def explain_duplicates(wkctx, graph_file):
     "Report on duplicate installation requirements, and where they come from."
     graph = DependencyGraph.from_file(graph_file)
+    show_explain_duplicates(graph)
 
+
+def show_explain_duplicates(graph: DependencyGraph) -> None:
     # Look for potential conflicts by tracking how many different versions of
     # each package are needed.
     conflicts = graph.get_install_dependency_versions()
@@ -231,8 +234,8 @@ def explain_duplicates(wkctx, graph_file):
         if len(versions) == 1:
             continue
 
-        usable_versions = {}
-        user_counter = 0
+        usable_versions: dict[str, list[str]] = {}
+        user_counter: int = 0
 
         print(f"\n{dep_name}")
         for node in sorted(nodes, key=lambda x: x.version):
@@ -240,7 +243,7 @@ def explain_duplicates(wkctx, graph_file):
 
             # Determine which parents can use which versions of this dependency,
             # grouping the output by the requirement specifier.
-            parents_by_req = {}
+            parents_by_req: dict[Requirement, set[str]] = {}
             for parent_edge in node.get_incoming_install_edges():
                 parents_by_req.setdefault(parent_edge.req, set()).add(
                     parent_edge.destination_node.key


### PR DESCRIPTION
…ict analysis

Extract duplicate package analysis logic from graph command into reusable function and integrate it into constraint file generation. When constraint resolution fails due to conflicting package versions, the system now automatically displays detailed information about which packages have multiple versions and which requirements match which versions.

This enhancement helps users understand why constraint generation failed by showing exactly which packages conflict and what version requirements are causing the conflicts, making debugging dependency issues much easier.

Changes:
- Extract show_explain_duplicates() from explain_duplicates command
- Add show_explain_duplicates() call to write_constraints_file() error path
- Import show_explain_duplicates in bootstrap.py

This adds output like this to the end of a bootstrap job when constraints cannot be resolved:

```
Some packages have multiple version based on different requirements:

dill
  0.3.8
    dill<0.3.9,>=0.3.0 matches ['0.3.8']
      datasets==4.0.0
  0.4.0
    dill>=0.3.8 matches ['0.3.8', '0.4.0']
      multiprocess==0.70.16
  * dill==0.3.8 usable by all consumers

numpy
  1.26.4
    numpy<2,>=1.26.0; python_version >= "3.12" matches ['1.26.4']
      pandas==2.2.1
  2.3.2
    numpy<=2.3.2,>=2.0.0 matches ['2.3.2']
      llmcompressor==0.7.1
    numpy>=1.17 matches ['2.3.2', '1.26.4']
      datasets==4.0.0
      transformers==4.56.0
      transformers==4.55.2
    numpy<3.0.0,>=1.17 matches ['2.3.2', '1.26.4']
      accelerate==1.10.0
  * No single version of numpy meets all requirements

tokenizers
  0.21.4
    tokenizers<0.22,>=0.21 matches ['0.21.4']
      transformers==4.55.2
  0.22.0
    tokenizers<=0.23.0,>=0.22.0 matches ['0.22.0']
      transformers==4.56.0
  * No single version of tokenizers meets all requirements

transformers
  4.55.2
    transformers<=4.55.2,>=4.53.0 matches ['4.55.2']
      llmcompressor==0.7.1
  4.56.0
    transformers matches ['4.56.0', '4.55.2']
      compressed-tensors==0.11.0
  * transformers==4.55.2 usable by all consumers
```
