### PR TITLE
revert(e2e): remove setuptools-scm<10 constraint

### DIFF
--- a/e2e/constraints.txt
+++ b/e2e/constraints.txt
@@ -1,9 +1,2 @@
 # This file is here in case we need to quickly add a constraint to
 # fix CI jobs.
-
-# setuptools-scm 10.0.2 added a build-system dependency on
-# vcs-versioning, which itself requires hatchling. This creates a
-# circular bootstrap dependency that causes e2e tests to fail because
-# hatchling's wheel is not yet available on the local wheel server
-# when vcs-versioning tries to install it. See #982.
-setuptools-scm<10


### PR DESCRIPTION
The circular build dependency (setuptools-scm → vcs-versioning → hatchling → pluggy → setuptools-scm) has been fixed upstream. vcs-versioning 1.1.0 switched its build backend from hatchling to setuptools, breaking the cycle.

See: https://github.com/pypa/setuptools-scm/pull/1325

Reverts: #983



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete build constraint to streamline project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->