### PR TITLE
fix(e2e): chain on_exit in constraint test EXIT traps

### DIFF
--- a/e2e/test_bootstrap_conflicting_requirements.sh
+++ b/e2e/test_bootstrap_conflicting_requirements.sh
@@ -12,7 +12,7 @@ source "$SCRIPTDIR/common.sh"
 
 # expected pbr version
 constraints_file=$(mktemp)
-trap "rm -f $constraints_file" EXIT
+trap 'rm -f "$constraints_file"; on_exit' EXIT
 echo "pbr==7.0.3" > "$constraints_file"
 
 # passing settings to bootstrap but should have 0 effect on it

--- a/e2e/test_bootstrap_constraints.sh
+++ b/e2e/test_bootstrap_constraints.sh
@@ -11,7 +11,7 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$SCRIPTDIR/common.sh"
 
 constraints_file=$(mktemp)
-trap "rm -f $constraints_file" EXIT
+trap 'rm -f "$constraints_file"; on_exit' EXIT
 echo "stevedore==4.0.0" > "$constraints_file"
 
 # passing settings to bootstrap but should have 0 effect on it

--- a/e2e/test_bootstrap_multiple_versions.sh
+++ b/e2e/test_bootstrap_multiple_versions.sh
@@ -10,7 +10,7 @@ source "$SCRIPTDIR/common.sh"
 # Create constraints file with generous ranges to test multiple versions
 # of build dependencies (not just top-level packages)
 constraints_file=$(mktemp)
-trap "rm -f $constraints_file" EXIT
+trap 'rm -f "$constraints_file"; on_exit' EXIT
 cat > "$constraints_file" <<EOF
 # Allow a range of flit-core versions to verify multiple-versions works for dependencies
 flit-core>=3.9,<3.12


### PR DESCRIPTION
fix(e2e): chain on_exit in constraint test EXIT traps

The three constraint e2e tests registered their own trap ... EXIT which silently replaced the on_exit handler from common.sh. Chain on_exit in each trap and switch to single quotes so $constraints_file is expanded at exit time rather than registration time.

Closes: #1062