### PR TITLE
feat(constraints): support <0 specifier to block packages

### DIFF
--- a/docs/how-tos/bootstrap-constraints.rst
+++ b/docs/how-tos/bootstrap-constraints.rst
@@ -53,3 +53,18 @@ Fromager can load constraints from `https://` URLs, too.
 .. code-block:: console
 
    $ fromager -c constraints.txt -c local-constraints.txt -c https://company.example/security-constraints.txt bootstrap my-package
+
+Blocking packages
+-----------------
+
+To block a package entirely so that no version is accepted, use the special
+constraint ``<0`` (or equivalently ``<0.0`` or ``<0.0.0``). No valid Python
+version can satisfy this specifier, so the package is effectively excluded from
+the build.
+
+.. code-block:: text
+
+   unwanted-package<0
+
+A blocked constraint cannot be combined with a regular constraint for the same
+package. Adding both will raise an error.

--- a/src/fromager/constraints.py
+++ b/src/fromager/constraints.py
@@ -4,12 +4,27 @@ import typing
 from collections.abc import Generator
 
 from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
 from packaging.utils import NormalizedName, canonicalize_name
 from packaging.version import Version
 
 from . import requirements_file
 
 logger = logging.getLogger(__name__)
+
+
+def _is_blocked_specifier(specifier: SpecifierSet) -> bool:
+    """Return True if specifier blocks a package entirely.
+
+    The convention ``<0``, ``<0.0``, or ``<0.0.0`` is used to mark a
+    package as blocked so that no version can satisfy the constraint.
+    """
+    specs = list(specifier)
+    return (
+        len(specs) == 1
+        and specs[0].operator == "<"
+        and Version(specs[0].version) == Version("0")
+    )
 
 
 class InvalidConstraintError(ValueError):
@@ -51,8 +66,12 @@ class Constraints:
         if not req.specifier:
             raise InvalidConstraintError(f"Constraint {unparsed!r} has no specifiers")
 
+        # A "blocked" specifier (<0, <0.0, <0.0.0) is intentionally
+        # unsatisfiable and used to exclude a package from builds.
+        blocked = _is_blocked_specifier(req.specifier)
+
         # verify that incoming constraint is okay by itself
-        if req.specifier.is_unsatisfiable():
+        if not blocked and req.specifier.is_unsatisfiable():
             raise InvalidConstraintError(f"Constraint {unparsed!r} is unsatisfiable")
 
         if not requirements_file.evaluate_marker(req, req):
@@ -60,14 +79,21 @@ class Constraints:
             return
 
         if previous is not None:
-            logger.debug("combining constraints %s and %s", previous, req)
-            new_specifier = req.specifier & previous.specifier
-            if new_specifier.is_unsatisfiable():
+            prev_blocked = _is_blocked_specifier(previous.specifier)
+            if blocked != prev_blocked:
                 raise InvalidConstraintError(
-                    f"Combined specifier '{new_specifier}' is not satisfiable "
+                    f"Cannot combine blocked and non-blocked constraints "
                     f"(existing: {previous}, new: {req})"
                 )
-            req.specifier = new_specifier
+            if not blocked:
+                logger.debug("combining constraints %s and %s", previous, req)
+                new_specifier = req.specifier & previous.specifier
+                if new_specifier.is_unsatisfiable():
+                    raise InvalidConstraintError(
+                        f"Combined specifier '{new_specifier}' is not satisfiable "
+                        f"(existing: {previous}, new: {req})"
+                    )
+                req.specifier = new_specifier
         else:
             logger.debug(f"adding constraint {req}")
 
@@ -95,6 +121,13 @@ class Constraints:
         constraint = self.get_constraint(pkg_name)
         if constraint:
             return bool(constraint.specifier.prereleases)
+        return False
+
+    def is_blocked(self, pkg_name: str) -> bool:
+        """Return True if the package is blocked by a ``<0`` constraint."""
+        constraint = self.get_constraint(pkg_name)
+        if constraint:
+            return _is_blocked_specifier(constraint.specifier)
         return False
 
     def is_satisfied_by(self, pkg_name: str, version: Version) -> bool:

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -173,3 +173,32 @@ def test_combine_constraints() -> None:
     assert c.get_constraint("foo") == Requirement("foo<2.0,>=1.0")
     c.add_constraint("foo!=1.1.0")
     assert c.get_constraint("foo") == Requirement("foo<2.0,>=1.0,!=1.1.0")
+
+
+@pytest.mark.parametrize("specifier", ["<0", "<0.0", "<0.0.0"])
+def test_blocked_package(specifier: str) -> None:
+    c = Constraints()
+    c.add_constraint(f"blocked-pkg{specifier}")
+    assert c.is_blocked("blocked-pkg")
+    assert not c.is_satisfied_by("blocked-pkg", Version("0"))
+    assert not c.is_satisfied_by("blocked-pkg", Version("0.0.1"))
+    assert not c.is_satisfied_by("blocked-pkg", Version("1.0"))
+
+
+def test_blocked_then_non_blocked_raises() -> None:
+    c = Constraints()
+    c.add_constraint("foo<0")
+    with pytest.raises(InvalidConstraintError, match=r"blocked and non-blocked"):
+        c.add_constraint("foo>=1.0")
+
+
+def test_non_blocked_then_blocked_raises() -> None:
+    c = Constraints()
+    c.add_constraint("foo>=1.0")
+    with pytest.raises(InvalidConstraintError, match=r"blocked and non-blocked"):
+        c.add_constraint("foo<0")
+
+
+def test_is_blocked_unknown_package() -> None:
+    c = Constraints()
+    assert not c.is_blocked("unknown")


### PR DESCRIPTION
# Pull Request Description

## What

The convention `<0` (also `<0.0` and `<0.0.0`) is intentionally unsatisfiable and used to exclude a package from builds. Skip the `is_unsatisfiable()` rejection for these specifiers and add a `Constraints.is_blocked()` query method. Combining a blocked and a non-blocked constraint for the same package raises an error.

## Why

See: #1096

- [X] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for blocking packages from version resolution using the `<0` constraint syntax (or equivalent forms).
  * Blocked constraints cannot be combined with regular constraints for the same package; mixing them results in an error.

* **Documentation**
  * New guide explaining how to exclude packages using blocking constraints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/python-wheel-build/fromager/pull/1132)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->