### PR TITLE
chore: make Candidate a dataclass

### DIFF
--- a/src/fromager/resolver.py
+++ b/src/fromager/resolver.py
@@ -339,13 +339,13 @@ def get_project_from_pypi(
                 continue
 
         c = Candidate(
-            name,
-            version,
+            name=name,
+            version=version,
             url=dp.url,
-            extras=extras,
+            extras=tuple(sorted(extras)),
             is_sdist=is_sdist,
             build_tag=build_tag,
-            metadata_url=dp.metadata_url if dp.has_metadata else None,
+            has_metadata=bool(dp.has_metadata),
         )
         if DEBUG_RESOLVER:
             logger.debug("candidate %s (%s) %s", dp.filename, c, dp.url)
@@ -723,7 +723,7 @@ class GenericProvider(BaseProvider):
                     continue
                 assert isinstance(version, Version)
                 version = version
-            candidates.append(Candidate(identifier, version, url=url))
+            candidates.append(Candidate(name=identifier, version=version, url=url))
         return candidates
 
 

--- a/tests/test_pep658_support.py
+++ b/tests/test_pep658_support.py
@@ -16,7 +16,7 @@ class TestPEP658Support:
             name="test-package",
             version=Version("1.0.0"),
             url="https://example.com/test-package-1.0.0-py3-none-any.whl",
-            metadata_url="https://example.com/test-package-1.0.0-py3-none-any.whl.metadata",
+            has_metadata=True,
         )
 
         assert (
@@ -132,12 +132,15 @@ Requires-Dist: requests >= 2.0.0
             name="test-package",
             version=Version("1.0.0"),
             url="https://example.com/test-package-1.0.0-py3-none-any.whl",
-            metadata_url="https://example.com/test-package-1.0.0-py3-none-any.whl.metadata",
+            has_metadata=True,
         )
 
         # The candidate should have the metadata URL attribute
         assert hasattr(candidate, "metadata_url")
-        assert candidate.metadata_url is not None
+        assert (
+            candidate.metadata_url
+            == "https://example.com/test-package-1.0.0-py3-none-any.whl.metadata"
+        )
 
     def test_metadata_url_construction(self):
         """Test that metadata URLs are constructed correctly."""
@@ -157,13 +160,18 @@ Requires-Dist: requests >= 2.0.0
             name="test-package",
             version=Version("1.0.0"),
             url="https://example.com/test.whl",
-            metadata_url="https://example.com/test.whl.metadata",
+            has_metadata=True,
         )
 
         candidate_without_metadata = Candidate(
             name="test-package",
             version=Version("1.0.0"),
             url="https://example.com/test.whl",
+        )
+
+        assert (
+            candidate_with_metadata.metadata_url
+            == "https://example.com/test.whl.metadata"
         )
 
         # Verify PEP 658 metadata URL handling


### PR DESCRIPTION
Convert the `Candidate` class to an immutable dataclass.

Instead of an URL to the metadata file, a candidate object now only holds an `has_metadata` flag. The metadata URL is always `self.url + 'metadata'`.

`extras` is now a sorted tuple instead of `Iterable[str] | None`. This simplifies the logic, too.