### PR TITLE
feat(resolver): promote cooldown enforcement log to INFO level

### DIFF
--- a/e2e/test_bootstrap_cooldown.sh
+++ b/e2e/test_bootstrap_cooldown.sh
@@ -59,6 +59,12 @@ if ! find "$OUTDIR/wheels-repo/downloads/" -name 'stevedore-5.3.0*.whl' | grep -
   pass=false
 fi
 
+# The cooldown must have logged that it skipped a stevedore version.
+if ! grep -q "stevedore: skipping.*cooldown" "$OUTDIR/bootstrap-flag.log"; then
+  echo "FAIL (flag): no cooldown enforcement message for stevedore found in log" 1>&2
+  pass=false
+fi
+
 # --- Pass 2: enforce the same cooldown via environment variable (FROMAGER_MIN_RELEASE_AGE) ---
 
 # Wipe output so the second run starts clean.
@@ -79,6 +85,11 @@ fi
 
 if ! find "$OUTDIR/wheels-repo/downloads/" -name 'stevedore-5.3.0*.whl' | grep -q .; then
   echo "FAIL (envvar): stevedore-5.3.0 wheel not found in wheels-repo" 1>&2
+  pass=false
+fi
+
+if ! grep -q "stevedore: skipping.*cooldown" "$OUTDIR/bootstrap-envvar.log"; then
+  echo "FAIL (envvar): no cooldown enforcement message for stevedore found in log" 1>&2
   pass=false
 fi
 

--- a/e2e/test_bootstrap_cooldown_gitlab.sh
+++ b/e2e/test_bootstrap_cooldown_gitlab.sh
@@ -75,4 +75,10 @@ if ! grep -q "GitLabTagProvider" "$OUTDIR/bootstrap.log"; then
   pass=false
 fi
 
+# The cooldown must have logged that it skipped a python-gitlab version.
+if ! grep -q "python-gitlab: skipping.*cooldown" "$OUTDIR/bootstrap.log"; then
+  echo "FAIL: no cooldown enforcement message for python-gitlab found in log" 1>&2
+  pass=false
+fi
+
 $pass

--- a/e2e/test_bootstrap_cooldown_prebuilt.sh
+++ b/e2e/test_bootstrap_cooldown_prebuilt.sh
@@ -62,4 +62,10 @@ if find "$OUTDIR/sdists-repo/" \( -name 'stevedore*.tar.gz' -o -name 'stevedore*
   pass=false
 fi
 
+# The cooldown must have logged that it skipped a stevedore version.
+if ! grep -q "stevedore: skipping.*cooldown" "$OUTDIR/bootstrap.log"; then
+  echo "FAIL: no cooldown enforcement message for stevedore found in log" 1>&2
+  pass=false
+fi
+
 $pass

--- a/e2e/test_bootstrap_cooldown_transitive.sh
+++ b/e2e/test_bootstrap_cooldown_transitive.sh
@@ -69,4 +69,10 @@ if ! find "$OUTDIR/wheels-repo/downloads/" -name 'pbr-6.1.1*.whl' | grep -q .; t
   pass=false
 fi
 
+# The cooldown must have logged that it skipped a pbr version.
+if ! grep -q "pbr: skipping.*cooldown" "$OUTDIR/bootstrap.log"; then
+  echo "FAIL: no cooldown enforcement message for pbr found in log" 1>&2
+  pass=false
+fi
+
 $pass

--- a/src/fromager/resolver.py
+++ b/src/fromager/resolver.py
@@ -724,15 +724,14 @@ class BaseProvider(ExtrasProvider):
         cutoff = self.cooldown.bootstrap_time - self.cooldown.min_age
         if candidate.upload_time > cutoff:
             # if this candidate is "too new", block/skip it
-            if DEBUG_RESOLVER:
-                age = self.cooldown.bootstrap_time - candidate.upload_time
-                logger.debug(
-                    "%s: skipping %s uploaded %s ago (cooldown: %s)",
-                    candidate.name,
-                    candidate.version,
-                    age,
-                    self.cooldown.min_age,
-                )
+            age = self.cooldown.bootstrap_time - candidate.upload_time
+            logger.info(
+                "%s: skipping %s uploaded %s ago (cooldown: %s)",
+                candidate.name,
+                candidate.version,
+                age,
+                self.cooldown.min_age,
+            )
             return True
         return False
 


### PR DESCRIPTION
The cooldown skip message was gated behind `DEBUG_RESOLVER` and logged at `DEBUG`.

Promote to `INFO` so operators can easily confirm cooldown enforcement is working without enabling verbose debug output.

