### PR TITLE
fix: pre-built wheel indexing for local wheel server

### DIFF
--- a/src/fromager/bootstrapper.py
+++ b/src/fromager/bootstrapper.py
@@ -500,6 +500,9 @@ class Bootstrapper:
 
         wheel_filename = wheels.download_wheel(req, wheel_url, self.ctx.wheels_prebuilt)
         unpack_dir = self._create_unpack_dir(req, resolved_version)
+        # Update the wheel mirror so pre-built wheels are indexed
+        # and available to subsequent builds that need them as dependencies
+        server.update_wheel_mirror(self.ctx)
         return (wheel_filename, unpack_dir)
 
     def _look_for_existing_wheel(


### PR DESCRIPTION
  Pre-built wheels were not being indexed in the local wheel server's
  simple API directory structure after download. This caused dependency
  resolution failures when those wheels were needed as build dependencies.

  Call update_wheel_mirror() in _download_prebuilt() to ensure pre-built
  wheels are immediately available to subsequent builds, matching the
  behavior of _build_wheel().

  Fixes dependency resolution for packages that require pre-built wheels
  as build dependencies.