### PR TITLE
refactor(bootstrap): extract resolution to RequirementResolver

### DIFF
--- a/src/fromager/requirement_resolver.py
+++ b/src/fromager/requirement_resolver.py
@@ -1,0 +1,248 @@
+"""Requirement resolution for bootstrap process.
+
+Handles PyPI and graph-based resolution strategies.
+Git URL resolution stays in Bootstrapper (orchestration concern).
+"""
+
+from __future__ import annotations
+
+import logging
+import typing
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+from . import resolver, sources, wheels
+from .dependency_graph import DependencyGraph
+from .requirements_file import RequirementType
+
+if typing.TYPE_CHECKING:
+    from . import context
+
+logger = logging.getLogger(__name__)
+
+
+class RequirementResolver:
+    """Resolve package requirements from PyPI or dependency graph.
+
+    Single Responsibility: Coordinate resolution strategies.
+    Reason to Change: Resolution algorithm or provider priorities change.
+
+    Resolution strategies (in order):
+    1. Previous dependency graph (if available)
+    2. PyPI lookup (via existing sources/resolver modules)
+
+    Git URL resolution is NOT handled here - that stays in Bootstrapper
+    because it requires BuildEnvironment and build dependencies.
+    """
+
+    def __init__(
+        self,
+        ctx: context.WorkContext,
+        prev_graph: DependencyGraph | None = None,
+    ) -> None:
+        """Initialize requirement resolver.
+
+        Args:
+            ctx: Work context with constraints and settings
+            prev_graph: Optional previous dependency graph for caching
+        """
+        self.ctx = ctx
+        self.prev_graph = prev_graph
+
+    def resolve_source(
+        self,
+        req: Requirement,
+        req_type: RequirementType,
+        parent_req: Requirement | None = None,
+    ) -> tuple[str, Version]:
+        """Resolve source package (sdist).
+
+        Tries resolution strategies in order:
+        1. Previous dependency graph
+        2. PyPI source resolution
+
+        Args:
+            req: Package requirement (must NOT have URL)
+            req_type: Type of requirement
+            parent_req: Parent requirement from dependency chain
+
+        Returns:
+            Tuple of (source_url, resolved_version)
+
+        Raises:
+            ValueError: If req contains a URL (must use Bootstrapper for git URLs)
+        """
+        if req.url:
+            raise ValueError(
+                f"Git URL requirements must be handled by Bootstrapper: {req}"
+            )
+
+        # Try graph first
+        cached_resolution = self._resolve_from_graph(
+            req=req,
+            req_type=req_type,
+            pre_built=False,
+            parent_req=parent_req,
+        )
+        if cached_resolution:
+            source_url, resolved_version = cached_resolution
+            logger.debug(f"resolved from previous bootstrap to {resolved_version}")
+            return source_url, resolved_version
+
+        # Fallback to PyPI
+        source_url, resolved_version = sources.resolve_source(
+            ctx=self.ctx,
+            req=req,
+            sdist_server_url=resolver.PYPI_SERVER_URL,
+            req_type=req_type,
+        )
+        return source_url, resolved_version
+
+    def resolve_prebuilt(
+        self,
+        req: Requirement,
+        req_type: RequirementType,
+        parent_req: Requirement | None = None,
+    ) -> tuple[str, Version]:
+        """Resolve pre-built package (wheels only).
+
+        Tries resolution strategies in order:
+        1. Previous dependency graph
+        2. PyPI wheel resolution
+
+        Args:
+            req: Package requirement
+            req_type: Type of requirement
+            parent_req: Parent requirement from dependency chain
+
+        Returns:
+            Tuple of (source_url, resolved_version)
+
+        Raises:
+            ValueError: If unable to resolve
+        """
+        # Try graph first
+        cached_resolution = self._resolve_from_graph(
+            req=req,
+            req_type=req_type,
+            pre_built=True,
+            parent_req=parent_req,
+        )
+
+        if cached_resolution and not req.url:
+            wheel_url, resolved_version = cached_resolution
+            logger.debug(f"resolved from previous bootstrap to {resolved_version}")
+            return wheel_url, resolved_version
+
+        # Fallback to PyPI prebuilt resolution
+        servers = wheels.get_wheel_server_urls(
+            self.ctx, req, cache_wheel_server_url=resolver.PYPI_SERVER_URL
+        )
+        wheel_url, resolved_version = wheels.resolve_prebuilt_wheel(
+            ctx=self.ctx, req=req, wheel_server_urls=servers, req_type=req_type
+        )
+        return wheel_url, resolved_version
+
+    def _resolve_from_graph(
+        self,
+        req: Requirement,
+        req_type: RequirementType,
+        pre_built: bool,
+        parent_req: Requirement | None,
+    ) -> tuple[str, Version] | None:
+        """Resolve from previous dependency graph.
+
+        Extracted from Bootstrapper._resolve_from_graph().
+
+        Args:
+            req: Package requirement
+            req_type: Type of requirement
+            pre_built: Whether to look for pre-built packages
+            parent_req: Parent requirement for graph traversal
+
+        Returns:
+            Tuple of (url, version) if found in graph, None otherwise
+        """
+        if not self.prev_graph:
+            return None
+
+        seen_version: set[str] = set()
+
+        # First perform resolution using the top level reqs before looking at history
+        possible_versions_in_top_level: list[tuple[str, Version]] = []
+        for (
+            top_level_edge
+        ) in self.ctx.dependency_graph.get_root_node().get_outgoing_edges(
+            req.name, RequirementType.TOP_LEVEL
+        ):
+            possible_versions_in_top_level.append(
+                (
+                    top_level_edge.destination_node.download_url,
+                    top_level_edge.destination_node.version,
+                )
+            )
+            seen_version.add(str(top_level_edge.destination_node.version))
+
+        resolver_result = self._resolve_from_version_source(
+            possible_versions_in_top_level, req
+        )
+        if resolver_result:
+            return resolver_result
+
+        # Only if there is nothing in top level reqs, resolve using history
+        possible_versions_from_graph: list[tuple[str, Version]] = []
+        # Check all nodes which have the same parent name irrespective of the parent's version
+        for parent_node in self.prev_graph.get_nodes_by_name(
+            parent_req.name if parent_req else None
+        ):
+            # If the edge matches the current req and type then it is a possible candidate.
+            # Filtering on type might not be necessary, but we are being safe here. This will
+            # for sure ensure that bootstrap takes the same route as it did in the previous one.
+            # If we don't filter by type then it might pick up a different version from a different
+            # type that should have appeared much later in the resolution process.
+            for edge in parent_node.get_outgoing_edges(req.name, req_type):
+                if (
+                    edge.destination_node.pre_built == pre_built
+                    and str(edge.destination_node.version) not in seen_version
+                ):
+                    possible_versions_from_graph.append(
+                        (
+                            edge.destination_node.download_url,
+                            edge.destination_node.version,
+                        )
+                    )
+                    seen_version.add(str(edge.destination_node.version))
+
+        return self._resolve_from_version_source(possible_versions_from_graph, req)
+
+    def _resolve_from_version_source(
+        self,
+        version_source: list[tuple[str, Version]],
+        req: Requirement,
+    ) -> tuple[str, Version] | None:
+        """Select best version from candidates.
+
+        Extracted from Bootstrapper._resolve_from_version_source().
+
+        Args:
+            version_source: List of (url, version) candidates
+            req: Package requirement with version specifier
+
+        Returns:
+            Tuple of (url, version) for best match, None if no match
+        """
+        if not version_source:
+            return None
+        try:
+            # No need to pass req type to enable caching since we are already using the graph as our cache.
+            # Do not cache candidates.
+            provider = resolver.GenericProvider(
+                version_source=lambda identifier: version_source,
+                constraints=self.ctx.constraints,
+                use_resolver_cache=False,
+            )
+            return resolver.resolve_from_provider(provider, req)
+        except Exception as err:
+            logger.debug(f"could not resolve {req} from {version_source}: {err}")
+            return None

