### PR TITLE
Test mode post merge cleanups

### DIFF
--- a/tests/test_bootstrap_test_mode.py
+++ b/tests/test_bootstrap_test_mode.py
@@ -10,84 +10,52 @@ Tests the test mode functionality:
 
 import json
 import pathlib
-import tempfile
-import typing
-from unittest.mock import Mock
 
 import pytest
 
 from fromager import bootstrapper, context
 
 
-@pytest.fixture
-def mock_context() -> typing.Generator[context.WorkContext, None, None]:
-    """Create a mock WorkContext for testing."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        work_dir = pathlib.Path(tmpdir)
-
-        mock_ctx = Mock(spec=context.WorkContext)
-        mock_ctx.work_dir = work_dir
-        mock_ctx.wheels_build = work_dir / "wheels-build"
-        mock_ctx.wheels_downloads = work_dir / "wheels-downloads"
-        mock_ctx.wheels_prebuilt = work_dir / "wheels-prebuilt"
-        mock_ctx.sdists_builds = work_dir / "sdists-builds"
-        mock_ctx.wheel_server_url = None
-        mock_ctx.constraints = Mock()
-        mock_ctx.constraints.get_constraint = Mock(return_value=None)
-        mock_ctx.settings = Mock()
-        mock_ctx.variant = "test"
-
-        for d in [
-            mock_ctx.wheels_build,
-            mock_ctx.wheels_downloads,
-            mock_ctx.wheels_prebuilt,
-            mock_ctx.sdists_builds,
-        ]:
-            d.mkdir(parents=True, exist_ok=True)
-
-        yield mock_ctx
-
-
 class TestBootstrapperInitialization:
     """Test Bootstrapper initialization with test_mode parameter."""
 
-    def test_test_mode_enabled(self, mock_context: context.WorkContext) -> None:
+    def test_test_mode_enabled(self, tmp_context: context.WorkContext) -> None:
         """Test Bootstrapper with test_mode=True."""
-        bt = bootstrapper.Bootstrapper(ctx=mock_context, test_mode=True)
+        bt = bootstrapper.Bootstrapper(ctx=tmp_context, test_mode=True)
         assert bt.test_mode is True
         assert isinstance(bt.failed_packages, list)
         assert len(bt.failed_packages) == 0
 
     def test_test_mode_disabled_by_default(
-        self, mock_context: context.WorkContext
+        self, tmp_context: context.WorkContext
     ) -> None:
         """Test Bootstrapper with test_mode=False (default)."""
-        bt = bootstrapper.Bootstrapper(ctx=mock_context)
+        bt = bootstrapper.Bootstrapper(ctx=tmp_context)
         assert bt.test_mode is False
 
     def test_test_mode_incompatible_with_sdist_only(
-        self, mock_context: context.WorkContext
+        self, tmp_context: context.WorkContext
     ) -> None:
         """Test that test_mode and sdist_only are mutually exclusive."""
         with pytest.raises(ValueError, match="--test-mode requires full wheel builds"):
-            bootstrapper.Bootstrapper(ctx=mock_context, test_mode=True, sdist_only=True)
+            bootstrapper.Bootstrapper(ctx=tmp_context, test_mode=True, sdist_only=True)
 
 
 class TestFinalizeExitCodes:
     """Test finalize() returns correct exit codes."""
 
     def test_finalize_no_failures_returns_zero(
-        self, mock_context: context.WorkContext
+        self, tmp_context: context.WorkContext
     ) -> None:
         """Test finalize returns 0 when no failures in test mode."""
-        bt = bootstrapper.Bootstrapper(ctx=mock_context, test_mode=True)
+        bt = bootstrapper.Bootstrapper(ctx=tmp_context, test_mode=True)
         assert bt.finalize() == 0
 
     def test_finalize_with_failures_returns_one(
-        self, mock_context: context.WorkContext
+        self, tmp_context: context.WorkContext
     ) -> None:
         """Test finalize returns 1 when there are failures in test mode."""
-        bt = bootstrapper.Bootstrapper(ctx=mock_context, test_mode=True)
+        bt = bootstrapper.Bootstrapper(ctx=tmp_context, test_mode=True)
         bt.failed_packages.append(
             {
                 "package": "failing-pkg",
@@ -100,10 +68,10 @@ class TestFinalizeExitCodes:
         assert bt.finalize() == 1
 
     def test_finalize_not_in_test_mode_returns_zero(
-        self, mock_context: context.WorkContext
+        self, tmp_context: context.WorkContext
     ) -> None:
         """Test finalize returns 0 when not in test mode (regardless of failures)."""
-        bt = bootstrapper.Bootstrapper(ctx=mock_context, test_mode=False)
+        bt = bootstrapper.Bootstrapper(ctx=tmp_context, test_mode=False)
         # Even if we manually add failures (shouldn't happen), it returns 0
         bt.failed_packages.append(
             {
@@ -117,10 +85,10 @@ class TestFinalizeExitCodes:
         assert bt.finalize() == 0
 
     def test_finalize_logs_failed_packages(
-        self, mock_context: context.WorkContext, caplog: pytest.LogCaptureFixture
+        self, tmp_context: context.WorkContext, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Test finalize logs the list of failed packages."""
-        bt = bootstrapper.Bootstrapper(ctx=mock_context, test_mode=True)
+        bt = bootstrapper.Bootstrapper(ctx=tmp_context, test_mode=True)
         bt.failed_packages.extend(
             [
                 {
@@ -166,10 +134,10 @@ class TestJsonFailureReport:
     """Test JSON failure report generation."""
 
     def test_finalize_writes_json_report(
-        self, mock_context: context.WorkContext
+        self, tmp_context: context.WorkContext
     ) -> None:
         """Test finalize writes test-mode-failures-<timestamp>.json with failure details."""
-        bt = bootstrapper.Bootstrapper(ctx=mock_context, test_mode=True)
+        bt = bootstrapper.Bootstrapper(ctx=tmp_context, test_mode=True)
         bt.failed_packages.append(
             {
                 "package": "failing-pkg",
@@ -182,7 +150,7 @@ class TestJsonFailureReport:
 
         bt.finalize()
 
-        report_path = _find_failure_report(mock_context.work_dir)
+        report_path = _find_failure_report(tmp_context.work_dir)
         assert report_path is not None
         assert report_path.name.startswith("test-mode-failures-")
         assert report_path.name.endswith(".json")
@@ -199,21 +167,21 @@ class TestJsonFailureReport:
         assert report["failures"][0]["failure_type"] == "bootstrap"
 
     def test_finalize_no_report_when_no_failures(
-        self, mock_context: context.WorkContext
+        self, tmp_context: context.WorkContext
     ) -> None:
         """Test finalize does not write report when there are no failures."""
-        bt = bootstrapper.Bootstrapper(ctx=mock_context, test_mode=True)
+        bt = bootstrapper.Bootstrapper(ctx=tmp_context, test_mode=True)
 
         bt.finalize()
 
-        report_path = _find_failure_report(mock_context.work_dir)
+        report_path = _find_failure_report(tmp_context.work_dir)
         assert report_path is None
 
     def test_finalize_report_with_null_version(
-        self, mock_context: context.WorkContext
+        self, tmp_context: context.WorkContext
     ) -> None:
         """Test finalize handles failures where version is None (resolution failure)."""
-        bt = bootstrapper.Bootstrapper(ctx=mock_context, test_mode=True)
+        bt = bootstrapper.Bootstrapper(ctx=tmp_context, test_mode=True)
         bt.failed_packages.append(
             {
                 "package": "failed-to-resolve",
@@ -226,7 +194,7 @@ class TestJsonFailureReport:
 
         bt.finalize()
 
-        report_path = _find_failure_report(mock_context.work_dir)
+        report_path = _find_failure_report(tmp_context.work_dir)
         assert report_path is not None
         with open(report_path) as f:
             report = json.load(f)
@@ -235,10 +203,10 @@ class TestJsonFailureReport:
         assert report["failures"][0]["failure_type"] == "resolution"
 
     def test_finalize_report_multiple_failure_types(
-        self, mock_context: context.WorkContext
+        self, tmp_context: context.WorkContext
     ) -> None:
         """Test finalize correctly reports multiple failures with different types."""
-        bt = bootstrapper.Bootstrapper(ctx=mock_context, test_mode=True)
+        bt = bootstrapper.Bootstrapper(ctx=tmp_context, test_mode=True)
         bt.failed_packages.extend(
             [
                 {
@@ -267,7 +235,7 @@ class TestJsonFailureReport:
 
         bt.finalize()
 
-        report_path = _find_failure_report(mock_context.work_dir)
+        report_path = _find_failure_report(tmp_context.work_dir)
         assert report_path is not None
         with open(report_path) as f:
             report = json.load(f)


### PR DESCRIPTION
Contains following commits
* refactor(bootstrapper): move resolution and tracking to bootstrap()
* refactor(tests): use existing tmp_context fixture in test-mode tests

Followup clean ups suggested by @dhellmann during review of https://github.com/python-wheel-build/fromager/pull/865 . There is one more cleanup but it will be larger refactor, so planning to send another PR for that.