### PR TITLE
feat(hooks): log loaded hooks on startup for build commands

### DIFF
--- a/e2e/test_prebuilt_wheel_hook.sh
+++ b/e2e/test_prebuilt_wheel_hook.sh
@@ -36,10 +36,18 @@ fromager \
     --settings-dir="$SCRIPTDIR/prebuilt_settings" \
     build-sequence "$OUTDIR/build-order.json"
 
-if ! grep -q "downloading prebuilt wheel ${DIST}==${VERSION}" "$log"; then
-  echo "Lack of message indicating download of prebuilt wheel" 1>&2
-  pass=false
-fi
+PATTERNS=(
+  "downloading prebuilt wheel ${DIST}==${VERSION}"
+  "loaded hook 'post_bootstrap': from package_plugins.hooks"
+  "loaded hook 'post_build': from package_plugins.hooks"
+  "loaded hook 'prebuilt_wheel': from package_plugins.hooks"
+)
+for pattern in $PATTERNS; do
+  if ! grep -q "$pattern" "$log"; then
+    echo "Lack of message indicating $pattern" 1>&2
+    pass=false
+  fi
+done
 
 
 EXPECTED_FILES="
@@ -56,7 +64,7 @@ for f in $EXPECTED_FILES; do
 done
 
 if $pass; then
-  if ! grep -q "${DIST}==${VERSION}" $OUTDIR/work-dir/test-prebuilt.txt; then
+  if ! grep -q "${DIST}==${VERSION}" "$OUTDIR"/work-dir/test-prebuilt.txt; then
     echo "FAIL: Did not find content in post-build hook output file" 1>&2
     pass=false
   fi

--- a/src/fromager/__main__.py
+++ b/src/fromager/__main__.py
@@ -11,6 +11,7 @@ from . import (
     commands,
     context,
     external_commands,
+    hooks,
     log,
     overrides,
     packagesettings,
@@ -215,6 +216,7 @@ def main(
             logger.info(f"constraints file: {constraints_file}")
             logger.info(f"network isolation: {network_isolation}")
             overrides.log_overrides()
+            hooks.log_hooks()
 
     if network_isolation and not SUPPORTS_NETWORK_ISOLATION:
         ctx.fail(f"network isolation is not available: {NETWORK_ISOLATION_ERROR}")


### PR DESCRIPTION
Add logging to display loaded hooks during application startup for build commands. This improves visibility into which hooks are available and being loaded from external packages.

Changes:
- Add log_hooks() function in hooks.py to enumerate and log all available hooks with their source module and distribution info
- Import hooks module in __main__.py and call log_hooks() during startup for commands that show build settings
- Update test_prebuilt_wheel_hook.sh to verify hook loading messages appear in logs and fix shell quoting issue