### PR TITLE
mergify: add auto-rebase and conflict notification rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -77,3 +77,23 @@ pull_request_rules:
     actions:
       merge:
         method: merge
+
+  - name: Auto-rebase approved PRs that are behind
+    conditions:
+      - "-draft"
+      - "-conflict"
+      - "#commits-behind>0"
+      - "base=main"
+      - "#approved-reviews-by>=1"
+    actions:
+      rebase:
+
+  - name: Ping author on conflicts
+    conditions:
+      - "conflict"
+      - "-closed"
+    actions:
+      comment:
+        message: |
+          This pull request has merge conflicts that must be resolved before it can be merged.
+          @{{ author }} please rebase your branch.


### PR DESCRIPTION
Add two new Mergify rules:
- Auto-rebase approved PRs that are behind main, eliminating the need to manually comment "@mergify rebase"
- Notify PR authors when merge conflicts are detected

