### PR TITLE
ci: add minimal permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -4,6 +4,9 @@ on:
   - push
   - pull_request
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     name: pre-commit

--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -6,6 +6,9 @@ name: Upload Python Package
 on:
   - push
 
+permissions:
+  contents: read
+
 jobs:
   build-n-publish:
     name: Build and publish Python distributions to PyPI
@@ -15,6 +18,7 @@ jobs:
     environment: release
 
     permissions:
+      contents: read
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,9 @@ name: CI
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   unit:
     name: unit


### PR DESCRIPTION
# Pull Request Description

## What

Add top-level `permissions: contents: read` to all three workflows (test, check, python-publish) to follow the GitHub security hardening recommendation of least-privilege token permissions. The publish workflow's existing job-level `id-token: write` override remains intact for trusted publishing.

## Why

See: #1008

- [X] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
