### PR TITLE
fix(docs): add quotes to git URL examples

### DIFF
--- a/docs/how-tos/build-from-git-repo.rst
+++ b/docs/how-tos/build-from-git-repo.rst
@@ -9,7 +9,7 @@ you can do the following:
 
 .. code-block:: console
 
-   $ fromager bootstrap stevedore @ git+https://github.com/openstack/stevedore.git
+   $ fromager bootstrap "stevedore @ git+https://github.com/openstack/stevedore.git"
 
 This will clone the ``stevedore`` repository and build the package from the
 local copy.
@@ -18,7 +18,7 @@ You can also use the ``bootstrap-parallel`` command for faster builds:
 
 .. code-block:: console
 
-   $ fromager bootstrap-parallel stevedore @ git+https://github.com/openstack/stevedore.git
+   $ fromager bootstrap-parallel "stevedore @ git+https://github.com/openstack/stevedore.git"
 
 This will perform the same operation but build wheels in parallel after the
 bootstrap phase completes.
@@ -31,7 +31,7 @@ the ``@`` syntax to specify the version.
 
 .. code-block:: console
 
-   $ fromager bootstrap stevedore @ git+https://github.com/openstack/stevedore.git@5.2.0
+   $ fromager bootstrap "stevedore @ git+https://github.com/openstack/stevedore.git@5.2.0"
 
 This will clone the ``stevedore`` repository at the tag ``5.2.0`` and build the
 package from the local copy.
@@ -40,7 +40,7 @@ Or with parallel builds:
 
 .. code-block:: console
 
-   $ fromager bootstrap-parallel stevedore @ git+https://github.com/openstack/stevedore.git@5.2.0
+   $ fromager bootstrap-parallel "stevedore @ git+https://github.com/openstack/stevedore.git@5.2.0"
 
 .. important::
 


### PR DESCRIPTION
Quote requirement specifications in build-from-git-repo.rst to prevent shell parsing errors caused by spaces around the @ symbol.