### PR TITLE
fix(deps): drop requests-mock from runtime deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dependencies = [
     "rich",
     "requests",
     "resolvelib",
-    "requests-mock",
     "starlette",
     "stevedore",
     "tomlkit",


### PR DESCRIPTION
# Pull Request Description

## What

<!-- Brief description of the change. -->

Drop requests-mock from runtime deps.

## Why

requests-mock is only imported by tests and does not belong in runtime
dependencies.

It was originally added as a test-only dependency and was accidentally
promoted into project.dependencies during the hatchling migration in
5e47f8b9254a7231bce627b9a7e5336d8707e711.

<!-- Link to issue (Closes #NNN) or explain the motivation. -->

- [x] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
