### PR TITLE
fix(sources): catch FileNotFoundError for broken symlinks

### DIFF
--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -883,10 +883,11 @@ def scan_compiled_extensions(
             elif suffix not in ignore_suffixes:
                 # Path.walk() lists symlinks to directories as filenames
                 # rather than dirnames, causing IsADirectoryError on open().
+                # Broken symlinks raise FileNotFoundError on open().
                 try:
                     with filepath.open("rb") as f:
                         header = f.read(_MAGIC_HEADERS_READ)
-                except IsADirectoryError:
+                except (IsADirectoryError, FileNotFoundError):
                     continue
                 if header.startswith(magic_headers):
                     relpath = filepath.relative_to(root_dir)

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -285,3 +285,11 @@ def test_scan_compiled_extensions(
         assert matches == [pathlib.Path(filename)]
     else:
         assert matches == []
+
+
+def test_scan_compiled_extensions_broken_symlink(tmp_path: pathlib.Path) -> None:
+    """Verify broken symlinks are skipped without raising an error."""
+    broken_link = tmp_path / "broken_link"
+    broken_link.symlink_to(tmp_path / "nonexistent_target")
+    matches = sources.scan_compiled_extensions(tmp_path)
+    assert matches == []


### PR DESCRIPTION
Closes: #1082

# Pull Request Description

## What

Add FileNotFoundError to the except clause in scan_compiled_extensions and add a regression test.


## Why

Broken symlinks (e.g. .dockerignore → missing .gitignore in PyTorch tarballs) crash the bootstrap with FileNotFoundError since 0.80.0.

- [x] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
