### PR TITLE
Lbarto/adding marker support

### DIFF
--- a/src/fromager/constraints.py
+++ b/src/fromager/constraints.py
@@ -29,7 +29,9 @@ class Constraints:
 
         # Check for conflicts with existing constraints
         for existing_req in previous:
-            existing_marker_key = str(existing_req.marker) if existing_req.marker else ""
+            existing_marker_key = (
+                str(existing_req.marker) if existing_req.marker else ""
+            )
 
             # If markers match (including both being empty), it's a conflict
             if marker_key == existing_marker_key:

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -93,6 +93,7 @@ def test_load_constraints_file(tmp_path: pathlib.Path):
     assert list(c) == ["egg", "torch"]  # type: ignore
     assert c.get_constraint("torch") == Requirement("torch==3.1.0")
 
+
 def test_get_constraint():
     c = constraints.Constraints()
 


### PR DESCRIPTION
# Note to reviewer

Closes #831 

Please approach this PR with skepticism, I don't want to cause regressions

* Adds support for markers when parsing constraints
* Adds tests for new functionality

Multiple constraints should be considered valid when there are multiple unique markers:

```
foo==1.0.0; platform_machine != 'ppc64le'
foo==1.0.1; platform_machine == 'ppc64le'

```

