### PR TITLE
fix: don't treat bad sdist metadata as fatal error

### DIFF
--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -692,7 +692,7 @@ PKG_INFO_CONTENT = """\
 Metadata-Version: 1.0
 Name: {name}
 Version: {version}
-Summary: Fromage stub PKG-INFO
+Summary: {summary}
 """
 
 
@@ -726,6 +726,7 @@ def ensure_pkg_info(
                 PKG_INFO_CONTENT.format(
                     name=req.name,
                     version=str(version),
+                    summary=dependencies.STUB_PKG_INFO_SUMMARY,
                 )
             )
             had_pkg_info = False


### PR DESCRIPTION
`default_get_install_dependencies_of_sdist` no longer treats bad sdist metadata as a fatal error. The function now logs a non-fatal error message to inform the user of potential issues.

Fromager stub metadata is no longer validated at all. It likely contains a wrong version number.