### PR TITLE
fix(ci): pin virtualenv<21 to fix hatch environment creation failure

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -21,7 +21,7 @@ jobs:
           python-version: "3.11"  # minimum supported lang version
 
       - name: Install dependencies
-        run: python -m pip install hatch 'click!=8.3.0'
+        run: python -m pip install hatch 'click!=8.3.0' 'virtualenv<21'
 
       - name: Run pre-commit hooks
         run: hatch run lint:install-hooks && hatch run lint:precommit
@@ -42,7 +42,7 @@ jobs:
           python-version: "3.11"  # minimum supported lang version
 
       - name: Install dependencies
-        run: python -m pip install hatch 'click!=8.3.0'
+        run: python -m pip install hatch 'click!=8.3.0' 'virtualenv<21'
 
       - name: Run
         run: hatch run lint:check
@@ -63,7 +63,7 @@ jobs:
           python-version: "3.11"  # minimum supported lang version
 
       - name: Install dependencies
-        run: python -m pip install hatch 'click!=8.3.0'
+        run: python -m pip install hatch 'click!=8.3.0' 'virtualenv<21'
 
       - name: Check MyPy
         run: hatch run mypy:check
@@ -84,7 +84,7 @@ jobs:
           python-version: "3.11"  # minimum supported lang version
 
       - name: Install dependencies
-        run: python -m pip install hatch 'click!=8.3.0'
+        run: python -m pip install hatch 'click!=8.3.0' 'virtualenv<21'
 
       - name: Run
         run: hatch run lint:pkglint
@@ -121,7 +121,7 @@ jobs:
           python-version: "3.11"  # minimum supported lang version
 
       - name: Install dependencies
-        run: python -m pip install hatch 'click!=8.3.0'
+        run: python -m pip install hatch 'click!=8.3.0' 'virtualenv<21'
 
       - name: Run
         run: hatch run docs:build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,7 +49,7 @@ jobs:
         run: unshare -rn echo "unshare works"
 
       - name: Install dependencies
-        run: python -m pip install hatch 'click!=8.3.0'
+        run: python -m pip install hatch 'click!=8.3.0' 'virtualenv<21'
 
       - name: Run tests
         run: hatch run test:test
@@ -123,7 +123,7 @@ jobs:
         run: unshare -rn echo "unshare works"
 
       - name: Install dependencies
-        run: python -m pip install hatch 'click!=8.3.0'
+        run: python -m pip install hatch 'click!=8.3.0' 'virtualenv<21'
 
       - name: Run tests
         run: HATCH_PYTHON=${{ matrix.python-version }} ./e2e/${{ matrix.test-script }}.sh
@@ -167,7 +167,7 @@ jobs:
             **/pyproject.toml
 
       - name: Install dependencies
-        run: python -m pip install hatch 'click!=8.3.0'
+        run: python -m pip install hatch 'click!=8.3.0' 'virtualenv<21'
 
       - name: Download coverage data
         uses: actions/download-artifact@v7


### PR DESCRIPTION
virtualenv 21.0.0 (released 2026-02-25) removed the `propose_interpreters` attribute from `virtualenv.discovery.builtin`, which hatch 1.16.4 depends on. This breaks all hatch-managed CI jobs.

Pin virtualenv<21 until hatch releases a compatible version.

Upstream: https://github.com/pypa/hatch/issues/2193 
 Issue tracking removal of the pin once it is fixed : https://github.com/python-wheel-build/fromager/issues/932

Closes: #930