### PR TITLE
docs(proposals): use glob toctree to prevent merge conflicts

### DIFF
--- a/docs/proposals/index.rst
+++ b/docs/proposals/index.rst
@@ -3,8 +3,6 @@ Fromager Enhancement Proposals
 
 .. toctree::
    :maxdepth: 1
+   :glob:
 
-   iterative-bootstrap
-   new-patcher-config
-   new-resolver-config
-   release-cooldown
+   *


### PR DESCRIPTION
Replace the hand-maintained file list in docs/proposals/index.rst with Sphinx's :glob: directive. This eliminates recurring merge conflicts when multiple proposal PRs are open simultaneously, as new proposals no longer need to modify the index file.

Closes: #1108

- [x] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
