### PR TITLE
fix: don't run `uv cache clean` in parallel with `uv pip install`

### DIFF
--- a/src/fromager/bootstrapper.py
+++ b/src/fromager/bootstrapper.py
@@ -422,6 +422,8 @@ class Bootstrapper:
             version=resolved_version,
             build_env=build_env,
         )
+        # invalidate uv cache
+        self.ctx.uv_clean_cache(req)
         server.update_wheel_mirror(self.ctx)
         # When we update the mirror, the built file moves to the
         # downloads directory.

--- a/src/fromager/build_environment.py
+++ b/src/fromager/build_environment.py
@@ -240,17 +240,6 @@ class BuildEnvironment:
         mapping = json.loads(result.strip())
         return {name: Version(version) for name, version in sorted(mapping.items())}
 
-    def clean_cache(self, req: Requirement) -> None:
-        """Invalidate and clean uv cache for requirement
-
-        uv caches package metadata and unpacked wheels for faster dependency
-        resolution and installation. ``uv pip install`` hardlinks files from
-        cache location. This function removes a package from all caches, so
-        subsequent installations use a new built.
-        """
-        logger.debug("invalidate uv cache for %s", req.name)
-        self.run(["uv", "cache", "clean", req.name])
-
 
 @metrics.timeit(description="prepare build environment")
 def prepare_build_environment(

--- a/src/fromager/commands/step.py
+++ b/src/fromager/commands/step.py
@@ -224,5 +224,6 @@ def build_wheel(
         version=dist_version,
         build_env=build_env,
     )
+    wkctx.uv_clean_cache(req)
     requirement_ctxvar.reset(token)
     print(wheel_filename)

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -336,9 +336,6 @@ def build_wheel(
         build_dir=pbi.build_dir(sdist_root_dir),
     )
 
-    # invalidate uv's cache
-    build_env.clean_cache(req)
-
     wheels = list(ctx.wheels_build.glob("*.whl"))
     if len(wheels) != 1:
         raise FileNotFoundError(


### PR DESCRIPTION
Refactor the code so `uv cache` is cleaned up after each batch of build wheels. Before there was a possibility that `uv cache clean` and `uv pip install` were running at the same time.

Fixes: #756