### PR TITLE
feat: Add `str` value support to config_settings

### DIFF
--- a/src/fromager/packagesettings.py
+++ b/src/fromager/packagesettings.py
@@ -426,7 +426,7 @@ class PackageSettings(pydantic.BaseModel):
     changelog: VariantChangelog = Field(default_factory=dict)
     """Changelog entries"""
 
-    config_settings: dict[str, list[str]] = Field(default_factory=dict)
+    config_settings: dict[str, str | list[str]] = Field(default_factory=dict)
     """PEP 517 arbitrary configuration for wheel builds
 
     https://peps.python.org/pep-0517/#config-settings
@@ -932,7 +932,7 @@ class PackageBuildInfo:
         return self._ps.build_options.build_ext_parallel
 
     @property
-    def config_settings(self) -> dict[str, list[str]]:
+    def config_settings(self) -> dict[str, str | list[str]]:
         return self._ps.config_settings
 
     @property

--- a/tests/test_packagesettings.py
+++ b/tests/test_packagesettings.py
@@ -49,6 +49,7 @@ FULL_EXPECTED: dict[str, typing.Any] = {
             "-Dsystem-freetype=true",
             "-Dsystem-qhull=true",
         ],
+        "cmake.define.BLA_VENDOR": "OpenBLAS",
     },
     "download_source": {
         "destination_filename": "${canonicalized_name}-${version}.tar.gz",

--- a/tests/test_wheels.py
+++ b/tests/test_wheels.py
@@ -52,7 +52,8 @@ def test_default_build_wheel(
     mock_build_wheel.assert_called_once_with(
         str(testdata_context.wheels_build),
         config_settings={
-            "setup-args": ["-Dsystem-freetype=true", "-Dsystem-qhull=true"]
+            "setup-args": ["-Dsystem-freetype=true", "-Dsystem-qhull=true"],
+            "cmake.define.BLA_VENDOR": "OpenBLAS",
         },
     )
 

--- a/tests/testdata/context/overrides/settings/test_pkg.yaml
+++ b/tests/testdata/context/overrides/settings/test_pkg.yaml
@@ -16,6 +16,7 @@ config_settings:
   setup-args:
     - "-Dsystem-freetype=true"
     - "-Dsystem-qhull=true"
+  "cmake.define.BLA_VENDOR": "OpenBLAS"
 env:
     EGG: spam
     EGG_AGAIN: "$EGG"


### PR DESCRIPTION
PEP 517 config settings now support `str` values in addition to `list[str]` values. `scikit-build-core` uses string values for some config settings like `cmake.define`.