### PR TITLE
fix(e2e): pin setuptools-scm<10 to fix circular bootstrap dependency

### DIFF
--- a/e2e/constraints.txt
+++ b/e2e/constraints.txt
@@ -1,2 +1,9 @@
 # This file is here in case we need to quickly add a constraint to
 # fix CI jobs.
+
+# setuptools-scm 10.0.2 added a build-system dependency on
+# vcs-versioning, which itself requires hatchling. This creates a
+# circular bootstrap dependency that causes e2e tests to fail because
+# hatchling's wheel is not yet available on the local wheel server
+# when vcs-versioning tries to install it. See #982.
+setuptools-scm<10


### PR DESCRIPTION
setuptools-scm 10.0.2 added vcs-versioning as a build-system dependency, which itself requires hatchling. During bootstrap, hatchling's wheel isn't available yet on the local wheel server when vcs-versioning tries to install it, causing ci_bootstrap_suite and ci_specialized_suite to fail across all Python versions and platforms.

Fixes: #982