### PR TITLE
test: add option to run tests with network access

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,7 +51,7 @@ jobs:
         run: python -m pip install hatch 'click!=8.3.0'
 
       - name: Run tests
-        run: hatch run test:test
+        run: hatch run test:test --with-network
 
       - name: Upload coverage
         uses: actions/upload-artifact@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ test = [
     "hatchling",
     "hatch-vcs",
     "click!=8.3.0",
+    "setuptools-scm",
 ]
 docs = [
     "sphinx",
@@ -283,3 +284,8 @@ description = "Sphinx docs."
 features = ["docs"]
 [tool.hatch.envs.docs.scripts]
 build = "sphinx-build -M html docs docs/_build -j auto --keep-going {args:--fail-on-warning --fresh-env -n}"
+
+[tool.pytest.ini_options]
+markers = [
+    "network: test that need network access",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,26 @@ TESTDATA_PATH = pathlib.Path(__file__).parent.absolute() / "testdata"
 E2E_PATH = pathlib.Path(__file__).parent.parent.absolute() / "e2e"
 
 
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--with-network",
+        action="store_true",
+        default=False,
+        help="run tests that require network access",
+    )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    if config.getoption("--with-network"):
+        return
+    skip_network = pytest.mark.skip(reason="need --with-network option to run")
+    for item in items:
+        if "network" in item.keywords:
+            item.add_marker(skip_network)
+
+
 @pytest.fixture
 def testdata_path() -> typing.Generator[pathlib.Path, None, None]:
     yield TESTDATA_PATH

--- a/tests/test_gitutils.py
+++ b/tests/test_gitutils.py
@@ -1,9 +1,29 @@
 import pathlib
+import shutil
+import subprocess
+import sys
 from unittest.mock import Mock, patch
 
 import pytest
+from packaging.version import Version
 
 from fromager.gitutils import git_clone_fast
+
+needs_git_command = pytest.mark.skipif(
+    shutil.which("git") is None, reason="requires 'git' command"
+)
+
+
+def setuptools_scm_version(root_dir: pathlib.Path) -> Version:
+    out = subprocess.check_output(
+        [sys.executable, "-m", "setuptools_scm"],
+        text=True,
+        stderr=subprocess.STDOUT,
+        cwd=str(root_dir),
+    )
+    # last line contains the version
+    lastline = out.strip().splitlines()[-1]
+    return Version(lastline)
 
 
 @patch("fromager.external_commands.run")
@@ -56,8 +76,12 @@ def test_git_clone_fast_submodules(m_run: Mock, tmp_path: pathlib.Path) -> None:
     )
 
 
-@pytest.mark.skip(reason="needs network access")
+@pytest.mark.network
+@needs_git_command
 def test_git_clone_real(tmp_path: pathlib.Path) -> None:
     repo_url = "https://github.com/python-wheel-build/fromager.git"
     git_clone_fast(output_dir=tmp_path, repo_url=repo_url, ref="refs/tags/0.73.0")
     assert tmp_path.joinpath("src", "fromager").is_dir()
+
+    # detect version from .git
+    assert setuptools_scm_version(tmp_path) == Version("0.73.0")


### PR DESCRIPTION
The new pytest option `--with-network` enables test cases that are decoratored with `network` marker. By default, tests like `test_git_clone_real` are disabled, because they spend a non-trivial amount of time to download content from a remote server.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added support for selectively running network-dependent tests via a new command-line flag
  * Enhanced git integration testing to properly handle version detection in cloned repositories
  * Improved test infrastructure for conditional test execution based on network availability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->