### PR TITLE
feat(dependencies): add --no-discovery flag to prevent PEP 517 hook fallback

### DIFF
--- a/src/fromager/commands/build.py
+++ b/src/fromager/commands/build.py
@@ -142,6 +142,12 @@ build._fromager_show_build_settings = True  # type: ignore
     "cache_wheel_server_url",
     help="url to a wheel server from where fromager can check if it had already built the wheel",
 )
+@click.option(
+    "--no-discovery",
+    is_flag=True,
+    default=False,
+    help="fail instead of running PEP 517 discovery hooks when cached dependency files are missing",
+)
 @click.argument("build_order_file")
 @click.pass_obj
 def build_sequence(
@@ -149,6 +155,7 @@ def build_sequence(
     build_order_file: str,
     force: bool,
     cache_wheel_server_url: str | None,
+    no_discovery: bool,
 ) -> None:
     """Build a sequence of wheels in order
 
@@ -160,6 +167,7 @@ def build_sequence(
     the build order file.
 
     """
+    wkctx.no_discovery = no_discovery
     server.start_wheel_server(wkctx)
 
     if force:
@@ -584,6 +592,12 @@ def _nodes_to_string(nodes: typing.Iterable[dependency_graph.DependencyNode]) ->
     default=None,
     help="maximum number of parallel workers to run (default: unlimited)",
 )
