### PR TITLE
Add a Security policy file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security policy
+
+## Supported versions
+
+Security updates are applied to the latest release only.
+
+## Reporting a vulnerability
+
+If you find a vulnerability in fromager, please report it using GitHub's
+vulnerability reporting under the _Security and quality_ tab (see [GitHub
+documentation](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/privately-reporting-a-security-vulnerability)
+for more information).
+
+**Please do not report security vulnerabilities through public GitHub
+issues.**
+
+In addition to the description of the vulnerability, if possible please
+include a short reproducer, a proposed severity rating, and other
+classifying metadata such as a [CWE](https://cwe.mitre.org/) ID or a
+[CVSS](https://www.first.org/cvss/) score.
+
+## Disclosure Policy
+
+We follow a coordinated disclosure process. We ask that you give us a
+reasonable amount of time to address the vulnerability before making
+any public disclosure.


### PR DESCRIPTION
# Pull Request Description

## What

This was identified as missing when assessing the fromager repository with OpenSSF's scorecard. See #1008.

## Why

A security policy file tells potential contributors how to privately disclose vulnerabilities. GitHub offers a native "report a vulnerability" button (maybe this needs to be configured at the repo level by admins?). If using GitHub is not desired, we could set up a mailing list or point people to Red Hat Product Security (secalert@redhat.com) since this projects is largely maintained by Red Hatters right now.

- [x] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
