### PR TITLE
fix: ensure we compare canonicalized versions of names

### DIFF
--- a/src/fromager/dependencies.py
+++ b/src/fromager/dependencies.py
@@ -375,13 +375,20 @@ def validate_dist_name_version(
 ) -> None:
     """Validate that dist name and version matches expected values"""
     req_name = canonicalize_name(req.name)
-    if dist_name != req_name:
-        raise ValueError(f"{what} does not match requirement {req_name!r}")
+    c_dist_name = canonicalize_name(dist_name)
+    if c_dist_name != req_name:
+        raise ValueError(
+            f"{what} {c_dist_name!r} does not match requirement {req_name!r}"
+        )
     if dist_version != version:
         if dist_version.public != version.public:
-            raise ValueError(f"{what} does not match public version {version!r}")
+            raise ValueError(
+                f"{what} {dist_version.public!r} does not match public version {version!r}"
+            )
         else:
-            logger.warning(f"{what} has different local version than {version!r}")
+            logger.warning(
+                f"{what} {dist_version.public!r} has different local version than {version!r}"
+            )
 
 
 def get_install_dependencies_of_wheel(

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from packaging.requirements import Requirement
+from packaging.version import Version
 
 from fromager import build_environment, context, dependencies
 
@@ -206,3 +207,49 @@ def test_get_build_sdist_dependencies_cached(
         build_env=build_env,
     )
     assert results == set([Requirement("foo==1.0")])
+
+
+def test_validate_dist_name_version_underscore() -> None:
+    req = Requirement("huggingface-hub")
+    ver = Version("0.35.1")
+    what = "sdist metadata"
+    dist_name = "huggingface_hub"
+    dist_version = Version("0.35.1")
+    try:
+        dependencies.validate_dist_name_version(req, ver, what, dist_name, dist_version)
+    except ValueError as err:
+        pytest.fail(f"Unexpected ValueError: {err}")
+
+
+def test_validate_dist_name_version_dash() -> None:
+    req = Requirement("huggingface-hub")
+    ver = Version("0.35.1")
+    what = "sdist metadata"
+    dist_name = "huggingface-hub"
+    dist_version = Version("0.35.1")
+    try:
+        dependencies.validate_dist_name_version(req, ver, what, dist_name, dist_version)
+    except ValueError as err:
+        pytest.fail(f"Unexpected ValueError: {err}")
+
+
+def test_validate_dist_name_version_case() -> None:
+    req = Requirement("huggingface-hub")
+    ver = Version("0.35.1")
+    what = "sdist metadata"
+    dist_name = "HuggingFace_Hub"
+    dist_version = Version("0.35.1")
+    try:
+        dependencies.validate_dist_name_version(req, ver, what, dist_name, dist_version)
+    except ValueError as err:
+        pytest.fail(f"Unexpected ValueError: {err}")
+
+
+def test_validate_dist_name_version_no_match() -> None:
+    req = Requirement("huggingface-hub")
+    ver = Version("0.35.1")
+    what = "sdist metadata"
+    dist_name = "huggingfacehub"
+    dist_version = Version("0.35.1")
+    with pytest.raises(ValueError):
+        dependencies.validate_dist_name_version(req, ver, what, dist_name, dist_version)


### PR DESCRIPTION
The validation of sdist metadata for packages is very loose and does not ensure that the sdist values match the canonical values. We should canonicalize the names before we compare them to avoid false negatives.