### PR TITLE
fix: Remove build_ext_parallel feature

### DIFF
--- a/src/fromager/packagesettings.py
+++ b/src/fromager/packagesettings.py
@@ -242,7 +242,7 @@ class BuildOptions(pydantic.BaseModel):
 
     ::
 
-        build_ext_parallel: False
+        build_ext_parallel: False  # DEPRECATED: ignored, will be removed
         cpu_cores_per_job: 1
         memory_per_job_gb: 1.0
     """
@@ -252,8 +252,10 @@ class BuildOptions(pydantic.BaseModel):
     build_ext_parallel: bool = False
     """Configure `build_ext[parallel]` in `DIST_EXTRA_CONFIG`
 
-    This enables parallel builds of setuptools extensions. Incompatible
-    with some packages, e.g. numba 0.60.0.
+    .. deprecated:: 0.72.0
+       This option is deprecated and will be removed in a future release.
+       The parallel build feature for extensions is unsafe due to race conditions.
+       This option is now ignored and will emit a warning if set to True.
     """
 
     cpu_cores_per_job: int = Field(default=1, ge=1)

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -7,7 +7,6 @@ import pathlib
 import shutil
 import sys
 import tempfile
-import textwrap
 import typing
 import zipfile
 
@@ -302,23 +301,13 @@ def build_wheel(
         build_env=build_env,
     )
 
-    if (
-        pbi.build_ext_parallel
-        and "DIST_EXTRA_CONFIG" not in extra_environ
-        and "MAX_JOBS" in extra_environ
-    ):
-        # configure setuptools to use parallel builds
-        # https://setuptools.pypa.io/en/latest/deprecated/distutils/configfile.html
-        dist_extra_cfg = build_env.path / "dist-extra.cfg"
-        dist_extra_cfg.write_text(
-            textwrap.dedent(
-                f"""
-                [build_ext]
-                parallel = {extra_environ["MAX_JOBS"]}
-                """
-            )
+    if pbi.build_ext_parallel:
+        logger.warning(
+            "%s: build_ext_parallel is deprecated and will be removed in a "
+            "future release. The parallel build feature for extensions is unsafe and "
+            "can cause build failures or miscompiled wheels. This option is now ignored.",
+            req.name,
         )
-        extra_environ["DIST_EXTRA_CONFIG"] = str(dist_extra_cfg)
 
     overrides.find_and_invoke(
         req.name,


### PR DESCRIPTION
Remove the build_ext_parallel feature which configures parallel builds of setuptools extensions via dist-extra.cfg. This feature was found to be unsafe due to race conditions in setuptools/distutils, causing:
- Intermittent build failures in packages like Cython and numba
- Miscompiled wheels with missing symbols (e.g., psutil)

Phase 1 of deprecation:
- Remove code that creates dist-extra.cfg and sets DIST_EXTRA_CONFIG
- Keep the build_ext_parallel option in the schema for compatibility
- Emit deprecation warning when the option is set to True
- Update documentation to mark the option as deprecated

The option will be completely removed in Phase 2 after a few releases.

Fixes: #808