+@click.option(
+    "--no-discovery",
+    is_flag=True,
+    default=False,
+    help="fail instead of running PEP 517 discovery hooks when cached dependency files are missing",
+)
 @click.argument("graph_file")
 @click.pass_obj
 def build_parallel(
@@ -592,6 +606,7 @@ def build_parallel(
     force: bool,
     cache_wheel_server_url: str | None,
     max_workers: int | None,
+    no_discovery: bool,
 ) -> None:
     """Build wheels in parallel based on a dependency graph
 
@@ -603,6 +618,7 @@ def build_parallel(
     parallel. Use --max-workers to limit the number of concurrent builds.
 
     """
+    wkctx.no_discovery = no_discovery
     wkctx.enable_parallel_builds()
 
     server.start_wheel_server(wkctx)

--- a/src/fromager/context.py
+++ b/src/fromager/context.py
@@ -94,6 +94,7 @@ class WorkContext:
         self.time_description_store: dict[str, str] = {}
 
         self._parallel_builds = False
+        self.no_discovery: bool = False
 
     def enable_parallel_builds(self) -> None:
         self._parallel_builds = True

--- a/src/fromager/dependencies.py
+++ b/src/fromager/dependencies.py
@@ -28,6 +28,18 @@ if typing.TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+class DiscoveryHookRequiredError(Exception):
+    """Raised when a PEP 517 discovery hook would be needed but --no-discovery is set."""
+
+    def __init__(self, req: Requirement, cache_file: pathlib.Path) -> None:
+        super().__init__(
+            f"Cached dependency file {cache_file} not found for {req} "
+            f"and --no-discovery prevents running PEP 517 hooks. "
+            f"Run bootstrap first to populate the cache."
+        )
+
+
 BUILD_SYSTEM_REQ_FILE_NAME = "build-system-requirements.txt"
 BUILD_BACKEND_REQ_FILE_NAME = "build-backend-requirements.txt"
 BUILD_SDIST_REQ_FILE_NAME = "build-sdist-requirements.txt"
@@ -51,6 +63,9 @@ def get_build_system_dependencies(
     if build_system_req_file.exists():
         logger.info(f"loading build system dependencies from {build_system_req_file}")
         return _read_requirements_file(build_system_req_file)
+
+    if ctx.no_discovery:
+        raise DiscoveryHookRequiredError(req, build_system_req_file)
 
     logger.debug(
         f"file {build_system_req_file} does not exist, getting dependencies from hook"
@@ -119,6 +134,9 @@ def get_build_backend_dependencies(
     if build_backend_req_file.exists():
         logger.info(f"loading build backend dependencies from {build_backend_req_file}")
         return _read_requirements_file(build_backend_req_file)
+
+    if ctx.no_discovery:
+        raise DiscoveryHookRequiredError(req, build_backend_req_file)
 
     logger.debug(
         f"file {build_backend_req_file} does not exist, getting dependencies from hook"
@@ -191,6 +209,9 @@ def get_build_sdist_dependencies(
     if build_sdist_req_file.exists():
         logger.info(f"loading build sdist dependencies from {build_sdist_req_file}")
         return _read_requirements_file(build_sdist_req_file)
+
+    if ctx.no_discovery:
+        raise DiscoveryHookRequiredError(req, build_sdist_req_file)
 
     logger.debug(
         f"file {build_sdist_req_file} does not exist, getting dependencies from hook"

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -179,6 +179,42 @@ def test_get_build_system_dependencies_cached(
     assert results == set([Requirement("foo==1.0")])
 
 
+def test_get_build_system_dependencies_no_discovery_raises(
+    tmp_context: context.WorkContext, tmp_path: pathlib.Path
+) -> None:
+    """Verify no_discovery raises when cache file is missing."""
+    tmp_context.no_discovery = True
+    sdist_root_dir = tmp_path / "sdist"
+    sdist_root_dir.mkdir()
+
+    with pytest.raises(dependencies.DiscoveryHookRequiredError, match="--no-discovery"):
+        dependencies.get_build_system_dependencies(
+            ctx=tmp_context,
+            req=Requirement("fromager"),
+            version=Version("1.0.0"),
+            sdist_root_dir=sdist_root_dir,
+        )
+
+
+def test_get_build_system_dependencies_no_discovery_uses_cache(
+    tmp_context: context.WorkContext, tmp_path: pathlib.Path
+) -> None:
+    """Verify no_discovery still works when cache file exists."""
+    tmp_context.no_discovery = True
+    sdist_root_dir = tmp_path / "sdist"
+    sdist_root_dir.mkdir()
+
+    req_file = tmp_path / "build-system-requirements.txt"
+    req_file.write_text("foo==1.0")
+    results = dependencies.get_build_system_dependencies(
+        ctx=tmp_context,
+        req=Requirement("fromager"),
+        version=Version("1.0.0"),
+        sdist_root_dir=sdist_root_dir,
+    )
+    assert results == set([Requirement("foo==1.0")])
+
+
 @patch("fromager.dependencies._write_requirements_file")
 @_clean_build_artifacts
 def test_get_build_backend_dependencies(
@@ -234,6 +270,53 @@ def test_get_build_backend_dependencies_cached(
         build_env=build_env,
     )
     assert results == set([Requirement("foo==1.0")])
+
+
+def test_get_build_backend_dependencies_no_discovery_uses_cache(
+    tmp_context: context.WorkContext, tmp_path: pathlib.Path
+) -> None:
+    """Verify no_discovery still works when cache file exists."""
+    tmp_context.no_discovery = True
+    sdist_root_dir = tmp_path / "sdist"
+    sdist_root_dir.mkdir()
+
+    req_file = tmp_path / "build-backend-requirements.txt"
+    req_file.write_text("foo==1.0")
+
+    build_env = build_environment.BuildEnvironment(
+        ctx=tmp_context,
+        parent_dir=tmp_path,
+    )
+    results = dependencies.get_build_backend_dependencies(
+        ctx=tmp_context,
+        req=Requirement("fromager"),
+        version=Version("1.0.0"),
+        sdist_root_dir=sdist_root_dir,
+        build_env=build_env,
+    )
+    assert results == set([Requirement("foo==1.0")])
+
+
+def test_get_build_backend_dependencies_no_discovery_raises(
+    tmp_context: context.WorkContext, tmp_path: pathlib.Path
+) -> None:
+    """Verify no_discovery raises when cache file is missing."""
+    tmp_context.no_discovery = True
+    sdist_root_dir = tmp_path / "sdist"
+    sdist_root_dir.mkdir()
+
+    build_env = build_environment.BuildEnvironment(
+        ctx=tmp_context,
+        parent_dir=tmp_path,
+    )
+    with pytest.raises(dependencies.DiscoveryHookRequiredError, match="--no-discovery"):
+        dependencies.get_build_backend_dependencies(
+            ctx=tmp_context,
+            req=Requirement("fromager"),
+            version=Version("1.0.0"),
+            sdist_root_dir=sdist_root_dir,
+            build_env=build_env,
+        )
 
 
 @patch("fromager.dependencies._write_requirements_file")
@@ -292,6 +375,53 @@ def test_get_build_sdist_dependencies_cached(
         build_env=build_env,
     )
     assert results == set([Requirement("foo==1.0")])
+
+
+def test_get_build_sdist_dependencies_no_discovery_uses_cache(
+    tmp_context: context.WorkContext, tmp_path: pathlib.Path
+) -> None:
+    """Verify no_discovery still works when cache file exists."""
+    tmp_context.no_discovery = True
+    sdist_root_dir = tmp_path / "sdist"
+    sdist_root_dir.mkdir()
+
+    req_file = tmp_path / "build-sdist-requirements.txt"
+    req_file.write_text("foo==1.0")
+
+    build_env = build_environment.BuildEnvironment(
+        ctx=tmp_context,
+        parent_dir=tmp_path,
+    )
+    results = dependencies.get_build_sdist_dependencies(
+        ctx=tmp_context,
+        req=Requirement("fromager"),
+        version=Version("1.0.0"),
+        sdist_root_dir=sdist_root_dir,
+        build_env=build_env,
+    )
+    assert results == set([Requirement("foo==1.0")])
+
+
+def test_get_build_sdist_dependencies_no_discovery_raises(
+    tmp_context: context.WorkContext, tmp_path: pathlib.Path
+) -> None:
+    """Verify no_discovery raises when cache file is missing."""
+    tmp_context.no_discovery = True
+    sdist_root_dir = tmp_path / "sdist"
+    sdist_root_dir.mkdir()
+
+    build_env = build_environment.BuildEnvironment(
+        ctx=tmp_context,
+        parent_dir=tmp_path,
+    )
+    with pytest.raises(dependencies.DiscoveryHookRequiredError, match="--no-discovery"):
+        dependencies.get_build_sdist_dependencies(
+            ctx=tmp_context,
+            req=Requirement("fromager"),
+            version=Version("1.0.0"),
+            sdist_root_dir=sdist_root_dir,
+            build_env=build_env,
+        )
 
 
 @patch("fromager.dependencies.pep517_metadata_of_sdist")


### PR DESCRIPTION

It helps the purpose of separating discovery from compilation.

Closes: #996


<!-- Link to issue (Closes #NNN) or explain the motivation. -->

- [x] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
