### PR TITLE
fix(e2e): use 127.0.0.1 for local wheel server on macOS

### DIFF
--- a/e2e/common.sh
+++ b/e2e/common.sh
@@ -73,11 +73,11 @@ start_local_wheel_server() {
     python3 -m http.server --directory "$serve_dir" 9999 &
     HTTP_SERVER_PID=$!
     if which ip 2>&1 >/dev/null; then
-        # Linux
+        # Linux: need host IP because podman can't reach localhost
         IP=$(ip route get 1.1.1.1 | grep 1.1.1.1 | awk '{print $7}')
     else
-        # macOS
-        IP=$(ipconfig getifaddr en0)
+        # macOS: no network isolation, localhost works
+        IP=127.0.0.1
     fi
     export WHEEL_SERVER_URL="http://${IP}:9999/simple"
 }

--- a/e2e/test_bootstrap_conflicting_requirements.sh
+++ b/e2e/test_bootstrap_conflicting_requirements.sh
@@ -13,7 +13,7 @@ source "$SCRIPTDIR/common.sh"
 # expected pbr version
 constraints_file=$(mktemp)
 trap "rm -f $constraints_file" EXIT
-echo "pbr==6.1.1" > "$constraints_file"
+echo "pbr==7.0.3" > "$constraints_file"
 
 # passing settings to bootstrap but should have 0 effect on it
 fromager \
@@ -47,7 +47,7 @@ $pass
 # packages should be written to the constraints file. Conflicting packages
 # (stevedore versions) should be excluded entirely.
 EXPECTED_LINES="
-pbr==6.1.1
+pbr==7.0.3
 "
 
 SHOULD_NOT_BE_PRESENT="


### PR DESCRIPTION
On macOS CI runners, `ipconfig getifaddr en0` returns a VM bridge address (e.g. 192.168.64.24) that becomes unreachable mid-test, causing uv to fail with tcp connect errors. Since macOS does not use network isolation (podman), 127.0.0.1 works reliably.

Closes: #922