### PR TITLE
remove a few redundant log prefixes

### DIFF
--- a/src/fromager/bootstrapper.py
+++ b/src/fromager/bootstrapper.py
@@ -570,7 +570,7 @@ class Bootstrapper:
             logger.info(f"has expected build tag {expected_build_tag}")
             # Get changelogs for debug info
             changelogs = pbi.get_changelog(resolved_version)
-            logger.debug(f"{req.name} has change logs {changelogs}")
+            logger.debug(f"has change logs {changelogs}")
 
             _, _, build_tag, _ = wheels.extract_info_from_wheel_file(
                 req, wheelfile_name

--- a/src/fromager/build_environment.py
+++ b/src/fromager/build_environment.py
@@ -323,9 +323,7 @@ def _safe_install(
     try:
         build_env.install(deps)
     except subprocess.CalledProcessError as err:
-        logger.error(
-            f"{req.name}: failed to install {dep_req_type} dependencies {deps}: {err}"
-        )
+        logger.error(f"failed to install {dep_req_type} dependencies {deps}: {err}")
         match = _uv_missing_dependency_pattern.search(err.output)
         if match is not None:
             req_info = match.groups()[0]
@@ -338,4 +336,4 @@ def _safe_install(
             deps,
         ) from err
 
-    logger.info("%s: installed %s requirements %s", req.name, dep_req_type, deps)
+    logger.info("installed %s requirements %s", dep_req_type, deps)


### PR DESCRIPTION
We have a few places where due to the combination of the logging context
and explicit message structure we log something like "pkg: pkg: message"
or "pkg-version: pkg: message". This commit removes a few of those.