### PR TITLE
fix: build installation dependencies before building consumers

### DIFF
--- a/src/fromager/commands/build.py
+++ b/src/fromager/commands/build.py
@@ -643,13 +643,17 @@ def build_parallel(
                 with req_ctxvar_context(
                     Requirement(node.canonicalized_name), node.version
                 ):
-                    # Get all build dependencies (build-system, build-backend, build-sdist)
+                    # Get all dependencies. If package A needs package B to be
+                    # installed, package B should not have a build dependency on
+                    # package A. So, building the installation dependencies of a
+                    # package before we build that package should be possible,
+                    # and doing so ensures that when we mark a package as ready
+                    # to be used for building other packages, all of the
+                    # installation dependencies are also ready.
                     build_deps: DependencyNodeList = [
-                        edge.destination_node
-                        for edge in node.children
-                        if edge.req_type.is_build_requirement
+                        edge.destination_node for edge in node.children
                     ]
-                    # A node can be built when all of its build dependencies are built
+                    # A node can be built when all of its dependencies are built
                     unbuilt_deps: set[str] = set(
                         dep.key for dep in build_deps if dep.key not in built_node_keys
                     )


### PR DESCRIPTION
Change the way we determine whether a package is ready to be built in
build-parallel so that we build its installation dependencies before we
build it.

Logically it should not be possible for package A installation
dependencies to depend in any way on A, so this ordering should be
safe. The change ensures that when we mark A as built, it is actually
ready to be consumed in build environments for other packages.

Addresses #755