### PR TITLE
fix: adds support for duplicate constraints, checks for conflicts

### DIFF
--- a/src/fromager/constraints.py
+++ b/src/fromager/constraints.py
@@ -15,7 +15,7 @@ class Constraints:
     def __init__(self) -> None:
         # mapping of canonical names to requirements
         # NOTE: Requirement.name is not normalized
-        self._data: dict[NormalizedName, list[Requirement]] = {}
+        self._data: dict[NormalizedName, Requirement] = {}
 
     def __iter__(self) -> Generator[NormalizedName, None, None]:
         yield from self._data
@@ -24,24 +24,19 @@ class Constraints:
         """Add new constraint, must not conflict with any existing constraints"""
         req = Requirement(unparsed)
         canon_name = canonicalize_name(req.name)
-        marker_key = str(req.marker) if req.marker else ""
-        previous = self._data.get(canon_name, [])
+        previous = self._data.get(canon_name)
 
-        # Check for conflicts with existing constraints
-        for existing_req in previous:
-            existing_marker_key = (
-                str(existing_req.marker) if existing_req.marker else ""
+        if not requirements_file.evaluate_marker(req, req):
+            logger.debug(f"Constraint {req} does not match environment")
+            return
+
+        if previous is not None:
+            raise KeyError(
+                f"{canon_name}: new constraint '{req}' conflicts with '{previous}'"
             )
-
-            # If markers match (including both being empty), it's a conflict
-            if marker_key == existing_marker_key:
-                raise KeyError(
-                    f"{canon_name}: new constraint '{req}' conflicts with existing constraint '{existing_req}'"
-                )
-
-        if canon_name not in self._data:
-            self._data[canon_name] = []
-        self._data[canon_name].append(req)
+        if requirements_file.evaluate_marker(req, req):
+            logger.debug(f"adding constraint {req}")
+            self._data[canon_name] = req
 
     def load_constraints_file(self, constraints_file: str | pathlib.Path) -> None:
         """Load constraints from a constraints file"""
@@ -51,14 +46,7 @@ class Constraints:
             self.add_constraint(line)
 
     def get_constraint(self, name: str) -> Requirement | None:
-        # Lookup the list by the key given (name), iterate through the list
-        # call evaluate_marker(req, req) until it returns true, then return that
-        constraints = self._data.get(canonicalize_name(name), [])
-
-        for constraint in constraints:
-            if requirements_file.evaluate_marker(constraint, constraint):
-                return constraint
-        return None
+        return self._data.get(canonicalize_name(name))
 
     def allow_prerelease(self, pkg_name: str) -> bool:
         constraint = self.get_constraint(pkg_name)


### PR DESCRIPTION
# Note to reviewer

Closes #831 

Please approach this PR with skepticism, I don't want to cause regressions

* Adds support for markers when parsing constraints
* Adds tests for new functionality

Multiple constraints should be considered valid when there are multiple unique markers:

```
foo==1.0.0; platform_machine != 'ppc64le'
foo==1.0.1; platform_machine == 'ppc64le'

```
