### PR TITLE
test: add return type annotations to all test functions

### DIFF
--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -12,17 +12,17 @@ from fromager import bootstrapper, context, dependency_graph, packagesettings
 from fromager.commands import bootstrap
 
 
-def test_get_requirements_single_arg():
+def test_get_requirements_single_arg() -> None:
     requirements = bootstrap._get_requirements_from_args(["a"], [])
     assert [Requirement("a")] == requirements
 
 
-def test_get_requirements_multiple_args():
+def test_get_requirements_multiple_args() -> None:
     requirements = bootstrap._get_requirements_from_args(["a", "b"], [])
     assert [Requirement("a"), Requirement("b")] == requirements
 
 
-def test_get_requirements_args_and_file(tmp_path: pathlib.Path):
+def test_get_requirements_args_and_file(tmp_path: pathlib.Path) -> None:
     requirements_file = tmp_path / "requirements.txt"
     requirements_file.write_text("c\n")
     requirements = bootstrap._get_requirements_from_args(
@@ -35,14 +35,14 @@ def test_get_requirements_args_and_file(tmp_path: pathlib.Path):
     ] == requirements
 
 
-def test_ignore_based_on_marker():
+def test_ignore_based_on_marker() -> None:
     requirements = bootstrap._get_requirements_from_args(
         ['foo; python_version<"3.9"'], []
     )
     assert [] == requirements
 
 
