### PR TITLE
chore(mergify): Trigger automatic update rule for approved PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,12 @@
 pull_request_rules:
+  - name: Automatic rebase to keep PRs up-to-date
+    conditions:
+      - "-draft"
+      - "-conflict"
+      - "-closed"
+      - "#approved-reviews-by>=1"
+    actions:
+      update:
   - name: Add CI label
     conditions:
       - or:


### PR DESCRIPTION
Add a new Mergify rule to automatically rebase approved PRs when the base branch (main) is updated. This keeps PRs current with the latest code and ensures tests run on the actual merge result.

The rebase happens automatically when:
- PR is not a draft
- PR has no merge conflicts
- PR is still open
- PR has at least 1 approval from maintainers

Benefits:
- Prevents stale PRs that fall behind main
- Catches integration issues early
- Ensures tests run on latest codebase
- Maintains cleaner linear commit history

The rebase rule is placed before the auto-merge rule to ensure PRs are up-to-date before automatic merging occurs.