### PR TITLE
fix(e2e): wait for local wheel server to be ready before proceeding

### DIFF
--- a/e2e/common.sh
+++ b/e2e/common.sh
@@ -80,4 +80,21 @@ start_local_wheel_server() {
         IP=127.0.0.1
     fi
     export WHEEL_SERVER_URL="http://${IP}:9999/simple"
+
+    # Wait for the server to accept connections (up to 15 s).
+    { set +x; } 2>/dev/null
+    local ready=false
+    for _ in $(seq 1 30); do
+        kill -0 "$HTTP_SERVER_PID" 2>/dev/null || break
+        curl -sf "http://${IP}:9999/" >/dev/null 2>&1 && { ready=true; break; }
+        sleep 0.5
+    done
+    set -x
+
+    if $ready; then
+        echo "Wheel server is ready"
+        return 0
+    fi
+    echo "ERROR: wheel server did not become ready" >&2
+    return 1
 }


### PR DESCRIPTION
On macOS, python3 -m http.server without --bind calls getaddrinfo() which returns AF_INET6 first, causing the server to bind to :: (IPv6). Since macOS defaults IPV6_V6ONLY=1, the IPv6 socket does not accept
IPv4 connections, so uv connecting to 127.0.0.1 gets ETIMEDOUT.

Also the start_local_wheel_server function launches python3 http.server in the background but returns immediately. On macOS CI runners the server can take a moment to start listening, causing uv to fail with TCP connect timeouts. Add a readiness poll loop that waits up to 15 seconds for the server to respond before returning.

Closes: #924