### PR TITLE
fix: always run prebuilt_wheel hook

### DIFF
--- a/src/fromager/commands/build.py
+++ b/src/fromager/commands/build.py
@@ -377,6 +377,10 @@ def _build(
             wheel_url=source_download_url,
             output_directory=wkctx.wheels_build,
         )
+    # We may have downloaded the prebuilt wheel in _is_wheel_built or
+    # via download_wheel(). Regardless, if it was a prebuilt wheel,
+    # run the hooks.
+    if prebuilt and wheel_filename:
         hooks.run_prebuilt_wheel_hooks(
             ctx=wkctx,
             req=req,


### PR DESCRIPTION
There are 2 potential places the prebuilt wheel could be downloaded,
and we want to always run the hook regardless of which place does the
download.