### PR TITLE
chore: use dataclass for DependencyNode

### DIFF
--- a/tests/test_dependency_graph.py
+++ b/tests/test_dependency_graph.py
@@ -1,0 +1,61 @@
+import dataclasses
+
+import pytest
+from packaging.utils import canonicalize_name
+from packaging.version import Version
+
+from fromager.dependency_graph import DependencyNode
+
+
+def mknode(name: str, version: str = "1.0", **kwargs) -> DependencyNode:
+    return DependencyNode(canonicalize_name(name), Version(version), **kwargs)
+
+
+def test_dependencynode_compare() -> None:
+    a_10 = mknode("a", "1.0")
+    a_20 = mknode("a", "2.0")
+    b = mknode("b", "1.0")
+    assert a_10 == a_10
+    assert not a_10 == a_20
+    assert a_10 != a_20
+    assert a_10 != b
+    assert a_10 == mknode("a", "1.0")
+    assert a_10 < a_20
+    assert a_10 <= a_10
+    assert a_10 >= a_10
+    assert b > a_10
+    assert b > a_20
+
+
+def test_dependencynode_hash() -> None:
+    a_10 = mknode("a", "1.0")
+    a_20 = mknode("a", "2.0")
+    b = mknode("b", "1.0")
+    s = {a_10, a_10, a_20}
+    assert s == {a_10, a_20}
+    assert a_10 in s
+    assert b not in s
+
+    s = {mknode("a"), mknode("a")}
+    assert len(s) == 1
+    assert s == {mknode("a")}
+
+
+def test_dependencynode_dataclass():
+    a = mknode("a", "1.0")
+    assert a.canonicalized_name == "a"
+    assert a.version == Version("1.0")
+    assert a.key == "a==1.0"
+    assert (
+        repr(a)
+        == "DependencyNode(canonicalized_name='a', version=<Version('1.0')>, download_url='', pre_built=False)"
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        a.version = Version("2.0")
+    with pytest.raises((TypeError, AttributeError)):
+        a.new_attribute = None
+
+    root = DependencyNode.construct_root_node()
+    assert root.canonicalized_name == ""
+    assert root.version == Version("0.0")
+    assert root.key == ""


### PR DESCRIPTION
Convert the `DependencyNode` and `DependencyEdge` into data classes. The classes are frozen (immutable) and support comparison, sorting, and hashing.