### PR TITLE
feat(lint): add requirement resolution to lint-requirements command

### DIFF
--- a/src/fromager/commands/lint_requirements.py
+++ b/src/fromager/commands/lint_requirements.py
@@ -5,7 +5,9 @@ import sys
 import click
 from packaging.requirements import InvalidRequirement, Requirement
 
-from fromager import requirements_file
+from fromager import bootstrapper, context, progress, requirements_file
+from fromager.log import requirement_ctxvar
+from fromager.requirements_file import RequirementType
 
 logger = logging.getLogger(__name__)
 
@@ -17,13 +19,17 @@ logger = logging.getLogger(__name__)
     required=True,
     type=click.Path(exists=False, path_type=pathlib.Path),
 )
-def lint_requirements(input_files_path: list[pathlib.Path]) -> None:
+@click.pass_obj
+def lint_requirements(
+    wkctx: context.WorkContext, input_files_path: list[pathlib.Path]
+) -> None:
     """
     Command to lint the constraints.txt and requirements.txt files
     This command takes a single wildcard path string for constraints.txt and requirements.txt.
     It checks the formatting of these files and reports issues if found. Files with names that
     end with constraints.txt (e.g. constraints.txt, global-constraints.txt, etc.) are not allowed
-    to contain extra dependencies.
+    to contain extra dependencies. Additionally, it resolves valid input requirements to ensure
+    we can find a matching version of each package.
     """
 
     if len(input_files_path) == 0:
@@ -31,6 +37,15 @@ def lint_requirements(input_files_path: list[pathlib.Path]) -> None:
         sys.exit(1)
 
     flag = True
+
+    # Create bootstrapper for requirement resolution
+    bt = bootstrapper.Bootstrapper(
+        ctx=wkctx,
+        progressbar=progress.Progressbar(None),
+        prev_graph=None,
+        cache_wheel_server_url=None,
+        sdist_only=True,
+    )
 
     for path in input_files_path:
         parsed_lines = requirements_file.parse_requirements_file(path)
@@ -47,6 +62,24 @@ def lint_requirements(input_files_path: list[pathlib.Path]) -> None:
                     raise InvalidRequirement(
                         "Constraints files cannot contain extra dependencies"
                     )
+
+                # Resolve the requirement to ensure it can be found
+                # Skip resolution for constraints files as they should only specify versions
+                if not path.name.endswith("constraints.txt"):
+                    token = requirement_ctxvar.set(requirement)
+                    try:
+                        _, version = bt.resolve_version(
+                            req=requirement,
+                            req_type=RequirementType.TOP_LEVEL,
+                        )
+                        logger.info(f"{requirement} resolves to {version}")
+                    except Exception as resolve_err:
+                        logger.error(
+                            f"{path}: {line}: Failed to resolve requirement: {resolve_err}"
+                        )
+                        flag = False
+                    finally:
+                        requirement_ctxvar.reset(token)
             except InvalidRequirement as err:
                 logger.error(f"{path}: {line}: {err}")
                 flag = False


### PR DESCRIPTION
Enhance the lint-requirements command to resolve valid input requirements using the same logic as the bootstrap command. This ensures that all requirements in requirements.txt files can be found and resolved to specific versions before proceeding with builds.

Changes:
- Add Bootstrapper integration for requirement resolution
- Resolve requirements files but skip constraints files
- Add proper error handling for resolution failures
- Use same resolution logic as bootstrap command with TOP_LEVEL requirement type
- Maintain existing validation for syntax and duplicate entries

The command now validates both syntax correctness and package availability, providing comprehensive linting for requirement specifications.

Chat log: https://gist.github.com/dhellmann/4b2bdc1012edce6870845641f87b10ae

Co-authored-by: Claude 3.5 Sonnet (Anthropic AI Assistant)