### PR TITLE
feat: add --build-wheel-server-url option

### DIFF
--- a/docs/how-tos/build-web-server.rst
+++ b/docs/how-tos/build-web-server.rst
@@ -1,0 +1,18 @@
+Using an External Build Web Server
+==================================
+
+By default, fromager runs its own internal web server to provide
+wheels as build requirements for packages that it builds. It maintains
+the content for the server by building or downloading wheels as it
+bootstraps or builds packages.
+
+For very large sets of dependencies, the internal web server may not
+perform well and will either result in errors in the logs, or
+potentially failed builds. In these cases it is straightforward to
+tell fromager that another web server is hosting the content that it
+is managing, and that it does not need to run an internal server by
+using the ``--build-wheel-server-url`` option.
+
+.. code-block:: console
+
+   $ fromager --build-wheel-server-url http://localhost:8080/simple/ bootstrap my-package

--- a/src/fromager/__main__.py
+++ b/src/fromager/__main__.py
@@ -80,6 +80,10 @@ else:
     help="location to manage wheel repository",
 )
 @click.option(
+    "--build-wheel-server-url",
+    help="An optional URL for external web server for building wheels, to replace the built-in server. Must be configured to serve the path specified for --wheels-repo.",
+)
+@click.option(
     "-t",
     "--work-dir",
     default=pathlib.Path("work-dir"),
@@ -149,6 +153,7 @@ def main(
     error_log_file: pathlib.Path,
     sdists_repo: pathlib.Path,
     wheels_repo: pathlib.Path,
+    build_wheel_server_url: str,
     work_dir: pathlib.Path,
     patches_dir: pathlib.Path,
     settings_file: pathlib.Path,
@@ -215,6 +220,10 @@ def main(
             logger.info(f"maximum concurrent jobs: {jobs}")
             logger.info(f"constraints file: {constraints_file}")
             logger.info(f"network isolation: {network_isolation}")
+            if build_wheel_server_url:
+                logger.info(f"external build wheel server: {build_wheel_server_url}")
+            else:
+                logger.info("using internal build wheel server")
             overrides.log_overrides()
             hooks.log_hooks()
 
@@ -233,6 +242,7 @@ def main(
         patches_dir=patches_dir,
         sdists_repo=sdists_repo,
         wheels_repo=wheels_repo,
+        wheel_server_url=build_wheel_server_url,
         work_dir=work_dir,
         cleanup=cleanup,
         variant=variant,

--- a/src/fromager/context.py
+++ b/src/fromager/context.py
@@ -45,6 +45,7 @@ class WorkContext:
         network_isolation: bool = False,
         max_jobs: int | None = None,
         settings_dir: pathlib.Path | None = None,
+        wheel_server_url: str = "",
     ):
         if active_settings is None:
             active_settings = packagesettings.Settings(
@@ -73,7 +74,7 @@ class WorkContext:
         self.work_dir = pathlib.Path(work_dir).resolve()
         self.graph_file = self.work_dir / "graph.json"
         self.uv_cache = self.work_dir / "uv-cache"
-        self.wheel_server_url = ""
+        self.wheel_server_url = wheel_server_url
         self.logs_dir = self.work_dir / "logs"
         self.cleanup = cleanup
         # separate value so bootstrap-parallel can keep build envs


### PR DESCRIPTION
Add a command line flag to let the user specify that there is an alternative web server running and serving the content of the wheels-repo so that fromager does not need to start its own internal server.

Fixes #768 