### PR TITLE
fix(mergify): remove auto-update rule that adds merge commits

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -78,17 +78,6 @@ pull_request_rules:
       merge:
         method: merge
 
-  - name: Auto-update approved PRs that are behind
-    conditions:
-      - "-draft"
-      - "-conflict"
-      - "#commits-behind>0"
-      - "base=main"
-      - "#approved-reviews-by>=1"
-      - "author!=dependabot[bot]"
-    actions:
-      update:
-
   - name: Ping author on conflicts
     conditions:
       - "conflict"


### PR DESCRIPTION
The update action defaulted to merge, causing Mergify to add "Merge branch 'main' into <branch>" commits to PRs instead of rebasing them.

Closes: #1069

- [x] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
