### PR TITLE
Generate minimal SBOM

### DIFF
--- a/docs/reference/config-reference.rst
+++ b/docs/reference/config-reference.rst
@@ -20,6 +20,8 @@ For example `flash_attn.yaml`.
 
 .. autopydantic_model:: fromager.packagesettings.ProjectOverride
 
+.. autopydantic_model:: fromager.packagesettings.SbomSettings
+
 Global Settings
 ---------------
 

--- a/src/fromager/packagesettings/__init__.py
+++ b/src/fromager/packagesettings/__init__.py
@@ -8,6 +8,7 @@ from ._models import (
     PackageSettings,
     ProjectOverride,
     ResolverDist,
+    SbomSettings,
     VariantInfo,
 )
 from ._pbi import PackageBuildInfo
@@ -47,6 +48,7 @@ __all__ = (
     "ProjectOverride",
     "RawAnnotations",
     "ResolverDist",
+    "SbomSettings",
     "Settings",
     "SettingsFile",
     "Template",

--- a/src/fromager/packagesettings/_models.py
+++ b/src/fromager/packagesettings/_models.py
@@ -29,6 +29,33 @@ from ._typedefs import (
 logger = logging.getLogger(__name__)
 
 
+class SbomSettings(pydantic.BaseModel):
+    """Global SBOM generation settings
+
+    ::
+
+      sbom:
+        supplier: "Organization: ExampleCo"
+        namespace: "https://www.example.com"
+        creators:
+          - "Organization: ExampleCo"
+    """
+
+    model_config = MODEL_CONFIG
+
+    supplier: str = "NOASSERTION"
+    """SPDX supplier field for the wheel package (e.g. ``Organization: ExampleCo``)"""
+
+    namespace: str = "https://spdx.org/spdxdocs"
+    """Base URL for the SPDX documentNamespace"""
+
+    creators: list[str] = Field(default_factory=list)
+    """Additional SPDX creator entries (e.g. ``Organization: ExampleCo``)
+
+    The fromager tool creator entry is always added automatically.
+    """
+
+
 class ResolverDist(pydantic.BaseModel):
     """Packages resolver dist
 
@@ -323,6 +350,14 @@ class PackageSettings(pydantic.BaseModel):
 
     download_source: DownloadSource = Field(default_factory=DownloadSource)
     """Alternative source download settings"""
+
+    purl: str | None = None
+    """Package URL (purl) override for SBOM generation
+
+    When set, this value is used instead of the default ``pkg:pypi/<name>@<version>``
+    purl. Useful for packages that are not on PyPI or are midstream forks.
+    Supports ``{name}`` and ``{version}`` format substitution.
+    """
 
     resolver_dist: ResolverDist = Field(default_factory=ResolverDist)
     """Resolve distribution version"""

--- a/src/fromager/packagesettings/_pbi.py
+++ b/src/fromager/packagesettings/_pbi.py
@@ -70,6 +70,11 @@ class PackageBuildInfo:
         return self._variant
 
     @property
+    def purl(self) -> str | None:
+        """Package URL (purl) override for SBOM generation."""
+        return self._ps.purl
+
+    @property
     def annotations(self) -> Annotations:
         """Get Package and variant annotations
 

--- a/src/fromager/packagesettings/_settings.py
+++ b/src/fromager/packagesettings/_settings.py
@@ -13,7 +13,7 @@ from packaging.utils import canonicalize_name
 from pydantic import Field
 
 from .. import overrides
-from ._models import PackageSettings
+from ._models import PackageSettings, SbomSettings
 from ._pbi import PackageBuildInfo
 from ._typedefs import MODEL_CONFIG, GlobalChangelog, Package, Variant
 
@@ -36,6 +36,14 @@ class SettingsFile(pydantic.BaseModel):
 
     changelog: GlobalChangelog = Field(default_factory=dict)
     """Changelog entries"""
+
+    sbom: SbomSettings | None = None
+    """SBOM generation settings
+
+    When set, Fromager generates SPDX 2.3 SBOM documents and embeds
+    them in built wheels per PEP 770. When absent (default), no SBOMs
+    are generated.
+    """
 
     @classmethod
     def from_string(
@@ -161,6 +169,11 @@ class Settings:
         """Change max jobs (for testing)"""
         self._pbi_cache.clear()
         self._max_jobs = jobs
+
+    @property
+    def sbom_settings(self) -> SbomSettings | None:
+        """Get global SBOM settings, or None if SBOM generation is disabled."""
+        return self._settings.sbom
 
     def variant_changelog(self) -> list[str]:
         """Get global changelog for current variant"""

--- a/src/fromager/sbom.py
+++ b/src/fromager/sbom.py
@@ -1,0 +1,140 @@
+"""Generate SPDX 2.3 SBOM documents for wheels built by Fromager.
+
+Produces minimal SPDX 2.3 JSON documents conforming to PEP 770 for
+embedding in the ``.dist-info/sboms/`` directory of built wheels.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import logging
+import pathlib
+import typing
+from datetime import UTC, datetime
+
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+from packaging.version import Version
+
+if typing.TYPE_CHECKING:
+    from . import context
+
+logger = logging.getLogger(__name__)
+
+SBOM_FILENAME = "fromager.spdx.json"
+
+
+def _build_purl(
+    *,
+    package_name: str,
+    package_version: Version,
+    purl_override: str | None,
+) -> str:
+    """Build a package URL for the SBOM.
+
+    Returns ``pkg:pypi/<name>@<version>`` by default. If a purl override
+    is set in per-package settings, it is used instead with
+    ``str.format()`` substitution for ``{name}`` and ``{version}``.
+    """
+    if purl_override:
+        try:
+            return purl_override.format(name=package_name, version=package_version)
+        except (KeyError, ValueError) as err:
+            raise ValueError(
+                f"invalid purl template {purl_override!r}: "
+                "only {name} and {version} are supported"
+            ) from err
+    return f"pkg:pypi/{package_name}@{package_version}"
+
+
+def generate_sbom(
+    *,
+    ctx: context.WorkContext,
+    req: Requirement,
+    version: Version,
+) -> dict[str, typing.Any]:
+    """Generate a minimal SPDX 2.3 JSON document for a wheel.
+
+    The document contains the wheel as the primary package and a
+    DESCRIBES relationship from the document to the package.
+    """
+    sbom_settings = ctx.settings.sbom_settings
+    if sbom_settings is None:
+        raise RuntimeError("generate_sbom called but SBOM settings are not configured")
+
+    pbi = ctx.package_build_info(req)
+    name = canonicalize_name(req.name)
+    fromager_version = importlib.metadata.version("fromager")
+    timestamp = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    creators = list(sbom_settings.creators)
+    creators.append(f"Tool: fromager-{fromager_version}")
+
+    namespace = f"{sbom_settings.namespace}/{name}-{version}.spdx.json"
+
+    package_entry: dict[str, typing.Any] = {
+        "SPDXID": "SPDXRef-wheel",
+        "name": name,
+        "versionInfo": str(version),
+        "downloadLocation": "NOASSERTION",
+        "supplier": sbom_settings.supplier,
+    }
+
+    purl = _build_purl(
+        package_name=name,
+        package_version=version,
+        purl_override=pbi.purl,
+    )
+    package_entry["externalRefs"] = [
+        {
+            "referenceCategory": "PACKAGE-MANAGER",
+            "referenceType": "purl",
+            "referenceLocator": purl,
+        }
+    ]
+
+    doc: dict[str, typing.Any] = {
+        "spdxVersion": "SPDX-2.3",
+        "dataLicense": "CC0-1.0",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": f"{name}-{version}",
+        "documentNamespace": namespace,
+        "creationInfo": {
+            "created": timestamp,
+            "creators": creators,
+        },
+        "packages": [package_entry],
+        "relationships": [
+            {
+                "spdxElementId": "SPDXRef-DOCUMENT",
+                "relationshipType": "DESCRIBES",
+                "relatedSpdxElement": "SPDXRef-wheel",
+            },
+        ],
+    }
+    return doc
+
+
+def write_sbom(
+    *,
+    sbom: dict[str, typing.Any],
+    dist_info_dir: pathlib.Path,
+) -> pathlib.Path:
+    """Write an SBOM document to the .dist-info/sboms/ directory.
+
+    Creates the sboms/ subdirectory if it does not already exist.
+    Returns the path to the written file.
+    """
+    sboms_dir = dist_info_dir / "sboms"
+    sboms_dir.mkdir(exist_ok=True)
+    # Fromager generates exactly one SBOM per wheel, so overwriting a
+    # previous fromager.spdx.json from an earlier run is expected.
+    # SBOMs from other tools (e.g. maturin's CycloneDX) use different
+    # filenames and are not affected.
+    sbom_path = sboms_dir / SBOM_FILENAME
+    with sbom_path.open("w", encoding="utf-8") as f:
+        json.dump(sbom, f, indent=2)
+        f.write("\n")
+    logger.info("wrote SBOM to %s", sbom_path)
+    return sbom_path

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -30,6 +30,7 @@ from . import (
     packagesettings,
     requirements_file,
     resolver,
+    sbom,
     sources,
 )
 
@@ -250,6 +251,15 @@ def add_extra_metadata_to_wheels(
                 )
         else:
             logger.debug("%s is a purelib wheel", req.name)
+
+        sbom_settings = ctx.settings.sbom_settings
+        if sbom_settings is not None:
+            sbom_doc = sbom.generate_sbom(
+                ctx=ctx,
+                req=req,
+                version=version,
+            )
+            sbom.write_sbom(sbom=sbom_doc, dist_info_dir=dist_info_dir)
 
         build_tag_from_settings = pbi.build_tag(version)
         build_tag = build_tag_from_settings if build_tag_from_settings else (0, "")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from click.testing import CliRunner
 
 from fromager import context, packagesettings
+from fromager.packagesettings import SbomSettings
 
 TESTDATA_PATH = pathlib.Path(__file__).parent.absolute() / "testdata"
 E2E_PATH = pathlib.Path(__file__).parent.parent.absolute() / "e2e"
@@ -80,6 +81,38 @@ def testdata_context(
     )
     ctx.setup()
     return ctx
+
+
+def make_sbom_ctx(
+    tmp_path: pathlib.Path,
+    sbom_settings: SbomSettings | None = None,
+    purl: str | None = None,
+) -> context.WorkContext:
+    """Create a minimal WorkContext with SBOM settings."""
+    settings_file = packagesettings.SettingsFile(sbom=sbom_settings)
+    settings = packagesettings.Settings(
+        settings=settings_file,
+        package_settings=[],
+        patches_dir=tmp_path / "patches",
+        variant="cpu",
+        max_jobs=None,
+    )
+    if purl is not None:
+        ps = packagesettings.PackageSettings.from_mapping(
+            "test-pkg",
+            {"purl": purl},
+            source="test",
+            has_config=True,
+        )
+        settings._package_settings[ps.name] = ps
+    return context.WorkContext(
+        active_settings=settings,
+        constraints_file=None,
+        patches_dir=tmp_path / "patches",
+        sdists_repo=tmp_path / "sdists-repo",
+        wheels_repo=tmp_path / "wheels-repo",
+        work_dir=tmp_path / "work-dir",
+    )
 
 
 @pytest.fixture

--- a/tests/test_packagesettings.py
+++ b/tests/test_packagesettings.py
@@ -72,6 +72,7 @@ FULL_EXPECTED: dict[str, typing.Any] = {
     },
     "name": "test-pkg",
     "has_config": True,
+    "purl": None,
     "project_override": {
         "remove_build_requires": ["cmake"],
         "update_build_requires": ["setuptools>=68.0.0", "torch"],
@@ -132,6 +133,7 @@ EMPTY_EXPECTED: dict[str, typing.Any] = {
         "submodule_paths": [],
     },
     "has_config": True,
+    "purl": None,
     "project_override": {
         "remove_build_requires": [],
         "update_build_requires": [],
@@ -171,6 +173,7 @@ PREBUILT_PKG_EXPECTED: dict[str, typing.Any] = {
         "submodule_paths": [],
     },
     "has_config": True,
+    "purl": None,
     "project_override": {
         "remove_build_requires": [],
         "update_build_requires": [],

--- a/tests/test_sbom.py
+++ b/tests/test_sbom.py
@@ -1,0 +1,175 @@
+import json
+import pathlib
+
+from conftest import make_sbom_ctx
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+from fromager import sbom
+from fromager.packagesettings import SbomSettings
+
+
+def test_generate_sbom_structure(tmp_path: pathlib.Path) -> None:
+    """Verify the generated SBOM has the required SPDX 2.3 fields."""
+    ctx = make_sbom_ctx(tmp_path, sbom_settings=SbomSettings())
+    doc = sbom.generate_sbom(
+        ctx=ctx,
+        req=Requirement("example-pkg==1.2.3"),
+        version=Version("1.2.3"),
+    )
+
+    assert doc["spdxVersion"] == "SPDX-2.3"
+    assert doc["dataLicense"] == "CC0-1.0"
+    assert doc["SPDXID"] == "SPDXRef-DOCUMENT"
+    assert doc["name"] == "example-pkg-1.2.3"
+    assert "documentNamespace" in doc
+    assert "creationInfo" in doc
+    assert doc["creationInfo"]["created"]
+    assert any("fromager" in c for c in doc["creationInfo"]["creators"])
+
+
+def test_generate_sbom_default_settings(tmp_path: pathlib.Path) -> None:
+    """Verify defaults when no custom settings are provided."""
+    ctx = make_sbom_ctx(tmp_path, sbom_settings=SbomSettings())
+    doc = sbom.generate_sbom(
+        ctx=ctx,
+        req=Requirement("my-package==2.0.0"),
+        version=Version("2.0.0"),
+    )
+
+    pkg = doc["packages"][0]
+    assert pkg["supplier"] == "NOASSERTION"
+    assert pkg["externalRefs"][0]["referenceLocator"] == "pkg:pypi/my-package@2.0.0"
+    assert doc["documentNamespace"] == (
+        "https://spdx.org/spdxdocs/my-package-2.0.0.spdx.json"
+    )
+
+
+def test_generate_sbom_custom_settings(tmp_path: pathlib.Path) -> None:
+    """Verify custom supplier, namespace, and creators are used."""
+    settings = SbomSettings(
+        supplier="Organization: ExampleCo",
+        namespace="https://www.example.com",
+        creators=["Organization: ExampleCo"],
+    )
+    ctx = make_sbom_ctx(tmp_path, sbom_settings=settings)
+    doc = sbom.generate_sbom(
+        ctx=ctx,
+        req=Requirement("my-package==2.0.0"),
+        version=Version("2.0.0"),
+    )
+
+    pkg = doc["packages"][0]
+    assert pkg["supplier"] == "Organization: ExampleCo"
+    assert doc["documentNamespace"] == (
+        "https://www.example.com/my-package-2.0.0.spdx.json"
+    )
+    creators = doc["creationInfo"]["creators"]
+    assert "Organization: ExampleCo" in creators
+    assert any("fromager" in c for c in creators)
+
+
+def test_generate_sbom_purl_override(tmp_path: pathlib.Path) -> None:
+    """Verify per-package purl override is used with template substitution."""
+    ctx = make_sbom_ctx(
+        tmp_path,
+        sbom_settings=SbomSettings(),
+        purl="pkg:generic/{name}@{version}",
+    )
+    doc = sbom.generate_sbom(
+        ctx=ctx,
+        req=Requirement("test-pkg==1.0.0"),
+        version=Version("1.0.0"),
+    )
+
+    pkg = doc["packages"][0]
+    ext_refs = pkg["externalRefs"]
+    assert len(ext_refs) == 1
+    assert ext_refs[0]["referenceLocator"] == "pkg:generic/test-pkg@1.0.0"
+
+
+def test_generate_sbom_default_purl(tmp_path: pathlib.Path) -> None:
+    """Verify default pkg:pypi purl is used when no override is set."""
+    ctx = make_sbom_ctx(tmp_path, sbom_settings=SbomSettings())
+    doc = sbom.generate_sbom(
+        ctx=ctx,
+        req=Requirement("test==0.1.0"),
+        version=Version("0.1.0"),
+    )
+
+    pkg = doc["packages"][0]
+    assert pkg["externalRefs"][0]["referenceLocator"] == "pkg:pypi/test@0.1.0"
+
+
+def test_generate_sbom_canonicalizes_name(tmp_path: pathlib.Path) -> None:
+    """Verify package name is canonicalized per PEP 503."""
+    ctx = make_sbom_ctx(tmp_path, sbom_settings=SbomSettings())
+    doc = sbom.generate_sbom(
+        ctx=ctx,
+        req=Requirement("My_Package==1.0.0"),
+        version=Version("1.0.0"),
+    )
+
+    pkg = doc["packages"][0]
+    assert pkg["name"] == "my-package"
+    assert doc["name"] == "my-package-1.0.0"
+    assert pkg["externalRefs"][0]["referenceLocator"] == "pkg:pypi/my-package@1.0.0"
+
+
+def test_generate_sbom_describes_relationship(tmp_path: pathlib.Path) -> None:
+    """Verify the DESCRIBES relationship exists."""
+    ctx = make_sbom_ctx(tmp_path, sbom_settings=SbomSettings())
+    doc = sbom.generate_sbom(
+        ctx=ctx,
+        req=Requirement("test==0.1.0"),
+        version=Version("0.1.0"),
+    )
+
+    rels = doc["relationships"]
+    assert len(rels) == 1
+    assert rels[0]["spdxElementId"] == "SPDXRef-DOCUMENT"
+    assert rels[0]["relationshipType"] == "DESCRIBES"
+    assert rels[0]["relatedSpdxElement"] == "SPDXRef-wheel"
+
+
+def test_write_sbom_creates_file(tmp_path: pathlib.Path) -> None:
+    """Verify write_sbom creates sboms/ dir and writes valid JSON."""
+    dist_info_dir = tmp_path / "pkg-1.0.dist-info"
+    dist_info_dir.mkdir()
+
+    ctx = make_sbom_ctx(tmp_path, sbom_settings=SbomSettings())
+    doc = sbom.generate_sbom(
+        ctx=ctx,
+        req=Requirement("pkg==1.0"),
+        version=Version("1.0"),
+    )
+    result = sbom.write_sbom(sbom=doc, dist_info_dir=dist_info_dir)
+
+    assert result == dist_info_dir / "sboms" / "fromager.spdx.json"
+    assert result.exists()
+
+    content = json.loads(result.read_text())
+    assert content["spdxVersion"] == "SPDX-2.3"
+
+
+def test_write_sbom_preserves_existing_files(tmp_path: pathlib.Path) -> None:
+    """Verify write_sbom does not overwrite existing SBOM files."""
+    dist_info_dir = tmp_path / "pkg-1.0.dist-info"
+    sboms_dir = dist_info_dir / "sboms"
+    sboms_dir.mkdir(parents=True)
+    existing = sboms_dir / "cyclonedx.json"
+    existing.write_text('{"bomFormat": "CycloneDX"}')
+
+    ctx = make_sbom_ctx(tmp_path, sbom_settings=SbomSettings())
+    doc = sbom.generate_sbom(
+        ctx=ctx,
+        req=Requirement("pkg==1.0"),
+        version=Version("1.0"),
+    )
+    sbom.write_sbom(sbom=doc, dist_info_dir=dist_info_dir)
+
+    # Existing file should be untouched
+    assert existing.exists()
+    assert json.loads(existing.read_text())["bomFormat"] == "CycloneDX"
+    # New file should also exist
+    assert (sboms_dir / "fromager.spdx.json").exists()

--- a/tests/test_wheels.py
+++ b/tests/test_wheels.py
@@ -4,10 +4,12 @@ from unittest.mock import Mock, patch
 
 import pytest
 import wheel.wheelfile  # type: ignore
+from conftest import make_sbom_ctx
 from packaging.requirements import Requirement
 from packaging.version import Version
 
 from fromager import build_environment, context, sources, wheels
+from fromager.packagesettings import SbomSettings
 
 
 @patch("fromager.sources.download_url")
@@ -142,6 +144,66 @@ def test_log_existing_sboms_when_absent(
         wheels._log_existing_sboms(req, dist_info_dir)
 
     assert "SBOM" not in caplog.text
+
+
+@patch("fromager.external_commands.run")
+def test_add_extra_metadata_generates_sbom_when_enabled(
+    mock_run: Mock, tmp_path: pathlib.Path
+) -> None:
+    """Verify SBOM is generated in .dist-info/sboms/ when sbom settings are configured."""
+    sbom_ctx = make_sbom_ctx(tmp_path, sbom_settings=SbomSettings())
+    sbom_ctx.setup()
+    req = Requirement("test_pkg==1.0.0")
+    version = Version("1.0.0")
+
+    wheel_dir = tmp_path / "wheel_build"
+    wheel_dir.mkdir()
+    wheel_file = wheel_dir / "test_pkg-1.0.0-py3-none-any.whl"
+
+    with zipfile.ZipFile(wheel_file, "w") as zf:
+        zf.writestr("test_pkg/__init__.py", "")
+        zf.writestr(
+            "test_pkg-1.0.0.dist-info/METADATA",
+            "Name: test_pkg\nVersion: 1.0.0\n",
+        )
+        zf.writestr(
+            "test_pkg-1.0.0.dist-info/WHEEL",
+            "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+        )
+
+    mock_run.return_value = ""
+
+    # Create the repacked wheel that wheel pack would produce
+    repacked = wheel_dir / "test_pkg-1.0.0-0-py3-none-any.whl"
+
+    sdist_dir = tmp_path / "sdist"
+    sdist_dir.mkdir()
+
+    # Capture the wheel contents before repack by inspecting what wheel pack receives
+    captured_contents: list[str] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> str:
+        # wheel pack is called with the unpacked dir as second arg
+        unpacked_dir = pathlib.Path(cmd[2])
+        for f in unpacked_dir.rglob("*"):
+            if f.is_file():
+                captured_contents.append(str(f.relative_to(unpacked_dir)))
+        repacked.touch()
+        return ""
+
+    mock_run.side_effect = fake_run
+
+    wheels.add_extra_metadata_to_wheels(
+        ctx=sbom_ctx,
+        req=req,
+        version=version,
+        extra_environ={},
+        sdist_root_dir=sdist_dir,
+        wheel_file=wheel_file,
+    )
+
+    # Verify the SBOM file was added to the unpacked wheel before repacking
+    assert any("sboms/fromager.spdx.json" in c for c in captured_contents)
 
 
 def test_download_wheel_unquotes_url_encoded_filenames(tmp_path: pathlib.Path) -> None:


### PR DESCRIPTION
This PR adds logging for discovering existing SBOMs in wheel being built, and a minimal implementation of a Fromager-specific SBOM. The values are set to Red Hat-specific metadata right now, but can be exposed via configuration to arbitrary values in a future PR (or I can tack on that change here as well if necessary).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SBOM generation: creates SPDX 2.3 SBOM JSON for built wheels when enabled, written to dist-info/sboms/.
  * SBOM configuration: global SBOM settings (supplier, namespace, creators) and optional per-package PURL override; exposed via settings and package metadata.
  * Logging: reports existing SBOM files found in wheel metadata.

* **Tests**
  * Added tests for SBOM generation, configuration propagation, PURL templating, output files, and logging.

* **Documentation**
  * Added docs for SBOM settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->