### PR TITLE
tests: pass GITHUB_TOKEN to tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Run tests
         run: hatch run test:test --with-network
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload coverage
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
@@ -126,6 +128,8 @@ jobs:
 
       - name: Run tests
         run: HATCH_PYTHON=${{ matrix.python-version }} ./e2e/${{ matrix.test-script }}.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload logs for debugging
         if: ${{ failure() }}


### PR DESCRIPTION


# Pull Request Description

## What

Pass GITHUB_TOKEN secret to Fromager tests, `GitHubTagResolver` is able to use authenticated GitHub requests. The token permissions is already limited to contents read.

## Why

Tests are running into GitHub API rate limiting issues.

- [X] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
