### PR TITLE
refactor: pass version to more hooks

### DIFF
--- a/src/fromager/bootstrapper.py
+++ b/src/fromager/bootstrapper.py
@@ -554,6 +554,7 @@ class Bootstrapper:
     def _prepare_build_dependencies(
         self,
         req: Requirement,
+        resolved_version: Version | None,
         sdist_root_dir: pathlib.Path,
         build_env: build_environment.BuildEnvironment,
     ) -> set[Requirement]:
@@ -561,6 +562,7 @@ class Bootstrapper:
         build_system_dependencies = dependencies.get_build_system_dependencies(
             ctx=self.ctx,
             req=req,
+            version=resolved_version,
             sdist_root_dir=sdist_root_dir,
         )
         self._handle_build_requirements(
@@ -575,6 +577,7 @@ class Bootstrapper:
         build_backend_dependencies = dependencies.get_build_backend_dependencies(
             ctx=self.ctx,
             req=req,
+            version=resolved_version,
             sdist_root_dir=sdist_root_dir,
             build_env=build_env,
         )
@@ -588,6 +591,7 @@ class Bootstrapper:
         build_sdist_dependencies = dependencies.get_build_sdist_dependencies(
             ctx=self.ctx,
             req=req,
+            version=resolved_version,
             sdist_root_dir=sdist_root_dir,
             build_env=build_env,
         )
@@ -851,7 +855,12 @@ class Bootstrapper:
             # Prepare build dependencies (always needed)
             # Note: This may recursively call bootstrap() for build deps,
             # which has its own error handling.
-            self._prepare_build_dependencies(req, sdist_root_dir, build_env)
+            self._prepare_build_dependencies(
+                req=req,
+                resolved_version=resolved_version,
+                sdist_root_dir=sdist_root_dir,
+                build_env=build_env,
+            )
 
             # Build wheel or sdist
             wheel_filename, sdist_filename = self._do_build(
@@ -1214,7 +1223,10 @@ class Bootstrapper:
             parent_dir=source_dir.parent,
         )
         build_dependencies = self._prepare_build_dependencies(
-            req, source_dir, build_env=build_env
+            req=req,
+            resolved_version=None,
+            sdist_root_dir=source_dir,
+            build_env=build_env,
         )
         build_env.install(build_dependencies)
 

--- a/src/fromager/build_environment.py
+++ b/src/fromager/build_environment.py
@@ -249,6 +249,7 @@ def prepare_build_environment(
     *,
     ctx: context.WorkContext,
     req: Requirement,
+    version: Version | None = None,
     sdist_root_dir: pathlib.Path,
 ) -> BuildEnvironment:
     logger.info("preparing build environment")
@@ -261,6 +262,7 @@ def prepare_build_environment(
     build_system_dependencies = dependencies.get_build_system_dependencies(
         ctx=ctx,
         req=req,
+        version=version,
         sdist_root_dir=sdist_root_dir,
     )
     _safe_install(
@@ -274,6 +276,7 @@ def prepare_build_environment(
     build_backend_dependencies = dependencies.get_build_backend_dependencies(
         ctx=ctx,
         req=req,
+        version=version,
         sdist_root_dir=sdist_root_dir,
         build_env=build_env,
     )
@@ -288,6 +291,7 @@ def prepare_build_environment(
     build_sdist_dependencies = dependencies.get_build_sdist_dependencies(
         ctx=ctx,
         req=req,
+        version=version,
         sdist_root_dir=sdist_root_dir,
         build_env=build_env,
     )

--- a/src/fromager/commands/build.py
+++ b/src/fromager/commands/build.py
@@ -420,7 +420,10 @@ def _build(
 
         # Build environment
         build_env = build_environment.prepare_build_environment(
-            ctx=wkctx, req=req, sdist_root_dir=source_root_dir
+            ctx=wkctx,
+            req=req,
+            version=resolved_version,
+            sdist_root_dir=source_root_dir,
         )
 
         # Make a new source distribution, in case we patched the code.

--- a/src/fromager/commands/step.py
+++ b/src/fromager/commands/step.py
@@ -180,7 +180,10 @@ def prepare_build(
     token = requirement_ctxvar.set(req)
     source_root_dir = _find_source_root_dir(wkctx, wkctx.work_dir, req, dist_version)
     build_environment.prepare_build_environment(
-        ctx=wkctx, req=req, sdist_root_dir=source_root_dir
+        ctx=wkctx,
+        req=req,
+        version=dist_version,
+        sdist_root_dir=source_root_dir,
     )
     requirement_ctxvar.reset(token)
 

--- a/src/fromager/dependencies.py
+++ b/src/fromager/dependencies.py
@@ -41,6 +41,7 @@ def get_build_system_dependencies(
     *,
     ctx: context.WorkContext,
     req: Requirement,
+    version: Version | None = None,
     sdist_root_dir: pathlib.Path,
 ) -> set[Requirement]:
     logger.info(f"getting build system dependencies for {req} in {sdist_root_dir}")
@@ -107,6 +108,7 @@ def get_build_backend_dependencies(
     *,
     ctx: context.WorkContext,
     req: Requirement,
+    version: Version | None = None,
     sdist_root_dir: pathlib.Path,
     build_env: build_environment.BuildEnvironment,
 ) -> set[Requirement]:
@@ -124,7 +126,7 @@ def get_build_backend_dependencies(
     extra_environ = packagesettings.get_extra_environ(
         ctx=ctx,
         req=req,
-        version=None,
+        version=version,
         sdist_root_dir=sdist_root_dir,
         build_env=build_env,
     )
@@ -178,6 +180,7 @@ def get_build_sdist_dependencies(
     *,
     ctx: context.WorkContext,
     req: Requirement,
+    version: Version | None = None,
     sdist_root_dir: pathlib.Path,
     build_env: build_environment.BuildEnvironment,
 ) -> set[Requirement]:
@@ -195,7 +198,7 @@ def get_build_sdist_dependencies(
     extra_environ = packagesettings.get_extra_environ(
         ctx=ctx,
         req=req,
-        version=None,
+        version=version,
         sdist_root_dir=sdist_root_dir,
         build_env=build_env,
     )

--- a/src/fromager/packagesettings.py
+++ b/src/fromager/packagesettings.py
@@ -883,6 +883,7 @@ class PackageBuildInfo:
         *,
         template_env: dict[str, str] | None = None,
         build_env: build_environment.BuildEnvironment | None = None,
+        version: Version | None = None,
     ) -> dict[str, str]:
         """Get extra environment variables for a variant
 
@@ -1226,7 +1227,10 @@ def get_extra_environ(
 ) -> dict[str, str]:
     """Get extra environment variables from settings and update hook"""
     pbi = ctx.package_build_info(req)
-    extra_environ = pbi.get_extra_environ(build_env=build_env)
+    extra_environ = pbi.get_extra_environ(
+        build_env=build_env,
+        version=version,
+    )
     overrides.find_and_invoke(
         req.name,
         "update_extra_environ",

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -155,6 +155,7 @@ def test_get_build_system_dependencies(
     results = dependencies.get_build_system_dependencies(
         ctx=tmp_context,
         req=Requirement("fromager"),
+        version=Version("1.0.0"),
         sdist_root_dir=tmp_path,
     )
     names = set(r.name for r in results)
@@ -172,6 +173,7 @@ def test_get_build_system_dependencies_cached(
     results = dependencies.get_build_system_dependencies(
         ctx=tmp_context,
         req=Requirement("fromager"),
+        version=Version("1.0.0"),
         sdist_root_dir=sdist_root_dir,
     )
     assert results == set([Requirement("foo==1.0")])
@@ -195,6 +197,7 @@ def test_get_build_backend_dependencies(
     build_system_dependencies = dependencies.get_build_system_dependencies(
         ctx=tmp_context,
         req=req,
+        version=Version("1.0.0"),
         sdist_root_dir=_fromager_root,
     )
     build_env.install(build_system_dependencies)
@@ -202,6 +205,7 @@ def test_get_build_backend_dependencies(
     results = dependencies.get_build_backend_dependencies(
         ctx=tmp_context,
         req=req,
+        version=Version("1.0.0"),
         sdist_root_dir=_fromager_root,
         build_env=build_env,
     )
@@ -225,6 +229,7 @@ def test_get_build_backend_dependencies_cached(
     results = dependencies.get_build_backend_dependencies(
         ctx=tmp_context,
         req=Requirement("fromager"),
+        version=Version("1.0.0"),
         sdist_root_dir=sdist_root_dir,
         build_env=build_env,
     )
@@ -249,6 +254,7 @@ def test_get_build_sdist_dependencies(
     build_system_dependencies = dependencies.get_build_system_dependencies(
         ctx=tmp_context,
         req=req,
+        version=Version("1.0.0"),
         sdist_root_dir=_fromager_root,
     )
     build_env.install(build_system_dependencies)
@@ -256,6 +262,7 @@ def test_get_build_sdist_dependencies(
     results = dependencies.get_build_sdist_dependencies(
         ctx=tmp_context,
         req=req,
+        version=Version("1.0.0"),
         sdist_root_dir=_fromager_root,
         build_env=build_env,
     )
@@ -280,6 +287,7 @@ def test_get_build_sdist_dependencies_cached(
     results = dependencies.get_build_sdist_dependencies(
         ctx=tmp_context,
         req=req,
+        version=Version("1.0.0"),
         sdist_root_dir=sdist_root_dir,
         build_env=build_env,
     )


### PR DESCRIPTION
Pass the resolved version to more methods and hooks. This gives `packagesettings.get_extra_environ` access to version information in most cases.

`dependencies.get_build_*_dependencies` hooks now have access to version in most cases. Nightly builds from VCS don't have the version. Nightly builds have to prepare an environment, then request package metadata to get the version from metadata.

The improvement will enable us to add the version as a template variable, so `env` in package settings can use something like `${__version__}` in the future.

See: #946