### PR TITLE
feat(settings): add version-specific prebuilt wheel configuration

### DIFF
--- a/docs/how-tos/version-specific-prebuilt.rst
+++ b/docs/how-tos/version-specific-prebuilt.rst
@@ -1,0 +1,81 @@
+Version-Specific Prebuilt Settings
+===================================
+
+When working with multiple collections that share the same variant but need
+different versions of a package, you may want some versions to use prebuilt
+wheels while others are built from source.
+
+Version-specific prebuilt settings allow you to configure ``pre_built`` and
+``wheel_server_url`` on a per-version basis within a variant, providing
+fine-grained control over which package versions use prebuilt wheels.
+
+Configuration
+-------------
+
+Add version-specific settings under the ``versions`` key within a variant:
+
+.. code-block:: yaml
+
+   # overrides/settings/torchvision.yaml
+   variants:
+     tpu-ubi9:
+       # Default behavior for unlisted versions
+       pre_built: false
+       
+       # Version-specific overrides  
+       versions:
+         # Use prebuilt wheel for this version
+         "0.24.0.dev20250730":
+           pre_built: true
+           wheel_server_url: https://gitlab.com/api/v4/projects/12345/packages/pypi/simple
+           
+         # Build from source for this version
+         "0.23.0":
+           pre_built: false
+
+Available Settings
+------------------
+
+Within each version-specific block, you can configure:
+
+``pre_built``
+  Boolean indicating whether to use prebuilt wheels for this version.
+  
+``wheel_server_url``
+  URL to download prebuilt wheels from for this version.
+  
+``env``
+  Environment variables specific to this version.
+
+``annotations``
+  Version-specific annotations.
+
+Precedence Rules
+----------------
+
+Version-specific settings override variant-wide settings. If both are defined,
+environment variables are merged with version-specific values taking precedence
+for conflicting keys.
+
+Example Use Case
+----------------
+
+Consider two TPU collections using different ``torchvision`` versions:
+
+**Global Collection** (``collections/accelerated/tpu-ubi9/requirements.txt``):
+
+.. code-block:: text
+
+   torchvision==0.24.0.dev20250730
+
+**Torch-2.8.0 Collection** (``collections/torch-2.8.0/tpu-ubi9/requirements.txt``):
+
+.. code-block:: text
+
+   torchvision==0.23.0
+
+With the configuration above:
+
+- Global collection downloads prebuilt ``torchvision==0.24.0.dev20250730`` wheels
+- Torch-2.8.0 collection builds ``torchvision==0.23.0`` from source
+- Both use the same variant (``tpu-ubi9``) with different build methods

--- a/src/fromager/commands/build.py
+++ b/src/fromager/commands/build.py
@@ -345,10 +345,14 @@ def _build(
 
     logger.info("starting processing")
     pbi = wkctx.package_build_info(req)
-    prebuilt = pbi.pre_built
+    # Use version-aware prebuilt check now that we have resolved_version
+    prebuilt = pbi.is_pre_built(resolved_version)
 
     wheel_server_urls = wheels.get_wheel_server_urls(
-        wkctx, req, cache_wheel_server_url=cache_wheel_server_url
+        wkctx,
+        req,
+        cache_wheel_server_url=cache_wheel_server_url,
+        version=resolved_version,
     )
 
     # See if we can reuse an existing wheel.

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -450,13 +450,21 @@ def _download_wheel_check(
 
 
 def get_wheel_server_urls(
-    ctx: context.WorkContext, req: Requirement, *, cache_wheel_server_url: str | None
+    ctx: context.WorkContext,
+    req: Requirement,
+    *,
+    cache_wheel_server_url: str | None,
+    version: Version | str | None = None,
 ) -> list[str]:
     pbi = ctx.package_build_info(req)
     wheel_server_urls: list[str] = []
-    if pbi.wheel_server_url:
+    # Use version-aware wheel server URL lookup if version is available
+    wheel_server_url = (
+        pbi.get_wheel_server_url(version) if version else pbi.wheel_server_url
+    )
+    if wheel_server_url:
         # use only the wheel server from settings if it is defined. Do not fallback to other URLs
-        wheel_server_urls.append(pbi.wheel_server_url)
+        wheel_server_urls.append(wheel_server_url)
     else:
         if ctx.wheel_server_url:
             # local wheel server

--- a/tests/test_packagesettings.py
+++ b/tests/test_packagesettings.py
@@ -87,6 +87,7 @@ FULL_EXPECTED: dict[str, typing.Any] = {
             "env": {"EGG": "spam ${EGG}", "EGG_AGAIN": "$EGG"},
             "wheel_server_url": "https://wheel.test/simple",
             "pre_built": False,
+            "versions": {},
         },
         "rocm": {
             "annotations": {
@@ -95,12 +96,14 @@ FULL_EXPECTED: dict[str, typing.Any] = {
             "env": {"SPAM": ""},
             "wheel_server_url": None,
             "pre_built": True,
+            "versions": {},
         },
         "cuda": {
             "annotations": None,
             "env": {},
             "wheel_server_url": None,
             "pre_built": False,
+            "versions": {},
         },
     },
 }
@@ -182,6 +185,7 @@ PREBUILT_PKG_EXPECTED: dict[str, typing.Any] = {
             "env": {},
             "pre_built": True,
             "wheel_server_url": None,
+            "versions": {},
         },
     },
 }

