### PR TITLE
Add ENV variables to control build concurrence

### DIFF
--- a/src/fromager/build_environment.py
+++ b/src/fromager/build_environment.py
@@ -130,6 +130,11 @@ class BuildEnvironment:
         venv_environ["UV_NO_MANAGED_PYTHON"] = "true"
         venv_environ["UV_PYTHON_DOWNLOADS"] = "never"
         venv_environ["UV_PYTHON"] = str(self.python)
+        # Set the maximum number of concurrent builds
+        # for testing an issue with pyzmq
+        venv_environ["UV_CONCURRENT_BUILDS"] = "1"
+        venv_environ["UV_CONCURRENT_DOWNLOADS"] = "1"
+        venv_environ["UV_CONCURRENT_INSTALLS"] = "1"
 
         return venv_environ
 


### PR DESCRIPTION
Add the following env variables:

UV_CONCURRENT_BUILDS
UV_CONCURRENT_DOWNLOADS
UV_CONCURRENT_INSTALLS

```
11:09:17 INFO termcolor-3.1.0: using existing wheel from /mnt/wheels-repo/downloads/termcolor-3.1.0-2-py3-none-any.whl
 91%|██████████████████████████████████▋   | 206/226 [00:38<00:01, 10.08pkg/s]11:09:17 ERROR ipykernel-6.30.1: ['uv', 'pip', 'install', '--verbose', '--upgrade', '--only-binary', ':all:', '--constraint', '/mnt/computed-constraints.txt', '--index-url', 'http://localhost:37267/simple/', '--trusted-host', 'localhost', 'jupyter_client>=6', 'hatchling>=1.4'] failed with DEBUG uv 0.8.15
DEBUG Checking for Python interpreter at path `build-3.12.9/bin/python3`
Using Python 3.12.9 environment at: build-3.12.9
DEBUG Acquired lock for `build-3.12.9`
DEBUG Using request timeout of 30s
DEBUG Solving with installed Python version: 3.12.9
DEBUG Solving with target Python version: >=3.12.9
DEBUG Adding direct dependency: jupyter-client>=6
DEBUG Adding direct dependency: hatchling>=1.4
DEBUG No cache entry for: http://localhost:37267/simple/jupyter-client/
DEBUG No cache entry for: http://localhost:37267/simple/hatchling/
DEBUG Searching for a compatible version of jupyter-client (>=6)
DEBUG Selecting: jupyter-client==8.6.3 [compatible] (jupyter_client-8.6.3-2-py3-none-any.whl)
DEBUG No cache entry for: http://localhost:37267/simple/jupyter-client/jupyter_client-8.6.3-2-py3-none-any.whl
DEBUG No cache entry for: http://localhost:37267/simple/hatchling/hatchling-1.27.0-2-py3-none-any.whl
WARN Range requests not supported for hatchling-1.27.0-2-py3-none-any.whl; streaming wheel
DEBUG No cache entry for: http://localhost:37267/simple/hatchling/hatchling-1.27.0-2-py3-none-any.whl
WARN Range requests not supported for jupyter_client-8.6.3-2-py3-none-any.whl; streaming wheel
DEBUG No cache entry for: http://localhost:37267/simple/jupyter-client/jupyter_client-8.6.3-2-py3-none-any.whl
DEBUG Adding transitive dependency for jupyter-client==8.6.3: jupyter-core>=4.12, <5.0.dev0 | >=5.1.dev0
DEBUG Adding transitive dependency for jupyter-client==8.6.3: python-dateutil>=2.8.2
DEBUG Adding transitive dependency for jupyter-client==8.6.3: pyzmq>=23.0
DEBUG Adding transitive dependency for jupyter-client==8.6.3: tornado>=6.2
DEBUG Adding transitive dependency for jupyter-client==8.6.3: traitlets>=5.3
DEBUG Searching for a compatible version of hatchling (>=1.4)
DEBUG Selecting: hatchling==1.27.0 [compatible] (hatchling-1.27.0-2-py3-none-any.whl)
DEBUG Adding transitive dependency for hatchling==1.27.0: packaging>=24.2
DEBUG Adding transitive dependency for hatchling==1.27.0: pathspec>=0.10.1
DEBUG Adding transitive dependency for hatchling==1.27.0: pluggy>=1.0.0
DEBUG Adding transitive dependency for hatchling==1.27.0: trove-classifiers*
DEBUG No cache entry for: http://localhost:37267/simple/jupyter-core/
DEBUG No cache entry for: http://localhost:37267/simple/python-dateutil/
DEBUG No cache entry for: http://localhost:37267/simple/pyzmq/
DEBUG No cache entry for: http://localhost:37267/simple/tornado/
DEBUG No cache entry for: http://localhost:37267/simple/traitlets/
DEBUG No cache entry for: http://localhost:37267/simple/packaging/
DEBUG No cache entry for: http://localhost:37267/simple/pathspec/
DEBUG No cache entry for: http://localhost:37267/simple/pluggy/
DEBUG No cache entry for: http://localhost:37267/simple/trove-classifiers/
DEBUG Checking netrc for credentials for http://localhost:37267/simple/pyzmq/
DEBUG Acquired lock for `credentials store`
DEBUG Released lock at `/opt/app-root/src/.local/share/uv/credentials/credentials.toml.lock`
DEBUG No credentials file found at /opt/app-root/src/.local/share/uv/credentials/credentials.toml
DEBUG Searching for a compatible version of jupyter-core (>=4.12, <5.0.dev0 | >=5.1.dev0)
DEBUG Selecting: jupyter-core==5.8.1 [compatible] (jupyter_core-5.8.1-2-py3-none-any.whl)
DEBUG No cache entry for: http://localhost:37267/simple/jupyter-core/jupyter_core-5.8.1-2-py3-none-any.whl
DEBUG No cache entry for: http://localhost:37267/simple/python-dateutil/python_dateutil-2.9.0.post0-2-py2.py3-none-any.whl
DEBUG No cache entry for: http://localhost:37267/simple/traitlets/traitlets-5.14.3-2-py3-none-any.whl
DEBUG No cache entry for: http://localhost:37267/simple/tornado/tornado-6.5.2-2-cp39-abi3-linux_aarch64.whl
DEBUG No cache entry for: http://localhost:37267/simple/packaging/packaging-25.0-2-py3-none-any.whl
DEBUG No cache entry for: http://localhost:37267/simple/pathspec/pathspec-0.12.1-2-py3-none-any.whl
DEBUG No cache entry for: http://localhost:37267/simple/trove-classifiers/trove_classifiers-2025.8.26.11-2-py3-none-any.whl
DEBUG Adding transitive dependency for jupyter-core==5.8.1: platformdirs>=2.5
DEBUG Adding transitive dependency for jupyter-core==5.8.1: traitlets>=5.3
DEBUG Searching for a compatible version of python-dateutil (>=2.8.2)
DEBUG Selecting: python-dateutil==2.9.0.post0 [compatible] (python_dateutil-2.9.0.post0-2-py2.py3-none-any.whl)
DEBUG No cache entry for: http://localhost:37267/simple/platformdirs/
DEBUG Adding transitive dependency for python-dateutil==2.9.0.post0: six>=1.5
DEBUG Searching for a compatible version of pyzmq (>=23.0)
DEBUG No compatible version found for: pyzmq
DEBUG Recording unit propagation conflict of pyzmq from incompatibility of (jupyter-client)
DEBUG Searching for a compatible version of jupyter-client (>=6, <8.6.3 | >8.6.3)
DEBUG No compatible version found for: jupyter-client
DEBUG No cache entry for: http://localhost:37267/simple/six/
DEBUG No cache entry for: http://localhost:37267/simple/platformdirs/platformdirs-4.4.0-2-py3-none-any.whl
DEBUG No cache entry for: http://localhost:37267/simple/six/six-1.17.0-2-py2.py3-none-any.whl
DEBUG No cache entry for: http://localhost:37267/simple/pluggy/pluggy-1.6.0-2-py3-none-any.whl
  × No solution found when resolving dependencies:
  ╰─▶ Because pyzmq was not found in the package registry and
      jupyter-client==8.6.3 depends on pyzmq>=23.0, we can conclude that
      jupyter-client==8.6.3 cannot be used.
      And because only jupyter-client==8.6.3 is available and you require
      jupyter-client==8.6.3, we can conclude that your requirements are
      unsatisfiable.
DEBUG Released lock at `/mnt/work-dir/ipykernel-6.30.1/build-3.12.9/.lock`
11:09:17 ERROR ipykernel-6.30.1: ipykernel: failed to install build-system dependencies {<Requirement('jupyter_client>=6')>, <Requirement('hatchling>=1.4')>}: Command '['uv', 'pip', 'install', '--verbose', '--upgrade', '--only-binary', ':all:', '--constraint', '/mnt/computed-constraints.txt', '--index-url', 'http://localhost:37267/simple/', '--trusted-host', 'localhost', 'jupyter_client>=6', 'hatchling>=1.4']' returned non-zero exit status 1.
11:09:17 INFO ipykernel-6.30.1: looking for candidates for <Requirement('jupyter_client>=6')>
11:09:17 INFO ipykernel-6.30.1: selecting <jupyter-client==8.6.3>
11:09:17 INFO ipykernel-6.30.1: successfully resolved <Requirement('jupyter_client>=6')>
11:09:17 INFO ipykernel-6.30.1: looking for candidates for <Requirement('hatchling>=1.4')>
11:09:17 INFO ipykernel-6.30.1: selecting <hatchling==1.27.0>
11:09:17 INFO ipykernel-6.30.1: successfully resolved <Requirement('hatchling>=1.4')>
11:09:17 ERROR Failed to build ipykernel==6.30.1: 
****************************************
Failed to install build-system dependency Because pyzmq was not found in the package registry. Check all build-system dependencies:
jupyter_client>=6 -> 8.6.3
hatchling>=1.4 -> 1.27.0
****************************************
 92%|██████████████████████████████████▊   | 207/226 [00:38<00:03,  5.38pkg/s]
11:09:17 ERROR ERROR: 
****************************************
Failed to install build-system dependency Because pyzmq was not found in the package registry. Check all build-system dependencies:
jupyter_client>=6 -> 8.6.3
hatchling>=1.4 -> 1.27.0
****************************************
 because Command '['uv', 'pip', 'install', '--verbose', '--upgrade', '--only-binary', ':all:', '--constraint', '/mnt/computed-constraints.txt', '--index-url', 'http://localhost:37267/simple/', '--trusted-host', 'localhost', 'jupyter_client>=6', 'hatchling>=1.4']' returned non-zero exit status 1.
```