--- a/tests/test_bootstrapper.py
+++ b/tests/test_bootstrapper.py
@@ -3,229 +3,11 @@ import pathlib
 from unittest.mock import Mock, patch
 
 from packaging.requirements import Requirement
-from packaging.utils import canonicalize_name
 from packaging.version import Version
 
 from fromager import bootstrapper, requirements_file
 from fromager.context import WorkContext
-from fromager.dependency_graph import DependencyGraph
 from fromager.requirements_file import RequirementType, SourceType
-
-old_graph = DependencyGraph()
-
-old_graph.add_dependency(
-    parent_name=None,
-    parent_version=None,
-    req_type=RequirementType.TOP_LEVEL,
-    req=Requirement("foo"),
-    req_version=Version("1.0.0"),
-)
-
-old_graph.add_dependency(
-    parent_name=canonicalize_name("foo"),
-    parent_version=Version("1.0.0"),
-    req_type=RequirementType.INSTALL,
-    req=Requirement("pbr>=5"),
-    req_version=Version("7"),
-)
-
-old_graph.add_dependency(
-    parent_name=None,
-    parent_version=None,
-    req_type=RequirementType.TOP_LEVEL,
-    req=Requirement("bar"),
-    req_version=Version("1.0.0"),
-)
-
-old_graph.add_dependency(
-    parent_name=canonicalize_name("bar"),
-    parent_version=Version("1.0.0"),
-    req_type=RequirementType.INSTALL,
-    req=Requirement("pbr>=5,<7"),
-    req_version=Version("6"),
-)
-
-old_graph.add_dependency(
-    parent_name=None,
-    parent_version=None,
-    req_type=RequirementType.TOP_LEVEL,
-    req=Requirement("blah"),
-    req_version=Version("1.0.0"),
-)
-
-old_graph.add_dependency(
-    parent_name=canonicalize_name("blah"),
-    parent_version=Version("1.0.0"),
-    req_type=RequirementType.INSTALL,
-    req=Requirement("pbr==5"),
-    req_version=Version("5"),
-)
-
-
-def test_resolve_from_graph_no_changes(tmp_context: WorkContext) -> None:
-    bt = bootstrapper.Bootstrapper(tmp_context, None, old_graph)
-    bt.why = [(RequirementType.TOP_LEVEL, Requirement("foo"), Version("1.0.0"))]
-
-    # resolving new dependency that doesn't exist in graph
-    assert (
-        bt._resolve_from_graph(
-            req_type=RequirementType.INSTALL,
-            req=Requirement("xyz"),
-            pre_built=False,
-        )
-        is None
-    )
-
-    # resolving pbr dependency of foo
-    assert bt._resolve_from_graph(
-        req_type=RequirementType.INSTALL,
-        req=Requirement("pbr>=5"),
-        pre_built=False,
-    ) == ("", Version("7"))
-
-    bt.why = [(RequirementType.TOP_LEVEL, Requirement("bar"), Version("1.0.0"))]
-    # resolving pbr dependency of bar
-    assert bt._resolve_from_graph(
-        req_type=RequirementType.INSTALL,
-        req=Requirement("pbr>=5,<7"),
-        pre_built=False,
-    ) == ("", Version("6"))
-
-    bt.why = [(RequirementType.TOP_LEVEL, Requirement("blah"), Version("1.0.0"))]
-    # resolving pbr dependency of blah
-    assert bt._resolve_from_graph(
-        req_type=RequirementType.INSTALL,
-        req=Requirement("pbr==5"),
-        pre_built=False,
-    ) == ("", Version("5"))
-
-
-def test_resolve_from_graph_install_dep_upgrade(tmp_context: WorkContext) -> None:
-    bt = bootstrapper.Bootstrapper(tmp_context, None, old_graph)
-
-    # simulating new bootstrap with a toplevel requirement of pbr==8
-    tmp_context.dependency_graph.add_dependency(
-        parent_name=None,
-        parent_version=None,
-        req_type=RequirementType.TOP_LEVEL,
-        req=Requirement("pbr==8"),
-        req_version=Version("8"),
-    )
-
-    bt.why = [(RequirementType.TOP_LEVEL, Requirement("foo"), Version("1.0.0"))]
-    # resolving pbr dependency of foo
-    assert bt._resolve_from_graph(
-        req_type=RequirementType.INSTALL,
-        req=Requirement("pbr>=5"),
-        pre_built=False,
-    ) == ("", Version("8"))
-
-    bt.why = [(RequirementType.TOP_LEVEL, Requirement("bar"), Version("1.0.0"))]
-    # resolving pbr dependency of bar
-    assert bt._resolve_from_graph(
-        req_type=RequirementType.INSTALL,
-        req=Requirement("pbr>=5,<7"),
-        pre_built=False,
-    ) == ("", Version("6"))
-
-    bt.why = [(RequirementType.TOP_LEVEL, Requirement("blah"), Version("1.0.0"))]
-    # resolving pbr dependency of blah
-    assert bt._resolve_from_graph(
-        req_type=RequirementType.INSTALL,
-        req=Requirement("pbr==5"),
-        pre_built=False,
-    ) == ("", Version("5"))
-
-
-def test_resolve_from_graph_install_dep_downgrade(tmp_context: WorkContext) -> None:
-    bt = bootstrapper.Bootstrapper(tmp_context, None, old_graph)
-
-    # simulating new bootstrap with a toplevel requirement of pbr<=6
-    tmp_context.dependency_graph.add_dependency(
-        parent_name=None,
-        parent_version=None,
-        req_type=RequirementType.TOP_LEVEL,
-        req=Requirement("pbr<=6"),
-        req_version=Version("6"),
-    )
-
-    bt.why = [(RequirementType.TOP_LEVEL, Requirement("foo"), Version("1.0.0"))]
-    # resolving pbr dependency of foo
-    assert bt._resolve_from_graph(
-        req_type=RequirementType.INSTALL,
-        req=Requirement("pbr>=5"),
-        pre_built=False,
-    ) == ("", Version("6"))
-
-    bt.why = [(RequirementType.TOP_LEVEL, Requirement("bar"), Version("1.0.0"))]
-    # resolving pbr dependency of bar
-    assert bt._resolve_from_graph(
-        req_type=RequirementType.INSTALL,
-        req=Requirement("pbr>=5,<7"),
-        pre_built=False,
-    ) == ("", Version("6"))
-
-    bt.why = [(RequirementType.TOP_LEVEL, Requirement("blah"), Version("1.0.0"))]
-    # resolving pbr dependency of blah
-    assert bt._resolve_from_graph(
-        req_type=RequirementType.INSTALL,
-        req=Requirement("pbr==5"),
-        pre_built=False,
-    ) == ("", Version("5"))
-
-
-def test_resolve_from_graph_toplevel_dep(tmp_context: WorkContext) -> None:
-    bt = bootstrapper.Bootstrapper(tmp_context, None, old_graph)
-
-    # simulating new bootstrap with a toplevel requirement for foo
-    tmp_context.dependency_graph.add_dependency(
-        parent_name=None,
-        parent_version=None,
-        req_type=RequirementType.TOP_LEVEL,
-        req=Requirement("foo==2"),
-        req_version=Version("2"),
-    )
-
-    # simulating new bootstrap with a toplevel requirement of bar (no change)
-    tmp_context.dependency_graph.add_dependency(
-        parent_name=None,
-        parent_version=None,
-        req_type=RequirementType.TOP_LEVEL,
-        req=Requirement("bar"),
-        req_version=Version("1.0.0"),
-    )
-
-    bt.why = []
-    # resolving foo
-    assert bt._resolve_from_graph(
-        req_type=RequirementType.TOP_LEVEL,
-        req=Requirement("foo==2"),
-        pre_built=False,
-    ) == ("", Version("2"))
-
-    bt.why = [(RequirementType.TOP_LEVEL, Requirement("foo"), Version("2"))]
-    # resolving pbr dependency of foo even if foo version changed
-    assert bt._resolve_from_graph(
-        req_type=RequirementType.INSTALL,
-        req=Requirement("pbr>=5"),
-        pre_built=False,
-    ) == ("", Version("7"))
-
-    bt.why = []
-    # resolving bar
-    assert bt._resolve_from_graph(
-        req_type=RequirementType.TOP_LEVEL,
-        req=Requirement("bar"),
-        pre_built=False,
-    ) == ("", Version("1.0.0"))
-
-    bt.why = [(RequirementType.TOP_LEVEL, Requirement("bar"), Version("1.0.0"))]
-    # resolving pbr dependency of bar
-    assert bt._resolve_from_graph(
-        req_type=RequirementType.INSTALL,
-        req=Requirement("pbr>=5,<7"),
-        pre_built=False,
-    ) == ("", Version("6"))
 
 
 def test_seen(tmp_context: WorkContext) -> None:
