### PR TITLE
feat(test): add hatch scripts and docs for coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage-report-*.md
 *.cover
 *.py.cover
 .hypothesis/

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -39,7 +39,26 @@ recent version of Python (as defined in `pyproject.toml` under `project.requires
 - `hatch run test:test` - Run unit tests with coverage
 - `hatch run test:test tests/test_bootstrapper.py` - Run specific test files
 - `hatch run test:test -k "test_metadata"` - Run tests with custom args
-- `hatch run test:coverage-report` - Generate coverage report
+- `hatch run test:coverage-erase` - Clean old coverage data
+- `hatch run test:coverage-report` - Combine and generate markdown coverage report (saved to `coverage-report-<timestamp>.md`)
+
+• **Coverage Report:**
+
+To generate a coverage report that includes both unit and e2e tests:
+
+```bash
+hatch run test:coverage-erase      # Clean old coverage data
+hatch run test:test                # Run unit tests (collects coverage)
+./e2e/run_all.sh                   # Run all e2e tests (collects coverage)
+hatch run test:coverage-report     # Combine and generate markdown report
+```
+
+The report is printed to the terminal and saved to a timestamped file
+(`coverage-report-YYYYMMDD-HHMMSS.md`). For unit-test-only coverage,
+skip the `run_all.sh` step. To run a single e2e suite instead of all,
+replace `run_all.sh` with one of: `ci_bootstrap_suite.sh`,
+`ci_bootstrap_parallel_suite.sh`, `ci_build_suite.sh`, `ci_config_suite.sh`,
+`ci_specialized_suite.sh`, `ci_workflow_suite.sh`.
 
 • **Linting & Code Quality:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,7 +229,9 @@ features = ["test"]
 
 [tool.hatch.envs.test.scripts]
 test = "python -m coverage run -m pytest --log-level DEBUG -vv {args:tests}"
-coverage-report = ["coverage combine", "coverage report --format=markdown"]
+coverage-erase = "coverage erase"
+coverage-combine = "coverage combine"
+coverage-report = ["coverage combine", "coverage report --format=markdown | tee coverage-report-$(date +%Y%m%d-%H%M%S).md"]
 
 [tool.hatch.envs.lint]
 description = "Run linters."


### PR DESCRIPTION
Add coverage lifecycle scripts (coverage-erase, coverage-combine, coverage-report) and document how to generate a combined coverage report that includes both unit and e2e tests.

Related to #1033

