### PR TITLE
mergify: switch from rebase to update action

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -78,15 +78,16 @@ pull_request_rules:
       merge:
         method: merge
 
-  - name: Auto-rebase approved PRs that are behind
+  - name: Auto-update approved PRs that are behind
     conditions:
       - "-draft"
       - "-conflict"
       - "#commits-behind>0"
       - "base=main"
       - "#approved-reviews-by>=1"
+      - "author!=dependabot[bot]"
     actions:
-      rebase:
+      update:
 
   - name: Ping author on conflicts
     conditions:


### PR DESCRIPTION
The rebase action for fork PRs is deprecated after July 1, 2026. Also exclude dependabot[bot] since Mergify cannot impersonate it.
