### PR TITLE
feat: uv cache clean is concurrency safe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "tomlkit",
     "tqdm",
     "wheel",
-    "uv",
+    "uv>=0.8.19",
 ]
 
 [project.optional-dependencies]

--- a/src/fromager/bootstrapper.py
+++ b/src/fromager/bootstrapper.py
@@ -422,8 +422,6 @@ class Bootstrapper:
             version=resolved_version,
             build_env=build_env,
         )
-        # invalidate uv cache
-        self.ctx.uv_clean_cache(req)
         server.update_wheel_mirror(self.ctx)
         # When we update the mirror, the built file moves to the
         # downloads directory.

--- a/src/fromager/commands/build.py
+++ b/src/fromager/commands/build.py
@@ -118,8 +118,6 @@ def build(
             force=True,
             cache_wheel_server_url=None,
         )
-        # invalidate uv cache
-        wkctx.uv_clean_cache(req)
     print(entry.wheel_filename)
 
 
@@ -435,8 +433,6 @@ def _build(
             version=resolved_version,
             build_env=build_env,
         )
-        # uv cache is cleaned in build / build_parallel commands
-        # wkctx.uv_clean_cache(req)
 
         hooks.run_post_build_hooks(
             ctx=wkctx,
@@ -726,9 +722,6 @@ def build_parallel(
                     except Exception as e:
                         logger.error(f"Failed to build {node.key}: {e}")
                         raise
-
-                # invalidate uv cache
-                wkctx.uv_clean_cache(*reqs)
 
     metrics.summarize(wkctx, "Building in parallel")
     _summary(wkctx, entries)

--- a/src/fromager/commands/step.py
+++ b/src/fromager/commands/step.py
@@ -224,6 +224,5 @@ def build_wheel(
         version=dist_version,
         build_env=build_env,
     )
-    wkctx.uv_clean_cache(req)
     requirement_ctxvar.reset(token)
     print(wheel_filename)

--- a/src/fromager/context.py
+++ b/src/fromager/context.py
@@ -141,7 +141,7 @@ class WorkContext:
         cache location. This function removes a package from all caches, so
         subsequent installations use a new built.
 
-        WARNING: 'uv clean cache' is not concurrency safe with 'uv pip install'.
+        'uv clean cache' is concurrency safe since 0.8.19.
         """
         if not reqs:
             raise ValueError("no requirements")

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -361,6 +361,11 @@ def build_wheel(
     )
     validate_wheel_filename(req=req, version=version, wheel_file=new_wheel_file)
 
+    # invalidate uv cache, so the new wheel is picked up. The step is only
+    # relevant for local development when a package is rebuilt multiple times
+    # without bumping the build tag.
+    ctx.uv_clean_cache(req)
+
     return new_wheel_file
 
 


### PR DESCRIPTION
Astral has improved uv to make cache clean and installation concurrency safe. The uv cache can now be cleaned up directly after a new wheel is placed in the wheel repo.