### PR TITLE
feat: setting for use pypi.org metadata

### DIFF
--- a/src/fromager/packagesettings.py
+++ b/src/fromager/packagesettings.py
@@ -192,6 +192,15 @@ class ResolverDist(pydantic.BaseModel):
     .. versionadded:: 0.52
     """
 
+    use_pypi_org_metadata: bool | None = None
+    """Can use metadata from pypi.org JSON / Simple API?
+
+    None (default) is for auto-setting. Packages with customizations (config,
+    patches, plugins) don't use pypi.org metadata by default.
+
+    .. versionadded:: 0.70
+    """
+
     @pydantic.model_validator(mode="after")
     def validate_ignore_platform(self) -> typing.Self:
         if self.ignore_platform and not self.include_wheels:
@@ -813,6 +822,21 @@ class PackageBuildInfo:
     def resolver_ignore_platform(self) -> bool:
         """Ignore the platform when resolving with wheels?"""
         return self._ps.resolver_dist.ignore_platform
+
+    @property
+    def use_pypi_org_metadata(self) -> bool:
+        """Can use metadata from pypi.org JSON / Simple API?
+
+        By default, packages with customizations do not use public
+        pypi.org metadata.
+        """
+        ps = self._ps
+        flag = ps.resolver_dist.use_pypi_org_metadata
+        if flag is not None:
+            # flag is set
+            return flag
+        # return True if package does not have any customizations
+        return not self.has_customizations
 
     def build_dir(self, sdist_root_dir: pathlib.Path) -> pathlib.Path:
         """Build directory for package (e.g. subdirectory)"""

--- a/tests/test_packagesettings.py
+++ b/tests/test_packagesettings.py
@@ -79,6 +79,7 @@ FULL_EXPECTED: dict[str, typing.Any] = {
         "include_wheels": True,
         "sdist_server_url": "https://sdist.test/egg",
         "ignore_platform": True,
+        "use_pypi_org_metadata": True,
     },
     "variants": {
         "cpu": {
@@ -138,6 +139,7 @@ EMPTY_EXPECTED: dict[str, typing.Any] = {
         "include_sdists": True,
         "include_wheels": False,
         "ignore_platform": False,
+        "use_pypi_org_metadata": None,
     },
     "variants": {},
 }
@@ -176,6 +178,7 @@ PREBUILT_PKG_EXPECTED: dict[str, typing.Any] = {
         "include_sdists": True,
         "include_wheels": False,
         "ignore_platform": False,
+        "use_pypi_org_metadata": None,
     },
     "variants": {
         "cpu": {
@@ -785,3 +788,16 @@ def test_pbi_annotations(testdata_context: context.WorkContext) -> None:
 
     pbi = testdata_context.settings.package_build_info(TEST_EMPTY_PKG)
     assert pbi.annotations == {}
+
+
+def test_use_pypi_org_metadata(testdata_context: context.WorkContext) -> None:
+    pbi = testdata_context.settings.package_build_info(TEST_PKG)
+    assert pbi.use_pypi_org_metadata
+
+    pbi = testdata_context.settings.package_build_info(TEST_EMPTY_PKG)
+    assert not pbi.use_pypi_org_metadata
+
+    pbi = testdata_context.settings.package_build_info(
+        "somepackage_without_customization"
+    )
+    assert pbi.use_pypi_org_metadata

--- a/tests/testdata/context/overrides/settings/test_pkg.yaml
+++ b/tests/testdata/context/overrides/settings/test_pkg.yaml
@@ -40,6 +40,7 @@ resolver_dist:
     include_sdists: true
     include_wheels: true
     ignore_platform: true
+    use_pypi_org_metadata: true
 variants:
     cpu:
         annotations:


### PR DESCRIPTION
The new resolver flag and package setting property `use_pypi_org_metadata` is used to indicate if a package with customizations can use upstream pypi.org metadata.

Packages with customizations (patches, plugins, configs) may not have the same metadata on pypi.org or may be a completely different project on PyPI than in downstream.