### PR TITLE
fix(sources): skip non-regular files in scan_compiled_extensions

### DIFF
--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -865,6 +865,10 @@ def scan_compiled_extensions(
                 logger.debug("file %s has a binary extension suffix", relpath)
                 issues.append(relpath)
             elif suffix not in ignore_suffixes:
+                # Path.walk() lists symlinks to directories as filenames
+                # rather than dirnames, causing IsADirectoryError on open().
+                if not filepath.is_file():
+                    continue
                 with filepath.open("rb") as f:
                     header = f.read(_MAGIC_HEADERS_READ)
                 if header.startswith(magic_headers):


### PR DESCRIPTION
pathlib.Path.walk() lists symlinks to directories as filenames rather than dirnames. This causes scan_compiled_extensions to attempt to open() them, resulting in IsADirectoryError. Add an is_file() check to skip non-regular files before attempting to read their contents.

Closes: #1001 

Closes: #1004

# Pull Request Description

## What

<!-- Brief description of the change. -->

## Why

<!-- Link to issue (Closes #NNN) or explain the motivation. -->

- [x] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
