### PR TITLE
fix: improve network isolation

### DIFF
--- a/src/fromager/external_commands.py
+++ b/src/fromager/external_commands.py
@@ -39,7 +39,7 @@ def detect_network_isolation() -> None:
     cmd = network_isolation_cmd()
     if os.name == "posix":
         check = [*cmd, "true"]
-        subprocess.check_call(check, stderr=subprocess.STDOUT)
+        subprocess.check_output(check, stderr=subprocess.STDOUT)
 
 
 class NetworkIsolationError(subprocess.CalledProcessError):

--- a/src/fromager/run_network_isolation.sh
+++ b/src/fromager/run_network_isolation.sh
@@ -22,11 +22,18 @@ if [ "$#" -eq 0 ]; then
 fi
 
 # bring loopback up
-ip link set lo up
+if command -v ip 2>&1 >/dev/null; then
+   ip link set lo up
+else
+   echo "'ip' command is missing, cannot bring up loopback device for $@" >&2
+   exit 2
+fi
 
 # set hostname to "localhost"
 if command -v hostname 2>&1 >/dev/null; then
    hostname localhost
+else
+   echo "'hostname' command is missing, cannot set host name to 'localhost' for $@" >&2
 fi
 
 # replace with command


### PR DESCRIPTION
Use `check_output` instead of `check_call` in network isolation detection helper. It captures the output to stdout and avoid spurious warnings about missing commands.

Add debug code to `run_network_isolation.sh` script. The script detects missing `ip` command and prints debug message + arguments on error.