### PR TITLE
fix: include package name in exception messages

### DIFF
--- a/e2e/test_bootstrap_constraints.sh
+++ b/e2e/test_bootstrap_constraints.sh
@@ -28,7 +28,7 @@ fromager \
 pass=true
 
 # Check for log message that the override is loaded
-if ! grep -q "ERROR: Unable to resolve requirement specifier stevedore==5.2.0 with constraint stevedore==4.0.0" "$OUTDIR/bootstrap.log"; then
+if ! grep -q "ERROR.*stevedore: Unable to resolve requirement specifier stevedore==5.2.0 with constraint stevedore==4.0.0" "$OUTDIR/bootstrap.log"; then
   echo "FAIL: did not throw expected error when constraint and requirement conflict" 1>&2
   pass=false
 fi

--- a/src/fromager/__main__.py
+++ b/src/fromager/__main__.py
@@ -275,7 +275,7 @@ def invoke_main() -> None:
             err,
             exc_info=True,
         )  # log the full traceback details to the debug log file, if any
-        logger.error(f"ERROR: {_format_exception(err)}")
+        logger.error(_format_exception(err))
         if _DEBUG:
             raise
         sys.exit(1)

--- a/src/fromager/commands/build.py
+++ b/src/fromager/commands/build.py
@@ -680,14 +680,15 @@ def build_parallel(
                     try:
                         entry = future.result()
                     except Exception as e:
-                        logger.error("failed to build: %s", e)
-                        raise
+                        logger.error(f"Failed to build {node.key}: {e}")
+                        raise RuntimeError(f"Failed to build {node.key}") from e
                     else:
                         # success
                         built_entries.append(entry)
                     finally:
                         # mark node as done, progress bar is updated in callback.
                         topo.done(node)
+                        # Re-raise with package context since context var is lost across threads
 
     metrics.summarize(wkctx, "Building in parallel")
     _summary(wkctx, built_entries)

--- a/src/fromager/commands/download_sequence.py
+++ b/src/fromager/commands/download_sequence.py
@@ -83,7 +83,8 @@ def download_sequence(
             except Exception as err:
                 logger.error(f"failed to download sdist for {req}: {err}")
                 if not ignore_missing_sdists:
-                    raise
+                    # Re-raise with package context since context var is lost across threads
+                    raise RuntimeError(f"Failed to download sdist for {req}") from err
         else:
             logger.info(
                 f"{entry['dist']}: uses a {entry['source_url_type']} downloader, skipping"


### PR DESCRIPTION
Add package name context to exception formatting to identify which
package failed during build errors. The package name is added by
FromagerLogRecord when messages are logged, and _format_exception
handles formatting chained exceptions with 'because' syntax.

Improve parallel build error handling to preserve package context
across thread boundaries using RuntimeError wrapper.

Tests added to test_external_commands.py verify error logging and
exception formatting include package names and handle chained exceptions.

Update e2e test pattern to match new log format that includes package names.

Closes: #845