### PR TITLE
refactor(sources): use EAFP pattern instead of is_file() check

### DIFF
--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -867,10 +867,11 @@ def scan_compiled_extensions(
             elif suffix not in ignore_suffixes:
                 # Path.walk() lists symlinks to directories as filenames
                 # rather than dirnames, causing IsADirectoryError on open().
-                if not filepath.is_file():
+                try:
+                    with filepath.open("rb") as f:
+                        header = f.read(_MAGIC_HEADERS_READ)
+                except IsADirectoryError:
                     continue
-                with filepath.open("rb") as f:
-                    header = f.read(_MAGIC_HEADERS_READ)
                 if header.startswith(magic_headers):
                     relpath = filepath.relative_to(root_dir)
                     logger.debug(


### PR DESCRIPTION

# Pull Request Description

## What

Replace the is_file() stat syscall with a try/except around open() to handle non-regular files in scan_compiled_extensions. 

Only IsADirectoryError is caught to avoid masking real I/O errors.

## Why

This avoids an extra syscall per file, eliminates the TOCTOU race between the check and the open, and is more idiomatic Python (EAFP over LBYL).
