### PR TITLE
refactor(graph): extract helpers from reduce_graph

### DIFF
--- a/tests/test_graph_commands.py
+++ b/tests/test_graph_commands.py
@@ -1,12 +1,18 @@
 """Test graph command functions that display constraint information."""
 
+from unittest.mock import Mock
+
 import pytest
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 from packaging.version import Version
 
 from fromager import dependency_graph
-from fromager.commands.graph import find_why, show_explain_duplicates
+from fromager.commands.graph import (
+    _find_customized_dependencies_for_node,
+    find_why,
+    show_explain_duplicates,
+)
 from fromager.requirements_file import RequirementType
 
 
@@ -189,3 +195,266 @@ def test_find_why_without_constraints(
     assert "(constraint:" not in captured.out
     assert "simple-child==2.0.0" in captured.out
     assert "simple-pkg==1.0.0" in captured.out
+
+
+def test_find_direct_customized_dependency() -> None:
+    """Test finding a direct child with customizations."""
+    # Setup: A -> B (customized)
+    graph = dependency_graph.DependencyGraph()
+    graph.add_dependency(
+        parent_name=None,
+        parent_version=None,
+        req_type=RequirementType.TOP_LEVEL,
+        req=Requirement("package-a"),
+        req_version=Version("1.0.0"),
+        download_url="https://example.com/package-a-1.0.0.tar.gz",
+    )
+    graph.add_dependency(
+        parent_name=canonicalize_name("package-a"),
+        parent_version=Version("1.0.0"),
+        req_type=RequirementType.INSTALL,
+        req=Requirement("package-b>=1.0"),
+        req_version=Version("2.0.0"),
+        download_url="https://example.com/package-b-2.0.0.tar.gz",
+    )
+
+    # Mock context to mark package-b as customized
+    mock_ctx = Mock()
+    mock_settings = Mock()
+
+    def mock_pbi(name: str) -> Mock:
+        pbi = Mock()
+        pbi.has_customizations = name == "package-b"
+        return pbi
+
+    mock_settings.package_build_info = mock_pbi
+    mock_ctx.settings = mock_settings
+
+    # Test
+    node_a = graph.nodes["package-a==1.0.0"]
+    result = _find_customized_dependencies_for_node(
+        mock_ctx, node_a, install_only=False
+    )
+
+    # Verify
+    assert len(result) == 1
+    assert "package-b==2.0.0" in result
+    assert result["package-b==2.0.0"] == "package-b>=1.0"
+
+
+def test_find_transitive_customized_dependency() -> None:
+    """Test finding customized dependency through non-customized intermediate."""
+    # Setup: A -> B (not customized) -> C (customized)
+    graph = dependency_graph.DependencyGraph()
+    graph.add_dependency(
+        parent_name=None,
+        parent_version=None,
+        req_type=RequirementType.TOP_LEVEL,
+        req=Requirement("package-a"),
+        req_version=Version("1.0.0"),
+        download_url="https://example.com/package-a-1.0.0.tar.gz",
+    )
+    graph.add_dependency(
+        parent_name=canonicalize_name("package-a"),
+        parent_version=Version("1.0.0"),
+        req_type=RequirementType.INSTALL,
+        req=Requirement("package-b>=1.0"),
+        req_version=Version("2.0.0"),
+        download_url="https://example.com/package-b-2.0.0.tar.gz",
+    )
+    graph.add_dependency(
+        parent_name=canonicalize_name("package-b"),
+        parent_version=Version("2.0.0"),
+        req_type=RequirementType.INSTALL,
+        req=Requirement("package-c"),
+        req_version=Version("3.0.0"),
+        download_url="https://example.com/package-c-3.0.0.tar.gz",
+    )
+
+    # Mock context: only package-c is customized
+    mock_ctx = Mock()
+    mock_settings = Mock()
+
+    def mock_pbi(name: str) -> Mock:
+        pbi = Mock()
+        pbi.has_customizations = name == "package-c"
+        return pbi
+
+    mock_settings.package_build_info = mock_pbi
+    mock_ctx.settings = mock_settings
+
+    # Test
+    node_a = graph.nodes["package-a==1.0.0"]
+    result = _find_customized_dependencies_for_node(
+        mock_ctx, node_a, install_only=False
+    )
+
+    # Verify: Should find C (not B), with A's original requirement
+    assert len(result) == 1
+    assert "package-c==3.0.0" in result
+    assert result["package-c==3.0.0"] == "package-b>=1.0"  # A's requirement, not B's
+
+
+def test_install_only_skips_build_dependencies() -> None:
+    """Test that install_only=True skips build dependencies."""
+    # Setup: A -> B (build dep, customized)
+    graph = dependency_graph.DependencyGraph()
+    graph.add_dependency(
+        parent_name=None,
+        parent_version=None,
+        req_type=RequirementType.TOP_LEVEL,
+        req=Requirement("package-a"),
+        req_version=Version("1.0.0"),
+        download_url="https://example.com/package-a-1.0.0.tar.gz",
+    )
+    graph.add_dependency(
+        parent_name=canonicalize_name("package-a"),
+        parent_version=Version("1.0.0"),
+        req_type=RequirementType.BUILD_BACKEND,  # Build dependency
+        req=Requirement("package-b"),
+        req_version=Version("2.0.0"),
+        download_url="https://example.com/package-b-2.0.0.tar.gz",
+    )
+
+    # Mock context: package-b is customized
+    mock_ctx = Mock()
+    mock_settings = Mock()
+
+    def mock_pbi(name: str) -> Mock:
+        pbi = Mock()
+        pbi.has_customizations = name == "package-b"
+        return pbi
+
+    mock_settings.package_build_info = mock_pbi
+    mock_ctx.settings = mock_settings
+
+    # Test with install_only=True
+    node_a = graph.nodes["package-a==1.0.0"]
+    result = _find_customized_dependencies_for_node(mock_ctx, node_a, install_only=True)
+
+    # Verify: Should be empty (build dep skipped)
+    assert len(result) == 0
+
+
+def test_cycle_prevention_no_infinite_loop() -> None:
+    """Test that circular dependencies don't cause infinite loops."""
+    # Setup: A -> B -> C -> A (cycle)
+    graph = dependency_graph.DependencyGraph()
+    graph.add_dependency(
+        parent_name=None,
+        parent_version=None,
+        req_type=RequirementType.TOP_LEVEL,
+        req=Requirement("package-a"),
+        req_version=Version("1.0.0"),
+        download_url="https://example.com/package-a-1.0.0.tar.gz",
+    )
+    graph.add_dependency(
+        parent_name=canonicalize_name("package-a"),
+        parent_version=Version("1.0.0"),
+        req_type=RequirementType.INSTALL,
+        req=Requirement("package-b"),
+        req_version=Version("1.0.0"),
+        download_url="https://example.com/package-b-1.0.0.tar.gz",
+    )
+    graph.add_dependency(
+        parent_name=canonicalize_name("package-b"),
+        parent_version=Version("1.0.0"),
+        req_type=RequirementType.INSTALL,
+        req=Requirement("package-c"),
+        req_version=Version("1.0.0"),
+        download_url="https://example.com/package-c-1.0.0.tar.gz",
+    )
+    # Create cycle: C -> A
+    graph.add_dependency(
+        parent_name=canonicalize_name("package-c"),
+        parent_version=Version("1.0.0"),
+        req_type=RequirementType.INSTALL,
+        req=Requirement("package-a"),
+        req_version=Version("1.0.0"),
+        download_url="https://example.com/package-a-1.0.0.tar.gz",
+    )
+
+    # Mock context: only package-c is customized
+    mock_ctx = Mock()
+    mock_settings = Mock()
+
+    def mock_pbi(name: str) -> Mock:
+        pbi = Mock()
+        pbi.has_customizations = name == "package-c"
+        return pbi
+
+    mock_settings.package_build_info = mock_pbi
+    mock_ctx.settings = mock_settings
+
+    # Test: Should not hang or raise error
+    node_a = graph.nodes["package-a==1.0.0"]
+    result = _find_customized_dependencies_for_node(
+        mock_ctx, node_a, install_only=False
+    )
+
+    # Verify: Should find C once, despite cycle
+    assert len(result) == 1
+    assert "package-c==1.0.0" in result
+
+
+def test_requirement_preservation_through_chain() -> None:
+    """Test that original requirement is preserved through dependency chain."""
+    # Setup: A requires "package-b>=1.0,<2.0"
+    #        A -> B -> C (customized)
+    graph = dependency_graph.DependencyGraph()
+    graph.add_dependency(
+        parent_name=None,
+        parent_version=None,
+        req_type=RequirementType.TOP_LEVEL,
+        req=Requirement("package-a"),
+        req_version=Version("1.0.0"),
+        download_url="https://example.com/package-a-1.0.0.tar.gz",
+    )
+    # A's requirement of B is specific
+    graph.add_dependency(
+        parent_name=canonicalize_name("package-a"),
+        parent_version=Version("1.0.0"),
+        req_type=RequirementType.INSTALL,
+        req=Requirement("package-b>=1.0,<2.0"),
+        req_version=Version("1.5.0"),
+        download_url="https://example.com/package-b-1.5.0.tar.gz",
+    )
+    # B's requirement of C is different
+    graph.add_dependency(
+        parent_name=canonicalize_name("package-b"),
+        parent_version=Version("1.5.0"),
+        req_type=RequirementType.INSTALL,
+        req=Requirement("package-c>=3.0"),
+        req_version=Version("3.5.0"),
+        download_url="https://example.com/package-c-3.5.0.tar.gz",
+    )
+
+    # Mock context: only package-c is customized
+    mock_ctx = Mock()
+    mock_settings = Mock()
+
+    def mock_pbi(name: str) -> Mock:
+        pbi = Mock()
+        pbi.has_customizations = name == "package-c"
+        return pbi
+
+    mock_settings.package_build_info = mock_pbi
+    mock_ctx.settings = mock_settings
+
+    # Test
+    node_a = graph.nodes["package-a==1.0.0"]
+    result = _find_customized_dependencies_for_node(
+        mock_ctx, node_a, install_only=False
+    )
+
+    # Verify: Should preserve A's original requirement, not B's
+    assert len(result) == 1
+    assert "package-c==3.5.0" in result
+    # Should be A's requirement of B (the first in the chain), not B's requirement of C
+    # Note: The packaging library may normalize the requirement string order
+    requirement_str = result["package-c==3.5.0"]
+    assert "package-b" in requirement_str
+    assert ">=1.0" in requirement_str or ">= 1.0" in requirement_str
+    assert "<2.0" in requirement_str or "< 2.0" in requirement_str
+    # Should NOT be B's requirement of C
+    assert "package-c" not in requirement_str


### PR DESCRIPTION
Split reduce_graph() into 4 focused helper functions to improve readability and maintainability. The main function is now a clear 3-step pipeline: get nodes, find customized, build dependencies.

Also added some tests for  _find_customized_dependencies_for_node()