### PR TITLE
docs: Add version-removed for resolve_source

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -121,6 +121,8 @@ Resolver hooks
 
 .. currentmodule:: fromager.resolver
 
+.. _resolver_provider_hook:
+
 .. autofromagerhook:: default_resolver_provider
 
     The ``get_resolver_provider()`` function allows an override to change
@@ -190,6 +192,11 @@ Source hooks
 ------------
 
 .. currentmodule:: fromager.sources
+
+.. versionremoved:: 0.80.0
+   The ``resolve_source`` hook and ``default_resolve_source`` function
+   were removed. Define a :ref:`resolver_provider <resolver_provider_hook>` hook
+   to resolve sources.
 
 .. autofromagerhook:: default_download_source
 


### PR DESCRIPTION
# Pull Request Description

## What

Add a version removed entry to inform users that the `resolve_source` hook and `default_resolve_source` were removed.

## Why

See 179c0963f431125c0b294ee863ce8d0cda8dbb8d

- [X] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