@@ -390,7 +172,7 @@ def test_build_order_name_canonicalization(tmp_context: WorkContext) -> None:
 
 
 def test_explain(tmp_context: WorkContext) -> None:
-    bt = bootstrapper.Bootstrapper(tmp_context, None, old_graph)
+    bt = bootstrapper.Bootstrapper(tmp_context)
     bt.why = [(RequirementType.TOP_LEVEL, Requirement("foo"), Version("1.0.0"))]
     assert bt._explain == f"{RequirementType.TOP_LEVEL} dependency foo (1.0.0)"
 
@@ -408,7 +190,7 @@ def test_explain(tmp_context: WorkContext) -> None:
 
 
 def test_is_build_requirement(tmp_context: WorkContext) -> None:
-    bt = bootstrapper.Bootstrapper(tmp_context, None, old_graph)
+    bt = bootstrapper.Bootstrapper(tmp_context)
     bt.why = []
     assert not bt._processing_build_requirement(RequirementType.TOP_LEVEL)
     assert bt._processing_build_requirement(RequirementType.BUILD_SYSTEM)

--- a/tests/test_requirement_resolver.py
+++ b/tests/test_requirement_resolver.py
@@ -1,0 +1,262 @@
+"""Tests for requirement_resolver module."""
+
+import pytest
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+from packaging.version import Version
+
+from fromager.context import WorkContext
+from fromager.dependency_graph import DependencyGraph
+from fromager.requirement_resolver import RequirementResolver
+from fromager.requirements_file import RequirementType
+
+# Test fixture: previous dependency graph
+old_graph = DependencyGraph()
+
+old_graph.add_dependency(
+    parent_name=None,
+    parent_version=None,
+    req_type=RequirementType.TOP_LEVEL,
+    req=Requirement("foo"),
+    req_version=Version("1.0.0"),
+)
+
+old_graph.add_dependency(
+    parent_name=canonicalize_name("foo"),
+    parent_version=Version("1.0.0"),
+    req_type=RequirementType.INSTALL,
+    req=Requirement("pbr>=5"),
+    req_version=Version("7"),
+)
+
+old_graph.add_dependency(
+    parent_name=None,
+    parent_version=None,
+    req_type=RequirementType.TOP_LEVEL,
+    req=Requirement("bar"),
+    req_version=Version("1.0.0"),
+)
+
+old_graph.add_dependency(
+    parent_name=canonicalize_name("bar"),
+    parent_version=Version("1.0.0"),
+    req_type=RequirementType.INSTALL,
+    req=Requirement("pbr>=5,<7"),
+    req_version=Version("6"),
+)
+
+old_graph.add_dependency(
+    parent_name=None,
+    parent_version=None,
+    req_type=RequirementType.TOP_LEVEL,
+    req=Requirement("blah"),
+    req_version=Version("1.0.0"),
+)
+
+old_graph.add_dependency(
+    parent_name=canonicalize_name("blah"),
+    parent_version=Version("1.0.0"),
+    req_type=RequirementType.INSTALL,
+    req=Requirement("pbr==5"),
+    req_version=Version("5"),
+)
+
+
+def test_resolve_from_graph_no_changes(tmp_context: WorkContext) -> None:
+    """RequirementResolver resolves from previous graph with no changes."""
+    resolver = RequirementResolver(tmp_context, old_graph)
+
+    # Resolving new dependency that doesn't exist in graph
+    assert (
+        resolver._resolve_from_graph(
+            req=Requirement("xyz"),
+            req_type=RequirementType.INSTALL,
+            pre_built=False,
+            parent_req=Requirement("foo"),
+        )
+        is None
+    )
+
+    # Resolving pbr dependency of foo
+    assert resolver._resolve_from_graph(
+        req=Requirement("pbr>=5"),
+        req_type=RequirementType.INSTALL,
+        pre_built=False,
+        parent_req=Requirement("foo"),
+    ) == ("", Version("7"))
+
+    # Resolving pbr dependency of bar
+    assert resolver._resolve_from_graph(
+        req=Requirement("pbr>=5,<7"),
+        req_type=RequirementType.INSTALL,
+        pre_built=False,
+        parent_req=Requirement("bar"),
+    ) == ("", Version("6"))
+
+    # Resolving pbr dependency of blah
+    assert resolver._resolve_from_graph(
+        req=Requirement("pbr==5"),
+        req_type=RequirementType.INSTALL,
+        pre_built=False,
+        parent_req=Requirement("blah"),
+    ) == ("", Version("5"))
+
+
+def test_resolve_from_graph_install_dep_upgrade(tmp_context: WorkContext) -> None:
+    """RequirementResolver prefers top-level requirements over history."""
+    resolver = RequirementResolver(tmp_context, old_graph)
+
+    # Simulating new bootstrap with a toplevel requirement of pbr==8
+    tmp_context.dependency_graph.add_dependency(
+        parent_name=None,
+        parent_version=None,
+        req_type=RequirementType.TOP_LEVEL,
+        req=Requirement("pbr==8"),
+        req_version=Version("8"),
+    )
+
+    # Resolving pbr dependency of foo - should get upgraded version from top-level
+    assert resolver._resolve_from_graph(
+        req=Requirement("pbr>=5"),
+        req_type=RequirementType.INSTALL,
+        pre_built=False,
+        parent_req=Requirement("foo"),
+    ) == ("", Version("8"))
+
+    # Resolving pbr dependency of bar - constraint prevents upgrade
+    assert resolver._resolve_from_graph(
+        req=Requirement("pbr>=5,<7"),
+        req_type=RequirementType.INSTALL,
+        pre_built=False,
+        parent_req=Requirement("bar"),
+    ) == ("", Version("6"))
+
+    # Resolving pbr dependency of blah - exact version requirement
+    assert resolver._resolve_from_graph(
+        req=Requirement("pbr==5"),
+        req_type=RequirementType.INSTALL,
+        pre_built=False,
+        parent_req=Requirement("blah"),
+    ) == ("", Version("5"))
+
+
+def test_resolve_from_graph_install_dep_downgrade(tmp_context: WorkContext) -> None:
+    """RequirementResolver handles version downgrades from top-level requirements."""
+    resolver = RequirementResolver(tmp_context, old_graph)
+
+    # Simulating new bootstrap with a toplevel requirement of pbr<=6
+    tmp_context.dependency_graph.add_dependency(
+        parent_name=None,
+        parent_version=None,
+        req_type=RequirementType.TOP_LEVEL,
+        req=Requirement("pbr<=6"),
+        req_version=Version("6"),
+    )
+
+    # Resolving pbr dependency of foo - gets downgraded to 6
+    assert resolver._resolve_from_graph(
+        req=Requirement("pbr>=5"),
+        req_type=RequirementType.INSTALL,
+        pre_built=False,
+        parent_req=Requirement("foo"),
+    ) == ("", Version("6"))
+
+    # Resolving pbr dependency of bar - already at 6
+    assert resolver._resolve_from_graph(
+        req=Requirement("pbr>=5,<7"),
+        req_type=RequirementType.INSTALL,
+        pre_built=False,
+        parent_req=Requirement("bar"),
+    ) == ("", Version("6"))
+
+    # Resolving pbr dependency of blah - exact version requirement
+    assert resolver._resolve_from_graph(
+        req=Requirement("pbr==5"),
+        req_type=RequirementType.INSTALL,
+        pre_built=False,
+        parent_req=Requirement("blah"),
+    ) == ("", Version("5"))
+
+
+def test_resolve_from_graph_toplevel_dep(tmp_context: WorkContext) -> None:
+    """RequirementResolver resolves top-level dependencies correctly."""
+    resolver = RequirementResolver(tmp_context, old_graph)
+
+    # Simulating new bootstrap with a toplevel requirement for foo
+    tmp_context.dependency_graph.add_dependency(
+        parent_name=None,
+        parent_version=None,
+        req_type=RequirementType.TOP_LEVEL,
+        req=Requirement("foo==2"),
+        req_version=Version("2"),
+    )
+
+    # Simulating new bootstrap with a toplevel requirement of bar (no change)
+    tmp_context.dependency_graph.add_dependency(
+        parent_name=None,
+        parent_version=None,
+        req_type=RequirementType.TOP_LEVEL,
+        req=Requirement("bar"),
+        req_version=Version("1.0.0"),
+    )
+
+    # Resolving foo - should get new version from top-level
+    assert resolver._resolve_from_graph(
+        req=Requirement("foo==2"),
+        req_type=RequirementType.TOP_LEVEL,
+        pre_built=False,
+        parent_req=None,
+    ) == ("", Version("2"))
+
+    # Resolving pbr dependency of foo even if foo version changed
+    assert resolver._resolve_from_graph(
+        req=Requirement("pbr>=5"),
+        req_type=RequirementType.INSTALL,
+        pre_built=False,
+        parent_req=Requirement("foo"),
+    ) == ("", Version("7"))
+
+    # Resolving bar
+    assert resolver._resolve_from_graph(
+        req=Requirement("bar"),
+        req_type=RequirementType.TOP_LEVEL,
+        pre_built=False,
+        parent_req=None,
+    ) == ("", Version("1.0.0"))
+
+    # Resolving pbr dependency of bar
+    assert resolver._resolve_from_graph(
+        req=Requirement("pbr>=5,<7"),
+        req_type=RequirementType.INSTALL,
+        pre_built=False,
+        parent_req=Requirement("bar"),
+    ) == ("", Version("6"))
+
+
+def test_resolve_from_graph_no_previous_graph(tmp_context: WorkContext) -> None:
+    """RequirementResolver returns None when no previous graph is available."""
+    resolver = RequirementResolver(tmp_context, prev_graph=None)
+
+    assert (
+        resolver._resolve_from_graph(
+            req=Requirement("pbr>=5"),
+            req_type=RequirementType.INSTALL,
+            pre_built=False,
+            parent_req=Requirement("foo"),
+        )
+        is None
+    )
+
+
+def test_resolve_source_rejects_git_urls(tmp_context: WorkContext) -> None:
+    """RequirementResolver.resolve_source() rejects git URLs."""
+    resolver = RequirementResolver(tmp_context)
+
+    with pytest.raises(
+        ValueError, match="Git URL requirements must be handled by Bootstrapper"
+    ):
+        resolver.resolve_source(
+            req=Requirement("package @ git+https://github.com/example/repo.git"),
+            req_type=RequirementType.TOP_LEVEL,
+            parent_req=None,
+        )


### PR DESCRIPTION
This commit moves PyPI and graph-based resolution logic from Bootstrapper to new
  RequirementResolver class in requirement_resolver.py module. This
  separates resolution concerns from orchestration

Key changes:
  - Created RequirementResolver with resolve_source() and resolve_prebuilt()
  - Extracted _resolve_from_graph() and _resolve_from_version_source()
  - Git URL resolution stays in Bootstrapper (requires build orchestration)
  - Session state (_resolved_requirements, why stack) stays in Bootstrapper
  - Updated tests to use new resolver interface

This commit is phase 1 of the plan which was
generated using claude and can be found here
in the gist: https://gist.github.com/rd4398/35bb4d56b0c11b4b5eb5f194a0886e26