### PR TITLE
ci: fix mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -36,8 +36,10 @@ pull_request_rules:
           - check-success=unit (3.14, 1.75, ubuntu-latest)
           - check-success=unit (3.14, 1.75, macos-latest)
 
-          # MyPy type checking
-          - check-success=mypy
+          # checks (see check.yaml)
+          - check-success=pre-commit
+          - check-success=pkglint
+          - check-success=readthedocs
 
           # E2E test suites (consolidated from individual tests)
           # Python 3.12 - Ubuntu only (macOS excluded)


### PR DESCRIPTION
# Pull Request Description

## What

PR #903 removed the `mypy` check and moved all checks to `pre-commit`. Update mergify configuration to require successful `pre-commit`, `pkglint`, and `docs` builds before a MR can be merged.