--- a/tests/test_version_specific_prebuilt.py
+++ b/tests/test_version_specific_prebuilt.py
@@ -1,0 +1,183 @@
+"""Test version-specific prebuilt settings functionality."""
+
+import pathlib
+import typing
+
+from fromager.packagesettings import (
+    PackageBuildInfo,
+    PackageSettings,
+    Settings,
+    Variant,
+)
+
+
+class MockSettings:
+    """Mock settings object for testing PackageBuildInfo."""
+
+    def __init__(self, variant: str = "tpu-ubi9", max_jobs: int | None = None) -> None:
+        self._variant = Variant(variant)
+        self._patches_dir: pathlib.Path | None = None
+        self._max_jobs = max_jobs
+
+    @property
+    def variant(self) -> Variant:
+        return self._variant
+
+    @property
+    def patches_dir(self) -> pathlib.Path | None:
+        return self._patches_dir
+
+    @property
+    def max_jobs(self) -> int | None:
+        return self._max_jobs
+
+    def variant_changelog(self) -> list[str]:
+        return []
+
+
+def test_version_specific_prebuilt_settings() -> None:
+    """Test that version-specific prebuilt settings override variant defaults."""
+    package_data = {
+        "variants": {
+            "tpu-ubi9": {
+                "pre_built": False,
+                "wheel_server_url": "https://default.example.com/simple/",
+                "versions": {
+                    "2.9.0.dev20250730": {
+                        "pre_built": True,
+                        "wheel_server_url": "https://prebuilt.example.com/simple/",
+                    },
+                    "0.24.0.dev20250730": {
+                        "pre_built": True,
+                    },
+                    "2.8.0": {
+                        "pre_built": False,
+                    },
+                },
+            }
+        }
+    }
+
+    ps = PackageSettings.from_mapping(
+        package="test-package",
+        parsed=package_data,
+        source="test",
+        has_config=True,
+    )
+
+    pbi = PackageBuildInfo(typing.cast(Settings, MockSettings()), ps)
+
+    # Version with prebuilt and custom URL
+    assert pbi.is_pre_built("2.9.0.dev20250730") is True
+    assert (
+        pbi.get_wheel_server_url("2.9.0.dev20250730")
+        == "https://prebuilt.example.com/simple/"
+    )
+
+    # Version with prebuilt but no custom URL (uses variant default)
+    assert pbi.is_pre_built("0.24.0.dev20250730") is True
+    assert (
+        pbi.get_wheel_server_url("0.24.0.dev20250730")
+        == "https://default.example.com/simple/"
+    )
+
+    # Version explicitly set to build from source
+    assert pbi.is_pre_built("2.8.0") is False
+    assert pbi.get_wheel_server_url("2.8.0") == "https://default.example.com/simple/"
+
+    # Unknown version uses variant default
+    assert pbi.is_pre_built("1.0.0") is False
+    assert pbi.get_wheel_server_url("1.0.0") == "https://default.example.com/simple/"
+
+    # No version specified uses variant default
+    assert pbi.is_pre_built() is False
+    assert pbi.get_wheel_server_url() == "https://default.example.com/simple/"
+
+    # Legacy property access
+    assert pbi.pre_built is False
+    assert pbi.wheel_server_url == "https://default.example.com/simple/"
+
+
+def test_version_specific_env_vars() -> None:
+    """Test that version-specific environment variables work correctly."""
+    package_data = {
+        "env": {
+            "GLOBAL_VAR": "global_value",
+        },
+        "variants": {
+            "cuda-ubi9": {
+                "env": {
+                    "VARIANT_VAR": "variant_value",
+                    "OVERRIDE_ME": "variant_override",
+                },
+                "versions": {
+                    "2.0.0": {
+                        "env": {
+                            "VERSION_VAR": "version_value",
+                            "OVERRIDE_ME": "version_override",
+                        }
+                    }
+                },
+            }
+        },
+    }
+
+    ps = PackageSettings.from_mapping(
+        package="test-package",
+        parsed=package_data,
+        source="test",
+        has_config=True,
+    )
+
+    pbi = PackageBuildInfo(
+        typing.cast(Settings, MockSettings(variant="cuda-ubi9", max_jobs=1)), ps
+    )
+
+    # With version: should include all levels with version taking precedence
+    env_with_version = pbi.get_extra_environ(
+        template_env={}, build_env=None, version="2.0.0"
+    )
+    assert env_with_version["GLOBAL_VAR"] == "global_value"
+    assert env_with_version["VARIANT_VAR"] == "variant_value"
+    assert env_with_version["VERSION_VAR"] == "version_value"
+    assert env_with_version["OVERRIDE_ME"] == "version_override"
+
+    # Without version: should not include version-specific vars
+    env_without_version = pbi.get_extra_environ(
+        template_env={},
+        build_env=None,
+    )
+    assert env_without_version["GLOBAL_VAR"] == "global_value"
+    assert env_without_version["VARIANT_VAR"] == "variant_value"
+    assert "VERSION_VAR" not in env_without_version
+    assert env_without_version["OVERRIDE_ME"] == "variant_override"
+
+
+def test_backward_compatibility() -> None:
+    """Test that existing configurations without version-specific settings still work."""
+    package_data = {
+        "variants": {
+            "cpu-ubi9": {
+                "pre_built": True,
+                "wheel_server_url": "https://legacy.example.com/simple/",
+            }
+        }
+    }
+
+    ps = PackageSettings.from_mapping(
+        package="legacy-package",
+        parsed=package_data,
+        source="test",
+        has_config=True,
+    )
+
+    pbi = PackageBuildInfo(typing.cast(Settings, MockSettings(variant="cpu-ubi9")), ps)
+
+    # All methods should return the variant-wide setting
+    assert pbi.pre_built is True
+    assert pbi.is_pre_built() is True
+    assert pbi.is_pre_built("1.0.0") is True
+
+    assert pbi.wheel_server_url == "https://legacy.example.com/simple/"
+    assert pbi.get_wheel_server_url() == "https://legacy.example.com/simple/"
+    assert pbi.get_wheel_server_url("1.0.0") == "https://legacy.example.com/simple/"


### PR DESCRIPTION
Enable fine-grained control over prebuilt vs source builds within variants by allowing per-version overrides. This resolves conflicts where different collections need different build methods for the same package version.

- Add VersionSpecificSettings model with pre_built and wheel_server_url
- Extend VariantInfo with versions mapping for version-specific overrides
- Update PackageBuildInfo with version-aware methods (is_pre_built, get_wheel_server_url)
- Modify bootstrapper, wheels, and build commands to use version-specific logic
- Add comprehensive tests validating precedence and backward compatibility
- Create detailed how-to documentation with examples and migration guide

Maintains full backward compatibility with existing variant-wide settings. Version-specific settings take precedence over variant defaults when present.

Fixes #801 