-def test_write_constraints_file_simple():
+def test_write_constraints_file_simple() -> None:
     buffer = io.StringIO()
     raw_graph = {
         "": {
@@ -87,7 +87,7 @@ def test_write_constraints_file_simple():
     assert expected == buffer.getvalue()
 
 
-def test_write_constraints_file_resolvable_duplicate():
+def test_write_constraints_file_resolvable_duplicate() -> None:
     buffer = io.StringIO()
     raw_graph = {
         "": {
@@ -140,7 +140,7 @@ def test_write_constraints_file_resolvable_duplicate():
     assert expected == buffer.getvalue()
 
 
-def test_write_constraints_file_unresolvable_duplicate():
+def test_write_constraints_file_unresolvable_duplicate() -> None:
     """Test that unresolvable duplicates cause the function to return False and not write conflicting constraints.
 
     This test has conflicting requirements for package 'c':
@@ -203,7 +203,7 @@ def test_write_constraints_file_unresolvable_duplicate():
     assert "c==" not in output  # No conflicting c versions should be written
 
 
-def test_write_constraints_file_duplicates():
+def test_write_constraints_file_duplicates() -> None:
     buffer = io.StringIO()
     raw_graph = {
         "": {
@@ -283,7 +283,7 @@ def test_write_constraints_file_duplicates():
     assert "b==" not in output_content
 
 
-def test_write_constraints_file_multiples():
+def test_write_constraints_file_multiples() -> None:
     buffer = io.StringIO()
     raw_graph = {
         "": {
@@ -342,7 +342,7 @@ def test_write_constraints_file_multiples():
     assert expected == buffer.getvalue()
 
 
-def test_write_constraints_file_prevents_false_resolution():
+def test_write_constraints_file_prevents_false_resolution() -> None:
     """Test that packages marked as unresolvable in early iterations stay unresolvable.
 
     This test validates the fix for the bug where a package could appear unresolvable
@@ -452,7 +452,7 @@ def test_write_constraints_file_prevents_false_resolution():
     assert "conflicted==" not in output_content
 
 
-def test_to_constraints_command_no_file_on_failure(tmp_path):
+def test_to_constraints_command_no_file_on_failure(tmp_path: pathlib.Path) -> None:
     """Test that the to-constraints logic doesn't create output files when there are constraint conflicts.
 
     This is a regression test for the bug where constraint resolution would write partial
@@ -531,7 +531,7 @@ def test_to_constraints_command_no_file_on_failure(tmp_path):
     )
 
 
-def test_skip_constraints_cli_option():
+def test_skip_constraints_cli_option() -> None:
     """Test that the --skip-constraints option is available in the CLI"""
     runner = CliRunner()
     result = runner.invoke(bootstrap.bootstrap, ["--help"])
@@ -545,7 +545,7 @@ def test_skip_constraints_cli_option():
 def test_resolve_version_from_git_url_with_submodules_enabled(
     mock_git_clone: Mock,
     tmp_context: context.WorkContext,
-):
+) -> None:
     """Test that git_clone is called with submodules=True when configured."""
     req = Requirement("test-pkg @ git+https://github.com/example/repo.git")
 
@@ -582,7 +582,7 @@ def test_resolve_version_from_git_url_with_submodules_enabled(
 def test_resolve_version_from_git_url_with_specific_submodule_paths(
     mock_git_clone: Mock,
     tmp_context: context.WorkContext,
-):
+) -> None:
     """Test that git_clone is called with specific submodule paths when configured."""
     req = Requirement("test-pkg @ git+https://github.com/example/repo.git")
 
@@ -618,7 +618,7 @@ def test_resolve_version_from_git_url_with_specific_submodule_paths(
 def test_resolve_version_from_git_url_with_submodules_disabled(
     mock_git_clone: Mock,
     tmp_context: context.WorkContext,
-):
+) -> None:
     """Test that git_clone is called with submodules=False by default."""
     req = Requirement("test-pkg @ git+https://github.com/example/repo.git")
 
@@ -645,7 +645,7 @@ def test_resolve_version_from_git_url_with_submodules_disabled(
 def test_resolve_version_from_git_url_with_git_ref(
     mock_git_clone: Mock,
     tmp_context: context.WorkContext,
-):
+) -> None:
     """Test that git_clone is called with the correct ref when URL includes @ref."""
     req = Requirement("test-pkg @ git+https://github.com/example/repo.git@v1.2.3")
 
@@ -677,7 +677,9 @@ def test_resolve_version_from_git_url_with_git_ref(
     assert call_args.kwargs["ref"] == "v1.2.3"
 
 
-def test_resolve_version_from_git_url_invalid_scheme(tmp_context: context.WorkContext):
+def test_resolve_version_from_git_url_invalid_scheme(
+    tmp_context: context.WorkContext,
+) -> None:
     """Test that non-git URLs raise ValueError."""
     req = Requirement("test-pkg @ https://github.com/example/repo.git")
 

--- a/tests/test_bootstrapper.py
+++ b/tests/test_bootstrapper.py
@@ -60,7 +60,7 @@ old_graph.add_dependency(
 )
 
 
-def test_resolve_from_graph_no_changes(tmp_context: WorkContext):
+def test_resolve_from_graph_no_changes(tmp_context: WorkContext) -> None:
     bt = bootstrapper.Bootstrapper(tmp_context, None, old_graph)
     bt.why = [(RequirementType.TOP_LEVEL, Requirement("foo"), Version("1.0.0"))]
 
@@ -98,7 +98,7 @@ def test_resolve_from_graph_no_changes(tmp_context: WorkContext):
     ) == ("", Version("5"))
 
 
-def test_resolve_from_graph_install_dep_upgrade(tmp_context: WorkContext):
+def test_resolve_from_graph_install_dep_upgrade(tmp_context: WorkContext) -> None:
     bt = bootstrapper.Bootstrapper(tmp_context, None, old_graph)
 
     # simulating new bootstrap with a toplevel requirement of pbr==8
@@ -135,7 +135,7 @@ def test_resolve_from_graph_install_dep_upgrade(tmp_context: WorkContext):
     ) == ("", Version("5"))
 
 
-def test_resolve_from_graph_install_dep_downgrade(tmp_context: WorkContext):
+def test_resolve_from_graph_install_dep_downgrade(tmp_context: WorkContext) -> None:
     bt = bootstrapper.Bootstrapper(tmp_context, None, old_graph)
 
     # simulating new bootstrap with a toplevel requirement of pbr<=6
@@ -172,7 +172,7 @@ def test_resolve_from_graph_install_dep_downgrade(tmp_context: WorkContext):
     ) == ("", Version("5"))
 
 
-def test_resolve_from_graph_toplevel_dep(tmp_context: WorkContext):
+def test_resolve_from_graph_toplevel_dep(tmp_context: WorkContext) -> None:
     bt = bootstrapper.Bootstrapper(tmp_context, None, old_graph)
 
     # simulating new bootstrap with a toplevel requirement for foo
@@ -226,19 +226,19 @@ def test_resolve_from_graph_toplevel_dep(tmp_context: WorkContext):
     ) == ("", Version("6"))
 
 
-def test_seen(tmp_context):
+def test_seen(tmp_context: WorkContext) -> None:
     bt = bootstrapper.Bootstrapper(tmp_context)
     req = Requirement("testdist")
-    version = "1.2"
+    version = Version("1.2")
     assert not bt._has_been_seen(req, version)
     bt._mark_as_seen(req, version)
     assert bt._has_been_seen(req, version)
 
 
-def test_seen_extras(tmp_context):
+def test_seen_extras(tmp_context: WorkContext) -> None:
     req1 = Requirement("testdist")
     req2 = Requirement("testdist[extra]")
-    version = "1.2"
+    version = Version("1.2")
     bt = bootstrapper.Bootstrapper(tmp_context)
     assert not bt._has_been_seen(req1, version)
     bt._mark_as_seen(req1, version)
@@ -249,19 +249,19 @@ def test_seen_extras(tmp_context):
     assert bt._has_been_seen(req2, version)
 
 
-def test_seen_name_canonicalization(tmp_context):
+def test_seen_name_canonicalization(tmp_context: WorkContext) -> None:
     req = Requirement("flit_core")
-    version = "1.2"
+    version = Version("1.2")
     bt = bootstrapper.Bootstrapper(tmp_context)
     assert not bt._has_been_seen(req, version)
     bt._mark_as_seen(req, version)
     assert bt._has_been_seen(req, version)
 
 
-def test_seen_requirements_sdist(tmp_context):
+def test_seen_requirements_sdist(tmp_context: WorkContext) -> None:
     bt = bootstrapper.Bootstrapper(tmp_context)
     req = Requirement("testdist")
-    version = "1.2"
+    version = Version("1.2")
     assert not bt._has_been_seen(req, version, sdist_only=False)
     assert not bt._has_been_seen(req, version, sdist_only=True)
     # sdist only does not affect wheel status
@@ -282,17 +282,17 @@ def test_seen_requirements_sdist(tmp_context):
     assert bt._has_been_seen(req2, version, sdist_only=False)
 
 
-def test_build_order(tmp_context):
+def test_build_order(tmp_context: WorkContext) -> None:
     bt = bootstrapper.Bootstrapper(tmp_context)
     bt._add_to_build_order(
         req=Requirement("buildme>1.0"),
-        version="6.0",
+        version=Version("6.0"),
         source_url="url",
         source_url_type="sdist",
     )
     bt._add_to_build_order(
         req=Requirement("testdist>1.0"),
-        version="1.2",
+        version=Version("1.2"),
         source_url="url",
         source_url_type="sdist",
     )
@@ -321,23 +321,23 @@ def test_build_order(tmp_context):
     assert expected == contents
 
 
-def test_build_order_repeats(tmp_context):
+def test_build_order_repeats(tmp_context: WorkContext) -> None:
     bt = bootstrapper.Bootstrapper(tmp_context)
     bt._add_to_build_order(
         Requirement("buildme>1.0"),
-        "6.0",
+        Version("6.0"),
         "url",
         "sdist",
     )
     bt._add_to_build_order(
         Requirement("buildme>1.0"),
-        "6.0",
+        Version("6.0"),
         "url",
         "sdist",
     )
     bt._add_to_build_order(
         Requirement("buildme[extra]>1.0"),
-        "6.0",
+        Version("6.0"),
         "url",
         "sdist",
     )
@@ -357,17 +357,17 @@ def test_build_order_repeats(tmp_context):
     assert expected == contents
 
 
-def test_build_order_name_canonicalization(tmp_context):
+def test_build_order_name_canonicalization(tmp_context: WorkContext) -> None:
     bt = bootstrapper.Bootstrapper(tmp_context)
     bt._add_to_build_order(
         Requirement("flit-core>1.0"),
-        "3.9.0",
+        Version("3.9.0"),
         "url",
         "sdist",
     )
     bt._add_to_build_order(
         Requirement("flit_core>1.0"),
-        "3.9.0",
+        Version("3.9.0"),
         "url",
         "sdist",
     )
@@ -387,7 +387,7 @@ def test_build_order_name_canonicalization(tmp_context):
     assert expected == contents
 
 
-def test_explain(tmp_context: WorkContext):
+def test_explain(tmp_context: WorkContext) -> None:
     bt = bootstrapper.Bootstrapper(tmp_context, None, old_graph)
     bt.why = [(RequirementType.TOP_LEVEL, Requirement("foo"), Version("1.0.0"))]
     assert bt._explain == f"{RequirementType.TOP_LEVEL} dependency foo (1.0.0)"
@@ -405,7 +405,7 @@ def test_explain(tmp_context: WorkContext):
     )
 
 
-def test_is_build_requirement(tmp_context: WorkContext):
+def test_is_build_requirement(tmp_context: WorkContext) -> None:
     bt = bootstrapper.Bootstrapper(tmp_context, None, old_graph)
     bt.why = []
     assert not bt._processing_build_requirement(RequirementType.TOP_LEVEL)

--- a/tests/test_build_environment.py
+++ b/tests/test_build_environment.py
@@ -13,7 +13,7 @@ from fromager.requirements_file import RequirementType
 def test_missing_dependency_format(
     resolve_dist: Mock,
     tmp_context: WorkContext,
-):
+) -> None:
     resolutions = {
         "flit_core": "3.9.0",
         "setuptools": "69.5.1",
@@ -40,7 +40,7 @@ def test_missing_dependency_format(
     assert "flit_core -> 3.9.0" in s
 
 
-def test_missing_dependency_pattern():
+def test_missing_dependency_pattern() -> None:
     msg = textwrap.dedent("""
         DEBUG uv 0.8.4
         DEBUG Searching for default Python interpreter in virtual environments
@@ -62,7 +62,7 @@ def test_missing_dependency_pattern():
     assert match is not None
 
 
-def test_missing_dependency_pattern_resolution_impossible():
+def test_missing_dependency_pattern_resolution_impossible() -> None:
     msg = textwrap.dedent("""
         DEBUG uv 0.8.4
         DEBUG Searching for default Python interpreter in virtual environments

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -9,7 +9,7 @@ def get_option_names(cmd: click.Command) -> typing.Iterable[str]:
     return [o.name for o in cmd.params if o.name]
 
 
-def test_bootstrap_pallel_options() -> None:
+def test_bootstrap_parallel_options() -> None:
     expected: set[str] = set()
     expected.update(get_option_names(bootstrap.bootstrap))
     expected.update(get_option_names(build.build_parallel))

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -9,33 +9,33 @@ from packaging.version import Version
 from fromager import constraints
 
 
-def test_constraint_is_satisfied_by():
+def test_constraint_is_satisfied_by() -> None:
     c = constraints.Constraints()
     c.add_constraint("foo<=1.1")
-    assert c.is_satisfied_by("foo", "1.1")
+    assert c.is_satisfied_by("foo", Version("1.1"))
     assert c.is_satisfied_by("foo", Version("1.0"))
     assert c.is_satisfied_by("bar", Version("2.0"))
 
 
-def test_constraint_canonical_name():
+def test_constraint_canonical_name() -> None:
     c = constraints.Constraints()
     c.add_constraint("flash_attn<=1.1")
-    assert c.is_satisfied_by("flash_attn", "1.1")
-    assert c.is_satisfied_by("flash-attn", "1.1")
-    assert c.is_satisfied_by("Flash-ATTN", "1.1")
+    assert c.is_satisfied_by("flash_attn", Version("1.1"))
+    assert c.is_satisfied_by("flash-attn", Version("1.1"))
+    assert c.is_satisfied_by("Flash-ATTN", Version("1.1"))
     assert list(c) == ["flash-attn"]
 
 
-def test_constraint_not_is_satisfied_by():
+def test_constraint_not_is_satisfied_by() -> None:
     c = constraints.Constraints()
     c.add_constraint("foo<=1.1")
     c.add_constraint("bar>=2.0")
-    assert not c.is_satisfied_by("foo", "1.2")
+    assert not c.is_satisfied_by("foo", Version("1.2"))
     assert not c.is_satisfied_by("foo", Version("2.0"))
     assert not c.is_satisfied_by("bar", Version("1.0"))
 
 
-def test_add_constraint_conflict():
+def test_add_constraint_conflict() -> None:
     c = constraints.Constraints()
     c.add_constraint("foo<=1.1")
     c.add_constraint("flit_core==2.0rc3")
@@ -101,7 +101,7 @@ def test_add_constraint_conflict():
         )
 
 
-def test_allow_prerelease():
+def test_allow_prerelease() -> None:
     c = constraints.Constraints()
     c.add_constraint("foo>=1.1")
     assert not c.allow_prerelease("foo")
@@ -111,14 +111,14 @@ def test_allow_prerelease():
     assert c.allow_prerelease("flit_core")
 
 
-def test_load_non_existant_constraints_file(tmp_path: pathlib.Path):
+def test_load_non_existant_constraints_file(tmp_path: pathlib.Path) -> None:
     non_existant_file = tmp_path / "non_existant.txt"
     c = constraints.Constraints()
     with pytest.raises(FileNotFoundError):
         c.load_constraints_file(non_existant_file)
 
 
-def test_load_constraints_file(tmp_path: pathlib.Path):
+def test_load_constraints_file(tmp_path: pathlib.Path) -> None:
     constraint_file = tmp_path / "constraint.txt"
     constraint_file.write_text("egg\ntorch==3.1.0 # comment\n")
     c = constraints.Constraints()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,9 +1,10 @@
 import os
+import pathlib
 
 from fromager import context
 
 
-def test_pip_constraints_args(tmp_path):
+def test_pip_constraints_args(tmp_path: pathlib.Path) -> None:
     constraints_file = tmp_path / "constraints.txt"
     constraints_file.write_text("\n")  # the file has to exist
     ctx = context.WorkContext(

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -49,15 +49,15 @@ _fromager_root = pathlib.Path(__file__).parent.parent
 def test_get_build_backend(
     build_system: dict[str, list[str]] | dict[str, str | list[str] | None],
     expected_results: dict[str, typing.Any] | dict[str, str | list[str] | None],
-):
+) -> None:
     pyproject_toml = {"build-system": build_system}
     actual = dependencies.get_build_backend(pyproject_toml)
     assert expected_results == actual
 
 
-def _clean_build_artifacts(f):
+def _clean_build_artifacts(f: typing.Callable[..., None]) -> typing.Callable[..., None]:
     @functools.wraps(f)
-    def _with_cleanup(*args, **kwds):
+    def _with_cleanup(*args: typing.Any, **kwds: typing.Any) -> None:
         try:
             f(*args, **kwds)
         finally:
@@ -74,7 +74,7 @@ def _clean_build_artifacts(f):
 @_clean_build_artifacts
 def test_get_build_system_dependencies(
     _: Mock, tmp_context: context.WorkContext, tmp_path: pathlib.Path
-):
+) -> None:
     pyproject_file = _fromager_root / "pyproject.toml"
     shutil.copyfile(pyproject_file, tmp_path / "pyproject.toml")
 
@@ -89,7 +89,7 @@ def test_get_build_system_dependencies(
 
 def test_get_build_system_dependencies_cached(
     tmp_context: context.WorkContext, tmp_path: pathlib.Path
-):
+) -> None:
     sdist_root_dir = tmp_path / "sdist"
     sdist_root_dir.mkdir()
 
@@ -107,7 +107,7 @@ def test_get_build_system_dependencies_cached(
 @_clean_build_artifacts
 def test_get_build_backend_dependencies(
     _: Mock, tmp_context: context.WorkContext, tmp_path: pathlib.Path
-):
+) -> None:
     # We have to install the build system dependencies into the build
     # environment to get the build sdist dependencies, and we are not running
     # our own local wheel server, so use the public one.
@@ -137,7 +137,7 @@ def test_get_build_backend_dependencies(
 
 def test_get_build_backend_dependencies_cached(
     tmp_context: context.WorkContext, tmp_path: pathlib.Path
-):
+) -> None:
     sdist_root_dir = tmp_path / "sdist"
     sdist_root_dir.mkdir()
 
@@ -161,7 +161,7 @@ def test_get_build_backend_dependencies_cached(
 @_clean_build_artifacts
 def test_get_build_sdist_dependencies(
     _: Mock, tmp_context: context.WorkContext, tmp_path: pathlib.Path
-):
+) -> None:
     # We have to install the build system dependencies into the build
     # environment to get the build sdist dependencies, and we are not running
     # our own local wheel server, so use the public one.
@@ -191,7 +191,7 @@ def test_get_build_sdist_dependencies(
 
 def test_get_build_sdist_dependencies_cached(
     tmp_context: context.WorkContext, tmp_path: pathlib.Path
-):
+) -> None:
     sdist_root_dir = tmp_path / "sdist"
     sdist_root_dir.mkdir()
 

--- a/tests/test_dependency_graph.py
+++ b/tests/test_dependency_graph.py
@@ -44,7 +44,7 @@ def test_dependencynode_hash() -> None:
     assert s == {mknode("a")}
 
 
-def test_dependencynode_dataclass():
+def test_dependencynode_dataclass() -> None:
     a = mknode("a", "1.0")
     assert a.canonicalized_name == "a"
     assert a.version == Version("1.0")
@@ -54,9 +54,9 @@ def test_dependencynode_dataclass():
         == "DependencyNode(canonicalized_name='a', version=<Version('1.0')>, download_url='', pre_built=False, constraint=None)"
     )
     with pytest.raises(dataclasses.FrozenInstanceError):
-        a.version = Version("2.0")
+        a.version = Version("2.0")  # type: ignore[misc]
     with pytest.raises((TypeError, AttributeError)):
-        a.new_attribute = None
+        a.new_attribute = None  # type: ignore[attr-defined]
 
     root = DependencyNode.construct_root_node()
     assert root.canonicalized_name == ""

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -2,7 +2,7 @@ import inspect
 from importlib.metadata import entry_points
 
 
-def test_ep_override_methods():
+def test_ep_override_methods() -> None:
     epg = entry_points(group="fromager.override_methods")
     assert epg
     for name in epg.names:

--- a/tests/test_external_commands.py
+++ b/tests/test_external_commands.py
@@ -9,19 +9,19 @@ import pytest
 from fromager import external_commands
 
 
-def test_external_commands_environ():
+def test_external_commands_environ() -> None:
     env = {"BLAH": "test"}
     output = external_commands.run(["sh", "-c", "echo $BLAH"], extra_environ=env)
     assert "test\n" == output
 
 
-def test_external_commands_log_file(tmp_path):
+def test_external_commands_log_file(tmp_path: pathlib.Path) -> None:
     log_filename = pathlib.Path(tmp_path) / "test.log"
     env = {"BLAH": "test"}
     output = external_commands.run(
         ["sh", "-c", "echo $BLAH"],
         extra_environ=env,
-        log_filename=log_filename,
+        log_filename=str(log_filename),
     )
     assert "test\n" == output
     assert log_filename.exists()
@@ -38,7 +38,7 @@ def test_external_commands_log_file(tmp_path):
 def test_external_commands_network_isolation(
     m_network_isolation_cmd: mock.Mock,
     m_run: mock.Mock,
-):
+) -> None:
     os.environ.clear()
     external_commands.run(
         ["host", "github.com"],
@@ -76,7 +76,7 @@ else:
     not SUPPORTS_NETWORK_ISOLATION,
     reason=f"network isolation is not supported: {NETWORK_ISOLATION_ERROR}",
 )
-def test_external_commands_network_isolation_real():
+def test_external_commands_network_isolation_real() -> None:
     with pytest.raises(external_commands.NetworkIsolationError) as e:
         external_commands.run(
             ["host", "github.com"],

--- a/tests/test_find_updates.py
+++ b/tests/test_find_updates.py
@@ -7,73 +7,73 @@ from fromager.commands.find_updates import _get_constraint_version
 class TestGetConstraintVersion:
     """Test cases for _get_constraint_version function."""
 
-    def test_equality_constraint(self):
+    def test_equality_constraint(self) -> None:
         """Test that equality constraints return the correct version."""
         req = Requirement("package==1.2.3")
         result = _get_constraint_version(req)
         assert result == Version("1.2.3")
 
-    def test_less_than_constraint(self):
+    def test_less_than_constraint(self) -> None:
         """Test that less than constraints return the correct version."""
         req = Requirement("package<2.0.0")
         result = _get_constraint_version(req)
         assert result == Version("2.0.0")
 
-    def test_less_than_or_equal_constraint(self):
+    def test_less_than_or_equal_constraint(self) -> None:
         """Test that less than or equal constraints return the correct version."""
         req = Requirement("package<=1.5.0")
         result = _get_constraint_version(req)
         assert result == Version("1.5.0")
 
-    def test_greater_than_constraint_unsupported(self):
+    def test_greater_than_constraint_unsupported(self) -> None:
         """Test that greater than constraints return None (unsupported)."""
         req = Requirement("package>1.0.0")
         result = _get_constraint_version(req)
         assert result is None
 
-    def test_greater_than_or_equal_constraint_unsupported(self):
+    def test_greater_than_or_equal_constraint_unsupported(self) -> None:
         """Test that greater than or equal constraints return None (unsupported)."""
         req = Requirement("package>=1.0.0")
         result = _get_constraint_version(req)
         assert result is None
 
-    def test_no_version_constraint(self):
+    def test_no_version_constraint(self) -> None:
         """Test that requirements without version constraints return None."""
         req = Requirement("package")
         result = _get_constraint_version(req)
         assert result is None
 
-    def test_multiple_constraints_with_one_supported(self):
+    def test_multiple_constraints_with_one_supported(self) -> None:
         """Test that multiple constraints with one supported constraint return the supported one."""
         req = Requirement("package>=1.0.0,<2.0.0")
         result = _get_constraint_version(req)
         assert result == Version("2.0.0")
 
-    def test_constraint_with_markers(self):
+    def test_constraint_with_markers(self) -> None:
         """Test that constraints with environment markers still work correctly."""
         req = Requirement("package==1.2.3; python_version >= '3.8'")
         result = _get_constraint_version(req)
         assert result == Version("1.2.3")
 
-    def test_tilde_equal_constraint_supported(self):
+    def test_tilde_equal_constraint_supported(self) -> None:
         """Test that tilde equal constraints (~=) return the correct version."""
         req = Requirement("package~=1.4.2")
         result = _get_constraint_version(req)
         assert result == Version("1.4.2")
 
-    def test_not_equal_constraint_supported(self):
+    def test_not_equal_constraint_supported(self) -> None:
         """Test that not equal constraints (!=) return the correct version."""
         req = Requirement("package!=1.0.0")
         result = _get_constraint_version(req)
         assert result == Version("1.0.0")
 
-    def test_arbitrary_equality_constraint_supported(self):
+    def test_arbitrary_equality_constraint_supported(self) -> None:
         """Test that arbitrary equality constraints (===) return the correct version."""
         req = Requirement("package===1.0.0")
         result = _get_constraint_version(req)
         assert result == Version("1.0.0")
 
-    def test_invalid_version_format(self):
+    def test_invalid_version_format(self) -> None:
         """Test that invalid version formats return None."""
         # We need to test the case where Version() construction fails
         # Let's create a requirement and then mock the Version parsing

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -2,9 +2,8 @@ import pathlib
 
 import pytest
 from packaging.requirements import Requirement
-from packaging.version import Version
 
-from fromager import finders
+from fromager import context, finders
 
 
 @pytest.mark.parametrize(
@@ -17,7 +16,13 @@ from fromager import finders
         ("ruamel-yaml", "0.18.6", "ruamel.yaml-0.18.6.tar.gz"),
     ],
 )
-def test_find_sdist(tmp_path, tmp_context, dist_name, version_string, expected_base):
+def test_find_sdist(
+    tmp_path: pathlib.Path,
+    tmp_context: context.WorkContext,
+    dist_name: str,
+    version_string: str,
+    expected_base: str,
+) -> None:
     sdists_repo = pathlib.Path(tmp_path)
     downloads = sdists_repo / "downloads"
     downloads.mkdir()
@@ -25,8 +30,7 @@ def test_find_sdist(tmp_path, tmp_context, dist_name, version_string, expected_b
     archive.write_text("not-empty")
 
     req = Requirement(dist_name)
-    ver = Version(version_string)
-    actual = finders.find_sdist(tmp_context, downloads, req, ver)
+    actual = finders.find_sdist(tmp_context, downloads, req, version_string)
     assert str(archive) == str(actual)
 
 
@@ -40,7 +44,9 @@ def test_find_sdist(tmp_path, tmp_context, dist_name, version_string, expected_b
         ("ruamel-yaml", "0.18.6", "ruamel.yaml-0.18.6-py3-none-any.whl"),
     ],
 )
-def test_find_wheel(tmp_path, dist_name, version_string, expected_base):
+def test_find_wheel(
+    tmp_path: pathlib.Path, dist_name: str, version_string: str, expected_base: str
+) -> None:
     wheels_repo = pathlib.Path(tmp_path)
     downloads = wheels_repo / "downloads"
     downloads.mkdir()
@@ -48,8 +54,7 @@ def test_find_wheel(tmp_path, dist_name, version_string, expected_base):
     wheel.write_text("not-empty")
 
     req = Requirement(dist_name)
-    ver = Version(version_string)
-    actual = finders.find_wheel(downloads, req, ver, 0)
+    actual = finders.find_wheel(downloads, req, version_string, ())
     assert str(wheel) == str(actual)
 
 
@@ -63,8 +68,13 @@ def test_find_wheel(tmp_path, dist_name, version_string, expected_base):
     ],
 )
 def test_find_source_dir(
-    tmp_path, tmp_context, dist_name, version_string, unpack_base, source_base
-):
+    tmp_path: pathlib.Path,
+    tmp_context: context.WorkContext,
+    dist_name: str,
+    version_string: str,
+    unpack_base: str,
+    source_base: str,
+) -> None:
     work_dir = pathlib.Path(tmp_path)
     unpack_dir = work_dir / unpack_base
     unpack_dir.mkdir()
@@ -73,6 +83,5 @@ def test_find_source_dir(
     print(f"created {source_dir}")
 
     req = Requirement(dist_name)
-    ver = Version(version_string)
-    actual = finders.find_source_dir(tmp_context, work_dir, req, ver)
+    actual = finders.find_source_dir(tmp_context, work_dir, req, version_string)
     assert str(source_dir) == str(actual)

--- a/tests/test_http_retry.py
+++ b/tests/test_http_retry.py
@@ -20,14 +20,14 @@ from fromager import http_retry
 class TestRetryHTTPAdapter:
     """Test cases for RetryHTTPAdapter class."""
 
-    def test_init_with_default_config(self):
+    def test_init_with_default_config(self) -> None:
         """Test adapter initialization with default configuration."""
         adapter = http_retry.RetryHTTPAdapter()
         assert adapter.timeout == 60.0
         assert adapter.backoff_factor == 1.0
         assert adapter.max_backoff == 60.0
 
-    def test_init_with_custom_config(self):
+    def test_init_with_custom_config(self) -> None:
         """Test adapter initialization with custom configuration."""
         custom_config = {
             "total": 3,
@@ -40,7 +40,7 @@ class TestRetryHTTPAdapter:
         assert adapter.timeout == 30.0
         assert adapter.backoff_factor == 2.0
 
-    def test_init_with_invalid_config_types(self):
+    def test_init_with_invalid_config_types(self) -> None:
         """Test adapter handles invalid configuration types gracefully."""
         invalid_config = {
             "total": "invalid",
@@ -55,7 +55,9 @@ class TestRetryHTTPAdapter:
 
     @patch("fromager.http_retry.RetryHTTPAdapter._handle_github_rate_limit")
     @patch("requests.adapters.HTTPAdapter.send")
-    def test_send_successful_response(self, mock_super_send, mock_github_handler):
+    def test_send_successful_response(
+        self, mock_super_send, mock_github_handler
+    ) -> None:
         """Test successful HTTP request without retries."""
         adapter = http_retry.RetryHTTPAdapter()
         request = Mock(spec=requests.PreparedRequest)
@@ -73,7 +75,7 @@ class TestRetryHTTPAdapter:
 
     @patch("time.sleep")
     @patch("requests.adapters.HTTPAdapter.send")
-    def test_send_retries_on_server_errors(self, mock_super_send, mock_sleep):
+    def test_send_retries_on_server_errors(self, mock_super_send, mock_sleep) -> None:
         """Test retry behavior on server error status codes."""
         adapter = http_retry.RetryHTTPAdapter()
         request = Mock(spec=requests.PreparedRequest)
@@ -94,7 +96,7 @@ class TestRetryHTTPAdapter:
 
     @patch("time.sleep")
     @patch("requests.adapters.HTTPAdapter.send")
-    def test_send_github_rate_limit_handling(self, mock_super_send, mock_sleep):
+    def test_send_github_rate_limit_handling(self, mock_super_send, mock_sleep) -> None:
         """Test GitHub API rate limit handling."""
         adapter = http_retry.RetryHTTPAdapter()
         request = Mock(spec=requests.PreparedRequest)
@@ -119,7 +121,9 @@ class TestRetryHTTPAdapter:
 
     @patch("time.sleep")
     @patch("requests.adapters.HTTPAdapter.send")
-    def test_send_retries_on_connection_error(self, mock_super_send, mock_sleep):
+    def test_send_retries_on_connection_error(
+        self, mock_super_send, mock_sleep
+    ) -> None:
         """Test retry behavior on connection errors."""
         adapter = http_retry.RetryHTTPAdapter()
         request = Mock(spec=requests.PreparedRequest)
@@ -141,7 +145,7 @@ class TestRetryHTTPAdapter:
         mock_sleep.assert_called_once()
 
     @patch("requests.adapters.HTTPAdapter.send")
-    def test_send_exhausts_retries_and_raises(self, mock_super_send):
+    def test_send_exhausts_retries_and_raises(self, mock_super_send) -> None:
         """Test that retries are exhausted and exception is raised."""
         adapter = http_retry.RetryHTTPAdapter(retry_config={"total": 1})
         request = Mock(spec=requests.PreparedRequest)
@@ -152,7 +156,7 @@ class TestRetryHTTPAdapter:
         with pytest.raises(ConnectionError):
             adapter.send(request)
 
-    def test_handle_github_rate_limit_with_reset_header(self):
+    def test_handle_github_rate_limit_with_reset_header(self) -> None:
         """Test GitHub rate limit handling with reset header."""
         adapter = http_retry.RetryHTTPAdapter()
         response = Mock(spec=requests.Response)
@@ -164,7 +168,7 @@ class TestRetryHTTPAdapter:
             adapter._handle_github_rate_limit(response, 0, 3)
             mock_sleep.assert_called_once()
 
-    def test_handle_github_rate_limit_without_reset_header(self):
+    def test_handle_github_rate_limit_without_reset_header(self) -> None:
         """Test GitHub rate limit handling without reset header."""
         adapter = http_retry.RetryHTTPAdapter()
         response = Mock(spec=requests.Response)
@@ -176,7 +180,7 @@ class TestRetryHTTPAdapter:
             adapter._handle_github_rate_limit(response, 0, 3)
             mock_sleep.assert_called_once()
 
-    def test_handle_retryable_exception(self):
+    def test_handle_retryable_exception(self) -> None:
         """Test handling of retryable exceptions."""
         adapter = http_retry.RetryHTTPAdapter()
         request = Mock(spec=requests.PreparedRequest)
@@ -187,7 +191,7 @@ class TestRetryHTTPAdapter:
             adapter._handle_retryable_exception(exception, request, 0, 3)
             mock_sleep.assert_called_once()
 
-    def test_handle_retryable_exception_max_attempts(self):
+    def test_handle_retryable_exception_max_attempts(self) -> None:
         """Test handling retryable exception at max attempts."""
         adapter = http_retry.RetryHTTPAdapter()
         request = Mock(spec=requests.PreparedRequest)
@@ -202,14 +206,14 @@ class TestRetryHTTPAdapter:
 class TestCreateRetrySession:
     """Test cases for create_retry_session function."""
 
-    def test_create_retry_session_default(self):
+    def test_create_retry_session_default(self) -> None:
         """Test creating a retry session with default configuration."""
         session = http_retry.create_retry_session()
         assert isinstance(session, requests.Session)
         assert "http://" in session.adapters
         assert "https://" in session.adapters
 
-    def test_create_retry_session_custom_config(self):
+    def test_create_retry_session_custom_config(self) -> None:
         """Test creating a retry session with custom configuration."""
         custom_config = {"total": 3, "backoff_factor": 2.0}
         session = http_retry.create_retry_session(
@@ -217,7 +221,7 @@ class TestCreateRetrySession:
         )
         assert isinstance(session, requests.Session)
 
-    def test_create_retry_session_basic(self):
+    def test_create_retry_session_basic(self) -> None:
         """Test basic session creation."""
         session = http_retry.create_retry_session()
         assert isinstance(session.get_adapter("http://"), http_retry.RetryHTTPAdapter)
@@ -228,7 +232,7 @@ class TestCreateRetrySession:
 class TestRetryOnExceptionDecorator:
     """Test cases for retry_on_exception decorator."""
 
-    def test_retry_decorator_success_on_first_attempt(self):
+    def test_retry_decorator_success_on_first_attempt(self) -> None:
         """Test decorator when function succeeds on first attempt."""
 
         @http_retry.retry_on_exception(max_attempts=3)
@@ -238,7 +242,7 @@ class TestRetryOnExceptionDecorator:
         result = successful_function()
         assert result == "success"
 
-    def test_retry_decorator_success_after_retries(self):
+    def test_retry_decorator_success_after_retries(self) -> None:
         """Test decorator when function succeeds after retries."""
         call_count = 0
 
@@ -255,7 +259,7 @@ class TestRetryOnExceptionDecorator:
             assert result == "success"
             assert call_count == 3
 
-    def test_retry_decorator_exhausts_attempts(self):
+    def test_retry_decorator_exhausts_attempts(self) -> None:
         """Test decorator when all retry attempts are exhausted."""
 
         @http_retry.retry_on_exception(max_attempts=2, backoff_factor=0.01)
@@ -266,7 +270,7 @@ class TestRetryOnExceptionDecorator:
             with pytest.raises(ConnectionError):
                 always_failing_function()
 
-    def test_retry_decorator_non_retryable_exception(self):
+    def test_retry_decorator_non_retryable_exception(self) -> None:
         """Test decorator with non-retryable exception."""
 
         @http_retry.retry_on_exception(exceptions=(ConnectionError,), max_attempts=3)
@@ -276,7 +280,7 @@ class TestRetryOnExceptionDecorator:
         with pytest.raises(ValueError):
             function_with_non_retryable_exception()
 
-    def test_retry_decorator_custom_exceptions(self):
+    def test_retry_decorator_custom_exceptions(self) -> None:
         """Test decorator with custom exception types."""
 
         @http_retry.retry_on_exception(
@@ -289,7 +293,7 @@ class TestRetryOnExceptionDecorator:
             with pytest.raises(ValueError):
                 function_with_custom_exceptions()
 
-    def test_retry_decorator_with_function_arguments(self):
+    def test_retry_decorator_with_function_arguments(self) -> None:
         """Test decorator preserves function arguments."""
 
         @http_retry.retry_on_exception(max_attempts=2)
@@ -303,7 +307,7 @@ class TestRetryOnExceptionDecorator:
 class TestGetRetrySession:
     """Test cases for get_retry_session function."""
 
-    def test_get_retry_session(self):
+    def test_get_retry_session(self) -> None:
         """Test getting a pre-configured retry session."""
         session = http_retry.get_retry_session()
         assert isinstance(session, requests.Session)
@@ -314,21 +318,25 @@ class TestGetRetrySession:
 class TestDefaultRetryConfig:
     """Test cases for default retry configuration."""
 
-    def test_default_retry_config_values(self):
+    def test_default_retry_config_values(self) -> None:
         """Test that default retry configuration has expected values."""
         config = http_retry.DEFAULT_RETRY_CONFIG
         assert config["total"] == 5
         assert config["backoff_factor"] == 1.0
-        assert 429 in config["status_forcelist"]
-        assert 502 in config["status_forcelist"]
-        assert "GET" in config["allowed_methods"]
+        status_forcelist = config["status_forcelist"]
+        assert isinstance(status_forcelist, list)
+        assert 429 in status_forcelist
+        assert 502 in status_forcelist
+        allowed_methods = config["allowed_methods"]
+        assert isinstance(allowed_methods, list)
+        assert "GET" in allowed_methods
         assert config["raise_on_status"] is False
 
 
 class TestRetryableExceptions:
     """Test cases for retryable exceptions tuple."""
 
-    def test_retryable_exceptions_contains_expected_types(self):
+    def test_retryable_exceptions_contains_expected_types(self) -> None:
         """Test that RETRYABLE_EXCEPTIONS contains expected exception types."""
         exceptions = http_retry.RETRYABLE_EXCEPTIONS
         assert ConnectionError in exceptions
@@ -344,7 +352,7 @@ class TestRetryableExceptions:
 class TestIntegration:
     """Integration test cases."""
 
-    def test_end_to_end_retry_session(self):
+    def test_end_to_end_retry_session(self) -> None:
         """Test end-to-end usage of retry session."""
         # Test that we can create a session and access its adapters
         session = http_retry.create_retry_session()
@@ -357,7 +365,7 @@ class TestIntegration:
         http_adapter = session.adapters["https://"]
         assert http_adapter.timeout == 60.0
 
-    def test_adapter_with_various_retryable_exceptions(self):
+    def test_adapter_with_various_retryable_exceptions(self) -> None:
         """Test adapter handles various retryable exceptions."""
         adapter = http_retry.RetryHTTPAdapter(retry_config={"total": 1})
         request = Mock(spec=requests.PreparedRequest)
@@ -381,7 +389,7 @@ class TestIntegration:
 
     @patch("time.sleep")
     @patch("random.uniform", return_value=0.5)
-    def test_backoff_calculation(self, mock_random, mock_sleep):
+    def test_backoff_calculation(self, mock_random, mock_sleep) -> None:
         """Test backoff time calculation with jitter."""
         adapter = http_retry.RetryHTTPAdapter()
         request = Mock(spec=requests.PreparedRequest)
@@ -395,7 +403,7 @@ class TestIntegration:
 
 
 # Test standalone functions
-def test_default_retry_config_structure():
+def test_default_retry_config_structure() -> None:
     """Test that DEFAULT_RETRY_CONFIG has the correct structure."""
     config = http_retry.DEFAULT_RETRY_CONFIG
     expected_keys = {
@@ -408,14 +416,14 @@ def test_default_retry_config_structure():
     assert set(config.keys()) == expected_keys
 
 
-def test_retryable_exceptions_tuple_is_not_empty():
+def test_retryable_exceptions_tuple_is_not_empty() -> None:
     """Test that RETRYABLE_EXCEPTIONS is not empty."""
     assert len(http_retry.RETRYABLE_EXCEPTIONS) > 0
 
 
 @patch("time.sleep")
 @patch("random.uniform", return_value=0.1)
-def test_retry_decorator_backoff_timing(mock_random, mock_sleep):
+def test_retry_decorator_backoff_timing(mock_random, mock_sleep) -> None:
     """Test retry decorator backoff timing calculation."""
     call_count = 0
 
@@ -440,7 +448,7 @@ def test_retry_decorator_backoff_timing(mock_random, mock_sleep):
 
 
 @patch("fromager.http_retry.logger")
-def test_adapter_logging_on_retry(mock_logger):
+def test_adapter_logging_on_retry(mock_logger) -> None:
     """Test that appropriate logging occurs during retries."""
     adapter = http_retry.RetryHTTPAdapter()
     request = Mock(spec=requests.PreparedRequest)
@@ -458,7 +466,7 @@ def test_adapter_logging_on_retry(mock_logger):
 
 
 @patch("fromager.http_retry.logger")
-def test_adapter_logging_on_github_rate_limit(mock_logger):
+def test_adapter_logging_on_github_rate_limit(mock_logger) -> None:
     """Test logging during GitHub rate limit handling."""
     adapter = http_retry.RetryHTTPAdapter()
     response = Mock(spec=requests.Response)

--- a/tests/test_minimize.py
+++ b/tests/test_minimize.py
@@ -216,7 +216,7 @@ def test_minimize_command_with_output_file() -> None:
         assert content == "requests==2.28.1"
 
 
-def test_minimize_requirements_function():
+def test_minimize_requirements_function() -> None:
     """Test the _minimize_requirements function directly"""
 
     # Create a simple dependency graph
@@ -267,7 +267,7 @@ def test_minimize_requirements_function():
     assert "package-c" not in minimal_names  # Should be removed
 
 
-def test_minimize_requirements_version_mismatch():
+def test_minimize_requirements_version_mismatch() -> None:
     """Test that requirements with version mismatches are NOT removed"""
 
     # Create a dependency graph
@@ -307,7 +307,7 @@ def test_minimize_requirements_version_mismatch():
     assert "package-c" in minimal_names  # Should NOT be removed due to version mismatch
 
 
-def test_minimize_requirements_multiple_versions():
+def test_minimize_requirements_multiple_versions() -> None:
     """Test behavior with multiple versions of the same dependency"""
 
     # Create a dependency graph
@@ -406,7 +406,7 @@ def test_minimize_command_nonexistent_files() -> None:
         assert result.exit_code != 0, "Command should fail with nonexistent files"
 
 
-def test_minimize_requirements_multiple_entries_same_package():
+def test_minimize_requirements_multiple_entries_same_package() -> None:
     """Test that multiple entries for the same package are handled correctly"""
 
     # Create a dependency graph
@@ -450,7 +450,7 @@ def test_minimize_requirements_multiple_entries_same_package():
     assert "package-c==2.0.0" in minimal_strs
 
 
-def test_minimize_requirements_exact_version_preserved():
+def test_minimize_requirements_exact_version_preserved() -> None:
     """Test that requirements with exact version specifications (==) are never removed"""
 
     # Create a dependency graph

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -6,21 +6,21 @@ import pytest
 from fromager import overrides
 
 
-def test_invoke_override_with_exact_args():
+def test_invoke_override_with_exact_args() -> None:
     def foo(arg1, arg2):
         return arg1 is not None and arg2 is not None
 
     assert overrides.invoke(foo, arg1="value1", arg2="value2")
 
 
-def test_invoke_override_with_more_args_than_needed():
+def test_invoke_override_with_more_args_than_needed() -> None:
     def foo(arg1, arg2):
         return arg1 is not None and arg2 is not None
 
     assert overrides.invoke(foo, arg1="value1", arg2="value2", arg3="value3")
 
 
-def test_invoke_override_with_not_enough_args():
+def test_invoke_override_with_not_enough_args() -> None:
     def foo(arg1, arg2):
         return arg1 is not None and arg2 is not None
 
@@ -31,7 +31,7 @@ def test_invoke_override_with_not_enough_args():
 @patch("fromager.overrides.find_override_method")
 def test_find_and_invoke(
     find_override_method: mock.Mock,
-):
+) -> None:
     def default_foo(arg1):
         return arg1 is not None
 

--- a/tests/test_packagesettings.py
+++ b/tests/test_packagesettings.py
@@ -423,7 +423,7 @@ def test_pbi_other(testdata_context: context.WorkContext) -> None:
     assert pbi.get_all_patches() is pbi.get_all_patches()
 
 
-def test_type_envvars():
+def test_type_envvars() -> None:
     ta = pydantic.TypeAdapter(EnvVars)
     v = ta.validate_python(
         {"int": 1, "float": 2.0, "true": True, "false": False, "str": "string"}
@@ -441,7 +441,7 @@ def test_type_envvars():
         ta.validate_python({"none": None})
 
 
-def test_type_package():
+def test_type_package() -> None:
     ta = pydantic.TypeAdapter(Package)
     assert ta.validate_python("Some_Package") == "some-package"
     assert ta.validate_python("some.package") == "some-package"
@@ -449,7 +449,7 @@ def test_type_package():
         ta.validate_python("invalid/package")
 
 
-def test_type_builddirectory():
+def test_type_builddirectory() -> None:
     ta = pydantic.TypeAdapter(BuildDirectory)
     assert ta.validate_python("python") == pathlib.Path("python")
     assert ta.validate_python("../tmp/build") == pathlib.Path("../tmp/build")
@@ -457,7 +457,7 @@ def test_type_builddirectory():
         ta.validate_python("/absolute/path")
 
 
-def test_global_settings(testdata_path: pathlib.Path):
+def test_global_settings(testdata_path: pathlib.Path) -> None:
     filename = testdata_path / "context/overrides/settings.yaml"
     gs = SettingsFile.from_file(filename)
     assert gs.changelog == {
@@ -588,11 +588,13 @@ def test_parallel_jobs(
         ("$${var:-default}", {}, "${var:-default}"),
     ],
 )
-def test_substitute_template(value: str, template_env: dict[str, str], expected: str):
+def test_substitute_template(
+    value: str, template_env: dict[str, str], expected: str
+) -> None:
     assert substitute_template(value, template_env) == expected
 
 
-def test_substitute_template_key_error():
+def test_substitute_template_key_error() -> None:
     # This test expects a ValueError to be raised by substitute_template
     with pytest.raises(ValueError) as excinfo:
         substitute_template("${DEFAULT:-default} ${UNKNOWN}", {})
@@ -603,21 +605,21 @@ def test_substitute_template_key_error():
     )
 
 
-def test_git_options_default():
+def test_git_options_default() -> None:
     """Test that GitOptions has correct default values."""
     git_opts = GitOptions()
     assert git_opts.submodules is False
     assert git_opts.submodule_paths == []
 
 
-def test_git_options_with_submodules_enabled():
+def test_git_options_with_submodules_enabled() -> None:
     """Test GitOptions with submodules enabled."""
     git_opts = GitOptions(submodules=True)
     assert git_opts.submodules is True
     assert git_opts.submodule_paths == []
 
 
-def test_git_options_with_specific_paths():
+def test_git_options_with_specific_paths() -> None:
     """Test GitOptions with specific submodule paths."""
     paths = ["vendor/lib1", "vendor/lib2"]
     git_opts = GitOptions(submodule_paths=paths)
@@ -625,7 +627,7 @@ def test_git_options_with_specific_paths():
     assert git_opts.submodule_paths == paths
 
 
-def test_git_options_with_both_settings():
+def test_git_options_with_both_settings() -> None:
     """Test GitOptions with both submodules and paths configured."""
     paths = ["vendor/lib1"]
     git_opts = GitOptions(submodules=True, submodule_paths=paths)
@@ -633,7 +635,7 @@ def test_git_options_with_both_settings():
     assert git_opts.submodule_paths == paths
 
 
-def test_package_settings_git_options_default():
+def test_package_settings_git_options_default() -> None:
     """Test that PackageSettings includes GitOptions with defaults."""
     settings = PackageSettings.from_default("test-pkg")
     assert hasattr(settings, "git_options")
@@ -642,10 +644,10 @@ def test_package_settings_git_options_default():
     assert settings.git_options.submodule_paths == []
 
 
-def test_package_settings_git_options_from_dict():
+def test_package_settings_git_options_from_dict() -> None:
     """Test PackageSettings can parse git_options from dictionary."""
     settings = PackageSettings(
-        **{
+        **{  # type: ignore[arg-type]
             "name": "test-pkg",
             "has_config": True,
             "git_options": {
@@ -657,16 +659,16 @@ def test_package_settings_git_options_from_dict():
     assert settings.git_options.submodule_paths == []  # Default value
 
 
-def test_package_settings_git_options_from_dict_empty():
+def test_package_settings_git_options_from_dict_empty() -> None:
     """Test PackageSettings can parse empty git_options from dictionary."""
     settings = PackageSettings(
-        **{"name": "test-pkg", "has_config": True, "git_options": {}}
+        **{"name": "test-pkg", "has_config": True, "git_options": {}}  # type: ignore[arg-type]
     )
     assert settings.git_options.submodules is False  # Default value
     assert settings.git_options.submodule_paths == []  # Default value
 
 
-def test_package_settings_git_options_from_file(tmp_path):
+def test_package_settings_git_options_from_file(tmp_path) -> None:
     """Test PackageSettings can parse git_options from a YAML file."""
     data = """
 git_options:
@@ -679,7 +681,7 @@ git_options:
     assert settings.git_options.submodule_paths == ["path/to/submodule"]
 
 
-def test_package_build_info_git_options(testdata_context: context.WorkContext):
+def test_package_build_info_git_options(testdata_context: context.WorkContext) -> None:
     """Test that PackageBuildInfo exposes git_options property."""
     req = Requirement("test-pkg==1.0.0")
     pbi = testdata_context.package_build_info(req)
@@ -705,7 +707,9 @@ git_options:
     assert custom_settings.git_options.submodule_paths == ["vendor/lib"]
 
 
-def test_package_build_info_exclusive_build(testdata_context: context.WorkContext):
+def test_package_build_info_exclusive_build(
+    testdata_context: context.WorkContext,
+) -> None:
     """Test that PackageBuildInfo correctly exposes exclusive_build from build_options."""
     # Test default package (should have exclusive_build=False by default)
     req = Requirement("test-empty-pkg==1.0.0")
@@ -738,7 +742,7 @@ build_options:
     assert custom_pbi.exclusive_build is True
 
 
-def test_resolver_dist_validator():
+def test_resolver_dist_validator() -> None:
     with pytest.raises(pydantic.ValidationError):
         ResolverDist(include_wheels=False, ignore_platform=True)
 

--- a/tests/test_pep658_support.py
+++ b/tests/test_pep658_support.py
@@ -10,7 +10,7 @@ from fromager.candidate import Candidate, get_metadata_for_wheel
 class TestPEP658Support:
     """Test PEP 658 metadata support in fromager."""
 
-    def test_candidate_with_metadata_url(self):
+    def test_candidate_with_metadata_url(self) -> None:
         """Test that Candidate can be created with a metadata URL."""
         candidate = Candidate(
             name="test-package",
@@ -24,7 +24,7 @@ class TestPEP658Support:
             == "https://example.com/test-package-1.0.0-py3-none-any.whl.metadata"
         )
 
-    def test_candidate_without_metadata_url(self):
+    def test_candidate_without_metadata_url(self) -> None:
         """Test that Candidate works without metadata URL (legacy behavior)."""
         candidate = Candidate(
             name="test-package",
@@ -35,7 +35,7 @@ class TestPEP658Support:
         assert candidate.metadata_url is None
 
     @patch("fromager.candidate.session")
-    def test_get_metadata_with_pep658_success(self, mock_session):
+    def test_get_metadata_with_pep658_success(self, mock_session) -> None:
         """Test successful metadata retrieval via PEP 658 endpoint."""
         # Mock the metadata response
         mock_response = Mock()
@@ -65,7 +65,7 @@ Requires-Dist: requests >= 2.0.0
         mock_session.get.assert_called_once_with(metadata_url)
 
     @patch("fromager.candidate.session")
-    def test_get_metadata_pep658_fallback_behavior(self, mock_session):
+    def test_get_metadata_pep658_fallback_behavior(self, mock_session) -> None:
         """Test that PEP 658 is tried first, then falls back to wheel download."""
         # Mock that metadata URL fails, then wheel URL succeeds
         responses = []
@@ -102,7 +102,7 @@ Requires-Dist: requests >= 2.0.0
         assert mock_session.get.call_count == 2
 
     @patch("fromager.candidate.session")
-    def test_get_metadata_without_pep658_behavior(self, mock_session):
+    def test_get_metadata_without_pep658_behavior(self, mock_session) -> None:
         """Test that without PEP 658 metadata URL, only wheel URL is called."""
         # Mock wheel request
         responses = []
@@ -126,7 +126,7 @@ Requires-Dist: requests >= 2.0.0
         assert responses[0] == ("wheel", wheel_url)
         mock_session.get.assert_called_once_with(wheel_url)
 
-    def test_candidate_repr_with_metadata_url(self):
+    def test_candidate_repr_with_metadata_url(self) -> None:
         """Test that Candidate representation includes metadata URL info."""
         candidate = Candidate(
             name="test-package",
@@ -142,7 +142,7 @@ Requires-Dist: requests >= 2.0.0
             == "https://example.com/test-package-1.0.0-py3-none-any.whl.metadata"
         )
 
-    def test_metadata_url_construction(self):
+    def test_metadata_url_construction(self) -> None:
         """Test that metadata URLs are constructed correctly."""
         base_url = (
             "https://pypi.org/simple/test-package/test-package-1.0.0-py3-none-any.whl"
@@ -153,7 +153,7 @@ Requires-Dist: requests >= 2.0.0
         assert expected_metadata_url.endswith(".whl.metadata")
         assert expected_metadata_url.startswith("https://")
 
-    def test_pep658_integration_with_resolver(self):
+    def test_pep658_integration_with_resolver(self) -> None:
         """Test that PEP 658 metadata URLs are properly handled by the candidate system."""
         # Test the basic integration of metadata URLs with candidates
         candidate_with_metadata = Candidate(

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -5,7 +5,7 @@ import requests_mock
 from fromager import read
 
 
-def test_read_from_file(tmp_path: pathlib.Path):
+def test_read_from_file(tmp_path: pathlib.Path) -> None:
     file = tmp_path / "test"
     text = ["hello", "world"]
     file.write_text("\n".join(text))
@@ -14,7 +14,7 @@ def test_read_from_file(tmp_path: pathlib.Path):
             assert line.strip() == text[index]
 
 
-def test_read_from_url():
+def test_read_from_url() -> None:
     url = "https://someurl.com"
     text = ["hello", "world"]
     with requests_mock.Mocker() as r:

--- a/tests/test_requirements_file.py
+++ b/tests/test_requirements_file.py
@@ -13,14 +13,14 @@ from fromager.requirements_file import (
 )
 
 
-def test_get_requirements_requirements_file(tmp_path: pathlib.Path):
+def test_get_requirements_requirements_file(tmp_path: pathlib.Path) -> None:
     req_file = tmp_path / "requirements.txt"
     req_file.write_text("c\n")
     requirements = parse_requirements_file(req_file)
     assert requirements == ["c"]
 
 
-def test_get_requirements_requirements_file_comments(tmp_path: pathlib.Path):
+def test_get_requirements_requirements_file_comments(tmp_path: pathlib.Path) -> None:
     req_file = tmp_path / "requirements.txt"
     req_file.write_text(
         textwrap.dedent("""
@@ -34,14 +34,14 @@ def test_get_requirements_requirements_file_comments(tmp_path: pathlib.Path):
     assert requirements == ["c", "d"]
 
 
-def test_get_requirements_file_with_comments_and_blanks(tmp_path: pathlib.Path):
+def test_get_requirements_file_with_comments_and_blanks(tmp_path: pathlib.Path) -> None:
     req_file = tmp_path / "requirements.txt"
     req_file.write_text("a\n\n# ignore\nb\nc\n")
     requirements = parse_requirements_file(req_file)
     assert requirements == ["a", "b", "c"]
 
 
-def test_req_type_flag():
+def test_req_type_flag() -> None:
     assert not RequirementType.INSTALL.is_build_requirement
     assert not RequirementType.TOP_LEVEL.is_build_requirement
     assert RequirementType.BUILD_SYSTEM.is_build_requirement
@@ -62,7 +62,7 @@ def test_req_type_flag():
 @pytest.mark.parametrize(
     "parent_e,marker_e,extras_e", list(product(["b-c", "b_c", "B_C"], repeat=3))
 )
-def test_evaluate_marker_canonical_names(parent_e, marker_e, extras_e):
+def test_evaluate_marker_canonical_names(parent_e, marker_e, extras_e) -> None:
     parent_req = Requirement(f"a[{parent_e}]")
     req = Requirement("d")
     marker = Marker(f"extra == '{marker_e}'")

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -112,7 +112,7 @@ def github_fromager_resolver() -> typing.Generator[
         yield resolvelib.Resolver(provider, reporter)
 
 
-def test_provider_choose_wheel():
+def test_provider_choose_wheel() -> None:
     with requests_mock.Mocker() as r:
         r.get(
             "https://pypi.org/simple/hydra-core/",
@@ -120,7 +120,7 @@ def test_provider_choose_wheel():
         )
 
         provider = resolver.PyPIProvider(include_sdists=False)
-        reporter = resolvelib.BaseReporter()
+        reporter: resolvelib.BaseReporter = resolvelib.BaseReporter()
         rslvr = resolvelib.Resolver(provider, reporter)
 
         result = rslvr.resolve([Requirement("hydra-core")])
@@ -235,7 +235,7 @@ def test_cache_not_overly_aggressive() -> None:
         assert len(cached_candidates) == 4
 
 
-def test_provider_choose_wheel_prereleases():
+def test_provider_choose_wheel_prereleases() -> None:
     with requests_mock.Mocker() as r:
         r.get(
             "https://pypi.org/simple/hydra-core/",
@@ -243,7 +243,7 @@ def test_provider_choose_wheel_prereleases():
         )
 
         provider = resolver.PyPIProvider(include_sdists=False)
-        reporter = resolvelib.BaseReporter()
+        reporter: resolvelib.BaseReporter = resolvelib.BaseReporter()
         rslvr = resolvelib.Resolver(provider, reporter)
 
         result = rslvr.resolve([Requirement("hydra-core==2.0.0a1")])
@@ -257,7 +257,7 @@ def test_provider_choose_wheel_prereleases():
         assert str(candidate.version) == "2.0.0a1"
 
 
-def test_provider_choose_wheel_local():
+def test_provider_choose_wheel_local() -> None:
     with requests_mock.Mocker() as r:
         r.get(
             "https://pypi.org/simple/hydra-core/",
@@ -265,7 +265,7 @@ def test_provider_choose_wheel_local():
         )
 
         provider = resolver.PyPIProvider(include_sdists=False)
-        reporter = resolvelib.BaseReporter()
+        reporter: resolvelib.BaseReporter = resolvelib.BaseReporter()
         rslvr = resolvelib.Resolver(provider, reporter)
 
         result = rslvr.resolve([Requirement("hydra-core==1.3.1+local")])
@@ -279,7 +279,7 @@ def test_provider_choose_wheel_local():
         assert str(candidate.version) == "1.3.1+local"
 
 
-def test_provider_choose_sdist():
+def test_provider_choose_sdist() -> None:
     with requests_mock.Mocker() as r:
         r.get(
             "https://pypi.org/simple/hydra-core/",
@@ -287,7 +287,7 @@ def test_provider_choose_sdist():
         )
 
         provider = resolver.PyPIProvider(include_wheels=False)
-        reporter = resolvelib.BaseReporter()
+        reporter: resolvelib.BaseReporter = resolvelib.BaseReporter()
         rslvr = resolvelib.Resolver(provider, reporter)
 
         result = rslvr.resolve([Requirement("hydra-core")])
@@ -301,7 +301,7 @@ def test_provider_choose_sdist():
         assert str(candidate.version) == "1.3.2"
 
 
-def test_provider_choose_either_with_constraint():
+def test_provider_choose_either_with_constraint() -> None:
     constraint = constraints.Constraints()
     constraint.add_constraint("hydra-core==1.3.2")
     with requests_mock.Mocker() as r:
@@ -313,7 +313,7 @@ def test_provider_choose_either_with_constraint():
         provider = resolver.PyPIProvider(
             include_wheels=True, include_sdists=True, constraints=constraint
         )
-        reporter = resolvelib.BaseReporter()
+        reporter: resolvelib.BaseReporter = resolvelib.BaseReporter()
         rslvr = resolvelib.Resolver(provider, reporter)
 
         result = rslvr.resolve([Requirement("hydra-core")])
@@ -328,7 +328,7 @@ def test_provider_choose_either_with_constraint():
         )
 
 
-def test_provider_constraint_mismatch():
+def test_provider_constraint_mismatch() -> None:
     constraint = constraints.Constraints()
     constraint.add_constraint("hydra-core<=1.1")
     with requests_mock.Mocker() as r:
@@ -338,14 +338,14 @@ def test_provider_constraint_mismatch():
         )
 
         provider = resolver.PyPIProvider(include_wheels=False, constraints=constraint)
-        reporter = resolvelib.BaseReporter()
+        reporter: resolvelib.BaseReporter = resolvelib.BaseReporter()
         rslvr = resolvelib.Resolver(provider, reporter)
 
         with pytest.raises(resolvelib.resolvers.ResolverException):
             rslvr.resolve([Requirement("hydra-core")])
 
 
-def test_provider_constraint_match():
+def test_provider_constraint_match() -> None:
     constraint = constraints.Constraints()
     constraint.add_constraint("hydra-core<=1.3")
     with requests_mock.Mocker() as r:
@@ -355,7 +355,7 @@ def test_provider_constraint_match():
         )
 
         provider = resolver.PyPIProvider(include_wheels=False, constraints=constraint)
-        reporter = resolvelib.BaseReporter()
+        reporter: resolvelib.BaseReporter = resolvelib.BaseReporter()
         rslvr = resolvelib.Resolver(provider, reporter)
 
         result = rslvr.resolve([Requirement("hydra-core")])
@@ -386,7 +386,7 @@ _ignore_platform_simple_response = """
 """
 
 
-def test_provider_platform_mismatch():
+def test_provider_platform_mismatch() -> None:
     constraint = constraints.Constraints()
     with requests_mock.Mocker() as r:
         r.get(
@@ -395,14 +395,14 @@ def test_provider_platform_mismatch():
         )
 
         provider = resolver.PyPIProvider(include_wheels=True, constraints=constraint)
-        reporter = resolvelib.BaseReporter()
+        reporter: resolvelib.BaseReporter = resolvelib.BaseReporter()
         rslvr = resolvelib.Resolver(provider, reporter)
 
         with pytest.raises(resolvelib.resolvers.ResolverException):
             rslvr.resolve([Requirement("fromager")])
 
 
-def test_provider_ignore_platform():
+def test_provider_ignore_platform() -> None:
     constraint = constraints.Constraints()
     with requests_mock.Mocker() as r:
         r.get(
@@ -413,7 +413,7 @@ def test_provider_ignore_platform():
         provider = resolver.PyPIProvider(
             include_wheels=True, constraints=constraint, ignore_platform=True
         )
-        reporter = resolvelib.BaseReporter()
+        reporter: resolvelib.BaseReporter = resolvelib.BaseReporter()
         rslvr = resolvelib.Resolver(provider, reporter)
 
         result = rslvr.resolve([Requirement("fromager")])
@@ -682,7 +682,7 @@ _github_fromager_tag_response = """
 """
 
 
-def test_resolve_github():
+def test_resolve_github() -> None:
     with requests_mock.Mocker() as r:
         r.get(
             "https://api.github.com:443/repos/python-wheel-build/fromager",
@@ -696,7 +696,7 @@ def test_resolve_github():
         provider = resolver.GitHubTagProvider(
             organization="python-wheel-build", repo="fromager"
         )
-        reporter = resolvelib.BaseReporter()
+        reporter: resolvelib.BaseReporter = resolvelib.BaseReporter()
         rslvr = resolvelib.Resolver(provider, reporter)
 
         result = rslvr.resolve([Requirement("fromager")])
@@ -711,7 +711,7 @@ def test_resolve_github():
         )
 
 
-def test_github_constraint_mismatch():
+def test_github_constraint_mismatch() -> None:
     constraint = constraints.Constraints()
     constraint.add_constraint("fromager>=1.0")
     with requests_mock.Mocker() as r:
@@ -727,14 +727,14 @@ def test_github_constraint_mismatch():
         provider = resolver.GitHubTagProvider(
             organization="python-wheel-build", repo="fromager", constraints=constraint
         )
-        reporter = resolvelib.BaseReporter()
+        reporter: resolvelib.BaseReporter = resolvelib.BaseReporter()
         rslvr = resolvelib.Resolver(provider, reporter)
 
         with pytest.raises(resolvelib.resolvers.ResolutionImpossible):
             rslvr.resolve([Requirement("fromager")])
 
 
-def test_github_constraint_match():
+def test_github_constraint_match() -> None:
     constraint = constraints.Constraints()
     constraint.add_constraint("fromager<0.9")
     with requests_mock.Mocker() as r:
@@ -750,7 +750,7 @@ def test_github_constraint_match():
         provider = resolver.GitHubTagProvider(
             organization="python-wheel-build", repo="fromager", constraints=constraint
         )
-        reporter = resolvelib.BaseReporter()
+        reporter: resolvelib.BaseReporter = resolvelib.BaseReporter()
         rslvr = resolvelib.Resolver(provider, reporter)
 
         result = rslvr.resolve([Requirement("fromager")])
@@ -765,12 +765,12 @@ def test_github_constraint_match():
         )
 
 
-def test_resolve_generic():
+def test_resolve_generic() -> None:
     def _versions(*args, **kwds):
         return [("url", "1.2"), ("url", "1.3"), ("url", "1.4.1")]
 
     provider = resolver.GenericProvider(version_source=_versions)
-    reporter = resolvelib.BaseReporter()
+    reporter: resolvelib.BaseReporter = resolvelib.BaseReporter()
     rslvr = resolvelib.Resolver(provider, reporter)
 
     result = rslvr.resolve([Requirement("fromager")])
@@ -886,7 +886,7 @@ def tag_match(identifier: str, item: str) -> Version | None:
     return None
 
 
-def test_resolve_gitlab():
+def test_resolve_gitlab() -> None:
     with requests_mock.Mocker() as r:
         r.get(
             "https://gitlab.com/api/v4/projects/mirrors%2Fgithub%2Fdecile-team%2Fsubmodlib/repository/tags",
@@ -898,7 +898,7 @@ def test_resolve_gitlab():
             server_url="https://gitlab.com",
             matcher=re.compile("v(.*)"),  # with match object
         )
-        reporter = resolvelib.BaseReporter()
+        reporter: resolvelib.BaseReporter = resolvelib.BaseReporter()
         rslvr = resolvelib.Resolver(provider, reporter)
 
         result = rslvr.resolve([Requirement("submodlib")])
@@ -913,7 +913,7 @@ def test_resolve_gitlab():
         )
 
 
-def test_gitlab_constraint_mismatch():
+def test_gitlab_constraint_mismatch() -> None:
     constraint = constraints.Constraints()
     constraint.add_constraint("submodlib>=1.0")
     with requests_mock.Mocker() as r:
@@ -928,14 +928,14 @@ def test_gitlab_constraint_mismatch():
             matcher=tag_match,  # match function
             constraints=constraint,
         )
-        reporter = resolvelib.BaseReporter()
+        reporter: resolvelib.BaseReporter = resolvelib.BaseReporter()
         rslvr = resolvelib.Resolver(provider, reporter)
 
         with pytest.raises(resolvelib.resolvers.ResolutionImpossible):
             rslvr.resolve([Requirement("submodlib")])
 
 
-def test_gitlab_constraint_match():
+def test_gitlab_constraint_match() -> None:
     constraint = constraints.Constraints()
     constraint.add_constraint("submodlib<0.0.3")
     with requests_mock.Mocker() as r:
@@ -950,7 +950,7 @@ def test_gitlab_constraint_match():
             matcher=None,  # default, Version() also ignores leading 'v'
             constraints=constraint,
         )
-        reporter = resolvelib.BaseReporter()
+        reporter: resolvelib.BaseReporter = resolvelib.BaseReporter()
         rslvr = resolvelib.Resolver(provider, reporter)
 
         result = rslvr.resolve([Requirement("submodlib")])
@@ -986,14 +986,14 @@ _response_with_data_yanked = """
 """
 
 
-def test_pep592_support_latest_version_yanked():
+def test_pep592_support_latest_version_yanked() -> None:
     with requests_mock.Mocker() as r:
         r.get(
             "https://pypi.org/simple/setuptools-scm/", text=_response_with_data_yanked
         )
 
         provider = resolver.PyPIProvider()
-        reporter = resolvelib.BaseReporter()
+        reporter: resolvelib.BaseReporter = resolvelib.BaseReporter()
         rslvr = resolvelib.Resolver(provider, reporter)
 
         result = rslvr.resolve([Requirement("setuptools-scm")])
@@ -1004,7 +1004,7 @@ def test_pep592_support_latest_version_yanked():
         assert str(candidate.version) == "8.3.1"
 
 
-def test_pep592_support_constraint_mismatch():
+def test_pep592_support_constraint_mismatch() -> None:
     constraint = constraints.Constraints()
     constraint.add_constraint("setuptools-scm>=9.0.0")
     with requests_mock.Mocker() as r:
@@ -1013,7 +1013,7 @@ def test_pep592_support_constraint_mismatch():
         )
 
         provider = resolver.PyPIProvider(constraints=constraint)
-        reporter = resolvelib.BaseReporter()
+        reporter: resolvelib.BaseReporter = resolvelib.BaseReporter()
         rslvr = resolvelib.Resolver(provider, reporter)
 
         with pytest.raises(resolvelib.resolvers.ResolverException):
@@ -1030,6 +1030,6 @@ def test_pep592_support_constraint_mismatch():
         ),
     ],
 )
-def test_extract_filename_from_url(url, filename):
+def test_extract_filename_from_url(url, filename) -> None:
     result = resolver.extract_filename_from_url(url)
     assert result == filename

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -9,7 +9,7 @@ from fromager import context, packagesettings, resolver, sources
 
 
 @patch("fromager.sources.download_url")
-def test_invalid_tarfile(mock_download_url, tmp_path: pathlib.Path):
+def test_invalid_tarfile(mock_download_url, tmp_path: pathlib.Path) -> None:
     mock_download_url.return_value = pathlib.Path(tmp_path / "test" / "fake_wheel.txt")
     fake_url = "https://www.thisisafakeurl.com"
     fake_dir = tmp_path / "test"
@@ -27,7 +27,7 @@ def test_default_download_source_from_settings(
     download_source_check: Mock,
     resolve: Mock,
     testdata_context: context.WorkContext,
-):
+) -> None:
     resolve.return_value = ("url", Version("42.1.2"))
     download_source_check.return_value = pathlib.Path("filename.zip")
     req = Requirement("test_pkg==42.1.2")
@@ -73,7 +73,7 @@ def test_default_download_source_with_predefined_resolve_dist(
     download_source_check: Mock,
     resolve: Mock,
     tmp_context: context.WorkContext,
-):
+) -> None:
     resolve.return_value = ("url", Version("1.0"))
     download_source_check.return_value = pathlib.Path("filename")
     req = Requirement("foo==1.0")
@@ -92,7 +92,9 @@ def test_default_download_source_with_predefined_resolve_dist(
 
 
 @patch("fromager.sources.default_resolve_source")
-def test_invalid_version(mock_default_resolve_source, tmp_context: context.WorkContext):
+def test_invalid_version(
+    mock_default_resolve_source, tmp_context: context.WorkContext
+) -> None:
     req = Requirement("fake==1.0")
     sdist_server_url = resolver.PYPI_SERVER_URL
     mock_default_resolve_source.return_value = (
@@ -115,7 +117,7 @@ def test_patch_sources_apply_unversioned_and_versioned(
     warning: Mock,
     tmp_path: pathlib.Path,
     testdata_context: context.WorkContext,
-):
+) -> None:
     source_root_dir = tmp_path / "test_pkg-1.0.2"
     source_root_dir.mkdir()
 
@@ -160,7 +162,7 @@ def test_patch_sources_apply_only_unversioned(
     apply_patch: Mock,
     tmp_path: pathlib.Path,
     tmp_context: context.WorkContext,
-):
+) -> None:
     patches_dir = tmp_path / "patches_dir"
     patches_dir.mkdir()
     tmp_context.settings.patches_dir = patches_dir

--- a/tests/test_versionmap.py
+++ b/tests/test_versionmap.py
@@ -5,7 +5,7 @@ from packaging.version import Version
 from fromager.versionmap import VersionMap
 
 
-def test_initialize():
+def test_initialize() -> None:
     m = VersionMap(
         {
             "1.2": "value for 1.2",
@@ -16,7 +16,7 @@ def test_initialize():
     assert list(m.versions()) == [Version("1.3"), Version("1.2"), Version("1.0")]
 
 
-def test_lookup():
+def test_lookup() -> None:
     m = VersionMap(
         {
             "1.2": "value for 1.2",
@@ -29,7 +29,7 @@ def test_lookup():
     assert m.lookup(Requirement("pkg<1.3")) == (Version("1.2"), "value for 1.2")
 
 
-def test_prerelease():
+def test_prerelease() -> None:
     m = VersionMap(
         {
             Version("0.4.1b0"): "value for 0.4.1b0",
@@ -55,7 +55,7 @@ def test_prerelease():
     ) == (Version("0.4.1b0"), "value for 0.4.1b0")
 
 
-def test_only_prerelease():
+def test_only_prerelease() -> None:
     m = VersionMap(
         {
             Version("0.4.1b0"): "value for 0.4.1b0",
@@ -70,7 +70,7 @@ def test_only_prerelease():
     )
 
 
-def test_with_constraint():
+def test_with_constraint() -> None:
     m = VersionMap(
         {
             "1.2": "value for 1.2",
@@ -88,7 +88,7 @@ def test_with_constraint():
     )
 
 
-def test_no_match():
+def test_no_match() -> None:
     m = VersionMap(
         {
             "1.2": "value for 1.2",


### PR DESCRIPTION
Add -> None return type annotations to all 205+ test functions
across 29 test files and resolve all 92 mypy type errors.

Changes include:
- Add return type annotations to all test functions and methods
- Fix type mismatches (str vs Version, Path vs str)
- Add explicit type annotations for variables where needed
- Fix function argument types to match expected signatures
- Add type ignore comments for intentional error test cases