### PR TITLE
feat(list-overrides): show per-package min_release_age in --details output

### DIFF
--- a/src/fromager/commands/list_overrides.py
+++ b/src/fromager/commands/list_overrides.py
@@ -111,6 +111,11 @@ def list_overrides(
             [v for v in all_patches.keys() if v is not None]
         )
 
+        min_release_age = ps.resolver_dist.min_release_age
+        min_release_age_str = (
+            str(min_release_age) if min_release_age is not None else ""
+        )
+
         if not all_pkg_versions:
             # This package has overrides, but none are version-specific.
             patches_str = str(num_global_patches) if num_global_patches else ""
@@ -119,6 +124,7 @@ def list_overrides(
                 "version": "",
                 "patches": patches_str,
                 "plugin_hooks": plugin_hooks_str,
+                "min_release_age": min_release_age_str,
             }
             # Add variant information
             row_data.update(variant_info)
@@ -135,6 +141,7 @@ def list_overrides(
                     "version": str(version),
                     "patches": patches_str,
                     "plugin_hooks": plugin_hooks_str,
+                    "min_release_age": min_release_age_str,
                 }
                 # Add variant information
                 row_data.update(variant_info)
@@ -166,7 +173,11 @@ def _export_csv(
 ) -> None:
     """Export data as CSV."""
     # Define field names in the order we want them
-    fieldnames = ["package", "version", "patches"] + variants + ["plugin_hooks"]
+    fieldnames = (
+        ["package", "version", "patches", "min_release_age"]
+        + variants
+        + ["plugin_hooks"]
+    )
 
     if output:
         with open(output, "w", newline="") as outfile:
@@ -190,13 +201,19 @@ def _export_table(data: list[dict], variants: list[str]) -> None:
     table.add_column("Version", justify="left", no_wrap=True)
     table.add_column("Patches", justify="left", no_wrap=True)
 
+    table.add_column("Min Release Age (days)", justify="left", no_wrap=True)
+
     for v in variants:
         table.add_column(v, justify="left", no_wrap=True)
 
     table.add_column("Plugin", justify="left")
 
     # Define column keys in the same order as CSV exporter
-    column_keys = ["package", "version", "patches"] + variants + ["plugin_hooks"]
+    column_keys = (
+        ["package", "version", "patches", "min_release_age"]
+        + variants
+        + ["plugin_hooks"]
+    )
 
     for row_data in data:
         row = [row_data.get(key, "") for key in column_keys]

--- a/tests/test_list_overrides.py
+++ b/tests/test_list_overrides.py
@@ -70,6 +70,7 @@ def test_list_overrides_details_table(
     assert "test-other-pkg" in result.stdout
     assert "test-pkg" in result.stdout
     assert "test-pkg-library" in result.stdout
+    assert "Min Release Age (days)" in result.stdout
 
 
 def test_list_overrides_details_json(
@@ -112,6 +113,7 @@ def test_list_overrides_details_json(
     assert "version" in first_item
     assert "patches" in first_item
     assert "plugin_hooks" in first_item
+    assert "min_release_age" in first_item
     assert "rocm" in first_item  # variant column
 
 
@@ -148,6 +150,7 @@ def test_list_overrides_details_csv(
     assert '"version"' in header
     assert '"patches"' in header
     assert '"plugin_hooks"' in header
+    assert '"min_release_age"' in header
     assert '"rocm"' in header  # variant column
 
     # Check data rows
@@ -251,3 +254,43 @@ def test_list_overrides_warnings_without_details(
         in result.output
     )
     assert "test-other-pkg" in result.output
+
+
+def test_list_overrides_min_release_age(
+    testdata_path: pathlib.Path, cli_runner: CliRunner
+) -> None:
+    """Test that min_release_age per-package override appears in --details output."""
+    overrides_dir = testdata_path / "context" / "overrides"
+    settings_file = overrides_dir / "settings.yaml"
+    settings_dir = overrides_dir / "settings"
+    patches_dir = overrides_dir / "patches"
+
+    result = cli_runner.invoke(
+        fromager,
+        [
+            "--settings-file",
+            str(settings_file),
+            "--settings-dir",
+            str(settings_dir),
+            "--patches-dir",
+            str(patches_dir),
+            "list-overrides",
+            "--details",
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0
+
+    json_output = _extract_json_from_output(result.stdout)
+    data = json.loads(json_output)
+
+    # test-cooldown-pkg has resolver_dist.min_release_age: 7 in its settings YAML
+    test_cooldown_pkg = next(
+        item for item in data if item["package"] == "test-cooldown-pkg"
+    )
+    assert test_cooldown_pkg["min_release_age"] == "7"
+
+    # test-other-pkg has no min_release_age override — should be empty
+    test_other_pkg = next(item for item in data if item["package"] == "test-other-pkg")
+    assert test_other_pkg["min_release_age"] == ""

--- a/tests/test_packagesettings.py
+++ b/tests/test_packagesettings.py
@@ -29,6 +29,7 @@ TEST_EMPTY_PKG = "test-empty-pkg"
 TEST_OTHER_PKG = "test-other-pkg"
 TEST_RELATED_PKG = "test-pkg-library"
 TEST_PREBUILT_PKG = "test-prebuilt-pkg"
+TEST_COOLDOWN_PKG = "test-cooldown-pkg"
 
 FULL_EXPECTED: dict[str, typing.Any] = {
     "annotations": {
@@ -507,6 +508,7 @@ def test_settings_overrides(testdata_context: context.WorkContext) -> None:
         TEST_OTHER_PKG,
         TEST_RELATED_PKG,
         TEST_PREBUILT_PKG,
+        TEST_COOLDOWN_PKG,
     }
 
 
@@ -552,6 +554,7 @@ def test_global_changelog(testdata_context: context.WorkContext) -> None:
 
 def test_settings_list(testdata_context: context.WorkContext) -> None:
     assert testdata_context.settings.list_overrides() == {
+        TEST_COOLDOWN_PKG,
         TEST_EMPTY_PKG,
         TEST_OTHER_PKG,
         TEST_PKG,

--- a/tests/testdata/context/overrides/settings/test_cooldown_pkg.yaml
+++ b/tests/testdata/context/overrides/settings/test_cooldown_pkg.yaml
@@ -1,0 +1,2 @@
+resolver_dist:
+    min_release_age: 7


### PR DESCRIPTION
Add a "Min Release Age (days)" column to `list-overrides --details` for all output formats (table, CSV, JSON). The column shows the per-package `resolver_dist.min_release_age` override value, or an empty string when the package inherits the global --min-release-age setting.


Closes: #1079

- [x] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
