### PR TITLE
test(unit): mark PyPI-backed tests as network

### DIFF
--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -181,6 +181,7 @@ def test_get_build_system_dependencies_cached(
 
 @patch("fromager.dependencies._write_requirements_file")
 @_clean_build_artifacts
+@pytest.mark.network
 def test_get_build_backend_dependencies(
     _: Mock, tmp_context: context.WorkContext, tmp_path: pathlib.Path
 ) -> None:
@@ -238,6 +239,7 @@ def test_get_build_backend_dependencies_cached(
 
 @patch("fromager.dependencies._write_requirements_file")
 @_clean_build_artifacts
+@pytest.mark.network
 def test_get_build_sdist_dependencies(
     _: Mock, tmp_context: context.WorkContext, tmp_path: pathlib.Path
 ) -> None:


### PR DESCRIPTION
# Pull Request Description

## What

<!-- Brief description of the change. -->

Mark PyPI-backed tests as network.

## Why

These tests install build requirements from https://pypi.org/simple via
uv, so they require real network access and should be skipped unless
--with-network is enabled.

<!-- Link to issue (Closes #NNN) or explain the motivation. -->

- [x] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
