### PR TITLE
feat: implement DependencyGraph.get_build_topology

### DIFF
--- a/src/fromager/commands/graph.py
+++ b/src/fromager/commands/graph.py
@@ -565,3 +565,43 @@ def migrate_graph(
             graph.serialize(f)
     else:
         graph.serialize(sys.stdout)
+
+
+@graph.command()
+@click.argument(
+    "graph-file",
+    type=clickext.ClickPath(),
+)
+@click.pass_obj
+def build_graph(
+    wkctx: context.WorkContext,
+    graph_file: pathlib.Path,
+):
+    """Print build graph steps for parallel-build
+
+    The build-graph command takes a graph.json file and analyzes in which
+    order parallel build is going to build the wheels. It also shows which
+    wheels are recognized as build dependencies or exclusive builds.
+    """
+    graph = DependencyGraph.from_file(graph_file)
+    topo = graph.get_build_topology(context=wkctx)
+    topo.prepare()
+
+    def n2s(nodes: typing.Iterable[DependencyNode]) -> str:
+        return ", ".join(sorted(node.key for node in nodes))
+
+    print(f"Build dependencies ({len(topo.dependency_nodes)}):")
+    print(n2s(topo.dependency_nodes), "\n")
+    if topo.exclusive_nodes:
+        print(f"Exclusive builds ({len(topo.exclusive_nodes)}):")
+        print(n2s(topo.exclusive_nodes), "\n")
+
+    print("Build rounds:")
+    rounds: int = 0
+    while topo.is_active():
+        rounds += 1
+        nodes_to_build = topo.get_available()
+        print(f"{rounds}.", n2s(nodes_to_build))
+        topo.done(*nodes_to_build)
+
+    print(f"\nBuilding {len(graph)} packages in {rounds} rounds.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,11 +7,17 @@ from click.testing import CliRunner
 from fromager import context, packagesettings
 
 TESTDATA_PATH = pathlib.Path(__file__).parent.absolute() / "testdata"
+E2E_PATH = pathlib.Path(__file__).parent.parent.absolute() / "e2e"
 
 
 @pytest.fixture
 def testdata_path() -> typing.Generator[pathlib.Path, None, None]:
     yield TESTDATA_PATH
+
+
+@pytest.fixture
+def e2e_path() -> typing.Generator[pathlib.Path, None, None]:
+    yield E2E_PATH
 
 
 @pytest.fixture

--- a/tests/test_commands_graph.py
+++ b/tests/test_commands_graph.py
@@ -1,0 +1,13 @@
+import pathlib
+
+from click.testing import CliRunner
+
+from fromager.__main__ import main as fromager
+
+
+def test_fromager_version(cli_runner: CliRunner, e2e_path: pathlib.Path) -> None:
+    graph_json = e2e_path / "build-parallel" / "graph.json"
+    result = cli_runner.invoke(fromager, ["graph", "build-graph", str(graph_json)])
+    assert result.exit_code == 0
+    assert "1. flit-core==3.12.0, setuptools==80.8.0" in result.stdout
+    assert "Building 16 packages in 4 rounds" in result.stdout


### PR DESCRIPTION
The `DependencyGraph.get_build_topology` method returns a `TrackingTopologicalSorter` with all nodes in the graph. Each node tracks its build dependency set. Nodes for a package with exclusive builds are flagged as exclusive.

The new `fromager graph build-graph` subcommand analyzes a graph file and prints a list of build steps.

```
$ fromager graph build-graph e2e/build-parallel/graph.json 
Build dependencies (6):
cython==3.1.1, flit-core==3.12.0, packaging==25.0, setuptools-scm==8.3.1, setuptools==80.8.0, wheel==0.46.1 

Build rounds:
1. flit-core==3.12.0, setuptools==80.8.0
2. cython==3.1.1, imapclient==3.0.1, jinja2==3.1.6, markupsafe==3.0.2, more-itertools==10.7.0, packaging==25.0
3. setuptools-scm==8.3.1, wheel==0.46.1
4. imapautofiler==1.14.0, jaraco-classes==3.4.0, jaraco-context==6.0.1, jaraco-functools==4.1.0, keyring==25.6.0, pyyaml==6.0.2

Building 16 packages in 4 rounds.
```