### PR TITLE
fix(build): correct skipped status in build-sequence-summary.json

### DIFF
--- a/src/fromager/commands/build.py
+++ b/src/fromager/commands/build.py
@@ -363,22 +363,21 @@ def _build(
             logger.info("using existing wheel from %s", wheel_filename)
             use_exiting_wheel = True
 
-    # See if we can download a prebuilt wheel.
-    if prebuilt and not wheel_filename:
-        logger.info("downloading prebuilt wheel")
-        wheel_filename = wheels.download_wheel(
-            req=req,
-            wheel_url=source_download_url,
-            output_directory=wkctx.wheels_build,
-        )
-    else:
-        # already downloaded
-        use_exiting_wheel = True
+    # Handle prebuilt wheels.
+    if prebuilt:
+        if not wheel_filename:
+            logger.info("downloading prebuilt wheel")
+            wheel_filename = wheels.download_wheel(
+                req=req,
+                wheel_url=source_download_url,
+                output_directory=wkctx.wheels_build,
+            )
+        else:
+            # already downloaded prebuilt wheel
+            use_exiting_wheel = True
 
-    # We may have downloaded the prebuilt wheel in _is_wheel_built or
-    # via download_wheel(). Regardless, if it was a prebuilt wheel,
-    # run the hooks.
-    if prebuilt and wheel_filename:
+        # Run hooks for prebuilt wheels. At this point wheel_filename should
+        # be set either from _is_wheel_built() or download_wheel().
         hooks.run_prebuilt_wheel_hooks(
             ctx=wkctx,
             req=req,


### PR DESCRIPTION
Fix incorrect logic that marked all non-prebuilt wheels as skipped when using --cache-wheel-server-url. The bug was in the _build() function where an else clause unconditionally set use_exiting_wheel=True for all non-prebuilt packages, regardless of whether they were actually built or reused.

Changes:
- Only set use_exiting_wheel=True when we actually have an existing wheel
- Consolidate duplicate prebuilt wheel checks into single block
- Eliminate redundant wheel_filename validation
- Add test validation for build-sequence-summary.json content

The fix ensures packages built from source show skipped=false and packages using existing wheels show skipped=true in the summary file.

Closes: #777

Chat log: https://gist.github.com/dhellmann/55da9cedbc977fe644f2c7584c7d1762

Co-authored-by: Claude 3.5 Sonnet (Anthropic AI Assistant)