### PR TITLE
fix(e2e): preserve failing test output before next test cleanup

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -133,7 +133,9 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.test-script }}-py${{ matrix.python-version }}-rs${{ matrix.rust-version }}-${{ matrix.os }}
-          path: e2e-output
+          path: |
+            e2e-output
+            e2e-failed-*
 
       - name: Upload coverage
         uses: actions/upload-artifact@v6

--- a/e2e/ci_suite_framework.sh
+++ b/e2e/ci_suite_framework.sh
@@ -54,6 +54,14 @@ run_test() {
         echo "PASSED: $test_name"
     else
         echo "FAILED: $test_name"
+        # Preserve output for debugging before next test cleans it up
+        local outdir
+        outdir="$(dirname "$SCRIPTDIR")/e2e-output"
+        local failed_dir
+        failed_dir="$(dirname "$SCRIPTDIR")/e2e-failed-${test_name}"
+        if [ -d "$outdir" ]; then
+            mv "$outdir" "$failed_dir" || true
+        fi
         FAILED_TESTS+=("$test_name")
         # Continue running other tests instead of exiting immediately
         # This provides more comprehensive feedback in CI


### PR DESCRIPTION
When a mid-suite test fails, its e2e-output/ directory is deleted by clean_test_environment() when the next test starts.

To fix this the patch moving e2e-output dir to e2e-failed-<test_name> dir on failure so the data survives cleanup, and update the CI workflow to upload these preserved directories alongside e2e-output.

Fixes #917