### PR TITLE
fix: report skipped builds

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -21,7 +21,7 @@ jobs:
           python-version: "3.11"  # minimum supported lang version
 
       - name: Install dependencies
-        run: python -m pip install hatch
+        run: python -m pip install hatch 'click!=8.3.0'
 
       - name: Run
         run: hatch run lint:check
@@ -42,7 +42,7 @@ jobs:
           python-version: "3.11"  # minimum supported lang version
 
       - name: Install dependencies
-        run: python -m pip install hatch
+        run: python -m pip install hatch 'click!=8.3.0'
 
       - name: Check MyPy
         run: hatch run mypy:check
@@ -63,7 +63,7 @@ jobs:
           python-version: "3.11"  # minimum supported lang version
 
       - name: Install dependencies
-        run: python -m pip install hatch
+        run: python -m pip install hatch 'click!=8.3.0'
 
       - name: Run
         run: hatch run lint:pkglint
@@ -100,7 +100,7 @@ jobs:
           python-version: "3.11"  # minimum supported lang version
 
       - name: Install dependencies
-        run: python -m pip install hatch
+        run: python -m pip install hatch 'click!=8.3.0'
 
       - name: Run
         run: hatch run docs:build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,7 +47,7 @@ jobs:
         run: unshare -rn echo "unshare works"
 
       - name: Install dependencies
-        run: python -m pip install hatch
+        run: python -m pip install hatch 'click!=8.3.0'
 
       - name: Run tests
         run: hatch run test:test
@@ -142,7 +142,7 @@ jobs:
         run: unshare -rn echo "unshare works"
 
       - name: Install dependencies
-        run: python -m pip install hatch
+        run: python -m pip install hatch 'click!=8.3.0'
 
       - name: Run tests
         run: ./e2e/test_${{ matrix.test-script }}.sh
@@ -184,7 +184,7 @@ jobs:
             **/pyproject.toml
 
       - name: Install dependencies
-        run: python -m pip install hatch
+        run: python -m pip install hatch 'click!=8.3.0'
 
       - name: Download coverage data
         uses: actions/download-artifact@v5

--- a/e2e/test_build_order.sh
+++ b/e2e/test_build_order.sh
@@ -109,7 +109,7 @@ if ! grep -q "skipping builds for versions of packages available" "$log"; then
   echo "Did not find message indicating builds would be skipped" 1>&2
   pass=false
 fi
-if ! grep -q "${DIST}-${VERSION}: using existing wheel" "$log"; then
+if ! grep -q "skipping building wheel since ${DIST}-${VERSION}-" "$log"; then
   echo "Did not find message indicating build of stevedore was skipped" 1>&2
   pass=false
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ test = [
     "twine>=6.1.0",
     "hatchling",
     "hatch-vcs",
+    "click!=8.3.0",
 ]
 docs = [
     "sphinx",


### PR DESCRIPTION
The build command now reports skipped builds again. Commit 330958e introduced a regression and did not set `BuildSequenceEntry.skipped` attribute any more.

The internal `_build` command now returns a `BuildSequenceEntry` object instead of `tuple[pathlibPath, bool]`. This change allows us to track properties like skipped and prebuilt more easily.

Also refactored `BuildSequenceEntry` to be a frozen, ordered, and hashable data class. Instances of the class are compared, sorted, and hashed by name and version.

Fixes: #769