### PR TITLE
fix: skip non-regular files in scan_compiled_extensions

### DIFF
--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -859,6 +859,8 @@ def scan_compiled_extensions(
     for directory, _, filenames in root_dir.walk():
         for filename in filenames:
             filepath = directory / filename
+            if not filepath.is_file():
+                continue
             suffix = filepath.suffix
             if suffix in extension_suffixes:
                 relpath = filepath.relative_to(root_dir)


### PR DESCRIPTION
Fixes: 

# Pull Request Description

## What

pathlib.Path.walk() lists symlinks to directories as filenames rather than dirnames. This causes scan_compiled_extensions to attempt to open() them, resulting in IsADirectoryError. Add an is_file() check to skip non-regular files before attempting to read their contents.



## Why

#1001