### PR TITLE
Use wheel binary from env

### DIFF
--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -238,8 +238,10 @@ def add_extra_metadata_to_wheels(
         build_tag_from_settings = pbi.build_tag(version)
         build_tag = build_tag_from_settings if build_tag_from_settings else (0, "")
 
+        # Use wheel binary from the same virtual environment as the running Python
+        wheel_bin = pathlib.Path(sys.executable).parent / "wheel"
         cmd = [
-            "wheel",
+            str(wheel_bin),
             "pack",
             str(wheel_root_dir),
             "--dest-dir",


### PR DESCRIPTION
When running fromager from within a virtual environment, use any other python dependency, i.e. wheel, from within that same virtual environment. This is particularly useful when the virtual environment uses a different python version which can drastically affect the built wheel.