### PR TITLE
fix: Add retry logic to GitHub and GitLab tag providers

### DIFF
--- a/docs/http-retry.md
+++ b/docs/http-retry.md
@@ -43,6 +43,7 @@ The retry mechanism specifically handles these error conditions:
 
 ### Server Errors
 
+- `408 Request Timeout` - Request took too long to complete
 - `504 Gateway Timeout` - Server overwhelmed or upstream timeout
 - `502 Bad Gateway` - Proxy/gateway errors
 - `503 Service Unavailable` - Temporary server overload

--- a/src/fromager/http_retry.py
+++ b/src/fromager/http_retry.py
@@ -2,6 +2,7 @@
 
 This module provides a robust retry mechanism for HTTP requests with exponential
 backoff, jitter, and specific handling for common network failures including:
+- Request timeouts (408)
 - Server timeouts (502, 503, 504)
 - Rate limiting (429, GitHub API rate limits)
 - Connection errors and incomplete reads
@@ -35,7 +36,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_RETRY_CONFIG = {
     "total": 5,
     "backoff_factor": 1.0,
-    "status_forcelist": [429, 500, 502, 503, 504],
+    "status_forcelist": [408, 429, 500, 502, 503, 504],
     "allowed_methods": ["GET", "PUT", "POST", "HEAD", "OPTIONS"],
     "raise_on_status": False,
 }

--- a/src/fromager/request_session.py
+++ b/src/fromager/request_session.py
@@ -6,7 +6,7 @@ from .http_retry import create_retry_session
 FROMAGER_RETRY_CONFIG = {
     "total": int(os.environ.get("FROMAGER_HTTP_RETRIES", "8")),
     "backoff_factor": float(os.environ.get("FROMAGER_HTTP_BACKOFF_FACTOR", "1.5")),
-    "status_forcelist": [429, 500, 502, 503, 504],
+    "status_forcelist": [408, 429, 500, 502, 503, 504],
     "allowed_methods": ["GET", "PUT", "POST", "HEAD", "OPTIONS"],
     "raise_on_status": False,
 }


### PR DESCRIPTION
Add application-level retry logic to GitHubTagProvider and GitLabTagProvider to handle transient API failures, particularly common with gitlab.com. The implementation uses the existing retry_on_exception decorator with 5 attempts and exponential backoff.

Changes:
- Apply @retry_on_exception decorator to GitHubTagProvider._find_tags()
- Apply @retry_on_exception decorator to GitLabTagProvider._find_tags()
- Add HTTP 408 (Request Timeout) to retry status codes
- Remove redundant try-except blocks that immediately re-raised
- Update documentation to reflect 408 status code handling

The two-layer retry strategy (HTTP-level + application-level) significantly improves build reliability when GitHub/GitLab APIs experience intermittent failures.

Fixes: #810