### PR TITLE
feat: improve resolver candidate

### DIFF
--- a/src/fromager/candidate.py
+++ b/src/fromager/candidate.py
@@ -1,4 +1,5 @@
 import dataclasses
+import datetime
 import logging
 import typing
 from email.message import EmailMessage, Message
@@ -32,6 +33,11 @@ class Candidate:
     extras: tuple[str, ...] = dataclasses.field(default=(), compare=False)
     build_tag: BuildTag = dataclasses.field(default=(), compare=False)
     has_metadata: bool = dataclasses.field(default=False, compare=False)
+    remote_tag: str | None = dataclasses.field(default=None, compare=False)
+    remote_commit: str | None = dataclasses.field(default=None, compare=False)
+    upload_time: datetime.datetime | None = dataclasses.field(
+        default=None, compare=False
+    )
 
     _metadata: Metadata | None = dataclasses.field(
         default=None, init=False, compare=False

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,3 +1,4 @@
+import datetime
 import re
 import typing
 
@@ -704,6 +705,9 @@ def test_resolve_github() -> None:
 
         candidate = result.mapping["fromager"]
         assert str(candidate.version) == "0.9.0"
+        assert candidate.remote_tag == "0.9.0"
+        assert candidate.remote_commit == "5fbdab491e983152f7e5c8200b4f7f62f714aedf"
+        assert candidate.upload_time is None
         # check the "URL" in case tag syntax does not match version syntax
         assert (
             str(candidate.url)
@@ -910,6 +914,11 @@ def test_resolve_gitlab() -> None:
         assert (
             str(candidate.url)
             == "https://gitlab.com/mirrors/github/decile-team/submodlib/-/archive/v0.0.3/submodlib-v0.0.3.tar.gz"
+        )
+        assert candidate.remote_tag == "v0.0.3"
+        assert candidate.remote_commit == "72ae33a1ead9761e7240c2e095873047339ada7c"
+        assert candidate.upload_time == datetime.datetime(
+            2025, 5, 14, 15, 43, 0, tzinfo=datetime.UTC
         )
 
 


### PR DESCRIPTION
The `Candidate` class can now track more information:

- `upload_time` (PyPI JSON API, Gitlab) is the upload time of a package or git tag.
- `remote_tag` (GitHub, Gitlab) is the tag name
- `remote_commit` (GitHub, Gitlab) is the remote commit hash

At the moment the information is just logged. In the future the `upload_time` can be used to detect old package versions.

The `VersionSource` callable can now return an iterable of `Candidate` objects. `url, version` tuple is deprecated.