### PR TITLE
fix(sources): skip broken symlinks in scan_compiled_extensions (#1082)

### DIFF
--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -883,10 +883,11 @@ def scan_compiled_extensions(
             elif suffix not in ignore_suffixes:
                 # Path.walk() lists symlinks to directories as filenames
                 # rather than dirnames, causing IsADirectoryError on open().
+                # Broken symlinks (target does not exist) raise FileNotFoundError.
                 try:
                     with filepath.open("rb") as f:
                         header = f.read(_MAGIC_HEADERS_READ)
-                except IsADirectoryError:
+                except (IsADirectoryError, FileNotFoundError):
                     continue
                 if header.startswith(magic_headers):
                     relpath = filepath.relative_to(root_dir)

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -285,3 +285,24 @@ def test_scan_compiled_extensions(
         assert matches == [pathlib.Path(filename)]
     else:
         assert matches == []
+
+
+def test_scan_compiled_extensions_skips_broken_symlinks(
+    tmp_path: pathlib.Path,
+) -> None:
+    # Symlink whose target does not exist: open() raises FileNotFoundError.
+    # Must be skipped, not propagated.
+    broken = tmp_path / "broken_link"
+    broken.symlink_to(tmp_path / "does_not_exist")
+    assert sources.scan_compiled_extensions(tmp_path) == []
+
+
+def test_scan_compiled_extensions_skips_dangling_symlink_alongside_real_file(
+    tmp_path: pathlib.Path,
+) -> None:
+    # A broken symlink must not mask detection of a real compiled extension
+    # elsewhere in the tree.
+    (tmp_path / "broken_link").symlink_to(tmp_path / "missing_target")
+    real = tmp_path / "ext.so"
+    real.write_bytes(b"anything")
+    assert sources.scan_compiled_extensions(tmp_path) == [pathlib.Path("ext.so")]


### PR DESCRIPTION
## Summary

Fixes #1082 — `scan_compiled_extensions` crashed on broken symlinks since 0.80.0.

Commit 400d3bd8 moved to an EAFP pattern catching only `IsADirectoryError` (for symlinks-to-directories returned as filenames by `Path.walk()`). Broken symlinks — where the target does not exist — raise `FileNotFoundError` on `open()` and were not caught, propagating out and crashing the entire bootstrap.

The fix adds `FileNotFoundError` to the except tuple and a comment noting why.

## Changes

- `src/fromager/sources.py`: catch `(IsADirectoryError, FileNotFoundError)` in the binary-header read path.
- `tests/test_sources.py`: two regression tests
  - `test_scan_compiled_extensions_skips_broken_symlinks` — standalone dangling symlink does not crash.
  - `test_scan_compiled_extensions_skips_dangling_symlink_alongside_real_file` — dangling symlink does not prevent detection of a real `.so` elsewhere in the tree.

## Test plan

- [x] `pytest tests/test_sources.py -k scan_compiled_extensions` → 10 passed (8 existing + 2 new)
- [x] `ruff check` / `ruff format --check` on both modified files → clean
- [x] Verified both new tests fail without the `FileNotFoundError` addition (original bug reproduces)