### PR TITLE
fix(types): update type annotations for stevedore compatibility

### DIFF
--- a/src/fromager/hooks.py
+++ b/src/fromager/hooks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import pathlib
 import typing
+from importlib.metadata import EntryPoint
 
 from packaging.requirements import Requirement
 from stevedore import extension, hook
@@ -39,7 +40,7 @@ def _get_hooks(name: str) -> hook.HookManager:
 def log_hooks() -> None:
     # We load the hooks differently here because we want all of them when
     # normally we would load them by name.
-    _mgr = extension.ExtensionManager(
+    _mgr: extension.ExtensionManager = extension.ExtensionManager(
         namespace="fromager.hooks",
         invoke_on_load=False,
         on_load_failure_callback=_die_on_plugin_load_failure,
@@ -56,9 +57,9 @@ def log_hooks() -> None:
 
 
 def _die_on_plugin_load_failure(
-    mgr: hook.HookManager,
-    ep: extension.Extension,
-    err: Exception,
+    mgr: extension.ExtensionManager,
+    ep: EntryPoint,
+    err: BaseException,
 ) -> typing.NoReturn:
     raise RuntimeError(f"failed to load overrides for {ep.name}") from err
 

--- a/src/fromager/overrides.py
+++ b/src/fromager/overrides.py
@@ -15,7 +15,7 @@ from stevedore import extension
 logger = logging.getLogger(__name__)
 
 
-_mgr = None
+_mgr: extension.ExtensionManager | None = None
 
 
 def _get_extensions() -> extension.ExtensionManager:
@@ -31,8 +31,8 @@ def _get_extensions() -> extension.ExtensionManager:
 
 def _die_on_plugin_load_failure(
     mgr: extension.ExtensionManager,
-    ep: extension.Extension,
-    err: Exception,
+    ep: metadata.EntryPoint,
+    err: BaseException,
 ) -> None:
     raise RuntimeError(f"failed to load overrides for {ep.name}") from err
 


### PR DESCRIPTION
Update type annotations in hooks.py and overrides.py to satisfy updated stevedore library type stubs.

Changes:
- Import EntryPoint from importlib.metadata
- Update callback signatures to match stevedore's expected types
- Change Exception to BaseException as required by type stubs
- Use metadata.EntryPoint in overrides.py for consistency

This fixes mypy type checking errors that appeared after updating to newer stevedore versions with stricter type annotations.

Fixes: #861