### PR TITLE
feat(bootstrapper): skip already-cached versions in multiple version mode

### DIFF
--- a/src/fromager/bootstrapper.py
+++ b/src/fromager/bootstrapper.py
@@ -1299,11 +1299,13 @@ class Bootstrapper:
         """RESOLVE phase: resolve versions and expand into START-phase items.
 
         Centralizes version resolution so all dependencies are expanded
-        uniformly. Future filtering (e.g. versions already on disk) and
-        parallelization can be added here in one place.
+        uniformly. In multiple_versions mode, filters out versions whose
+        wheels are already cached to avoid redundant builds and
+        transitive dependency processing.
 
         Returns:
-            One START-phase item per resolved version.
+            One START-phase item per resolved version that needs building.
+            Empty list if all versions are already cached.
         """
         resolved_versions = self.resolve_versions(
             item.req,
@@ -1315,6 +1317,27 @@ class Bootstrapper:
 
         if self.multiple_versions:
             logger.info(f"resolved {len(resolved_versions)} version(s) for {item.req}")
+            filtered: list[tuple[str, Version]] = []
+            for source_url, version in resolved_versions:
+                cached_wheel, _ = self._find_cached_wheel(item.req, version)
+                if cached_wheel:
+                    logger.info(
+                        f"{item.req.name}=={version}: wheel already cached "
+                        f"at {cached_wheel.name}, skipping"
+                    )
+                else:
+                    filtered.append((source_url, version))
+            if not filtered:
+                # Always process the highest version (first in
+                # resolved_versions) so new transitive dependencies
+                # are discovered even when every wheel is cached.
+                logger.info(
+                    f"all versions of {item.req.name} already cached, "
+                    f"keeping highest version {resolved_versions[0][1]} "
+                    f"for dependency discovery"
+                )
+                filtered.append(resolved_versions[0])
+            resolved_versions = filtered
 
         # Build list so highest version ends up on top of the stack
         # (last element after extend) and is processed first.

--- a/tests/test_bootstrapper_iterative.py
+++ b/tests/test_bootstrapper_iterative.py
@@ -277,6 +277,82 @@ class TestPhaseResolve:
 
         assert result[0].why_snapshot == snapshot
 
+    def test_filters_cached_versions_in_multiple_versions_mode(
+        self, tmp_context: WorkContext
+    ) -> None:
+        """Cached versions are filtered out before creating START items."""
+        bt = bootstrapper.Bootstrapper(tmp_context, multiple_versions=True)
+        item = _make_resolve_item()
+
+        def mock_cache(req: Requirement, version: Version) -> tuple:
+            if str(version) == "2.0":
+                return (tmp_context.work_dir / "pkg-2.0-py3-none-any.whl", None)
+            return (None, None)
+
+        with (
+            patch.object(
+                bt,
+                "resolve_versions",
+                return_value=[
+                    ("url-3.0", Version("3.0")),
+                    ("url-2.0", Version("2.0")),
+                    ("url-1.0", Version("1.0")),
+                ],
+            ),
+            patch.object(bt, "_find_cached_wheel", side_effect=mock_cache),
+        ):
+            result = bt._phase_resolve(item)
+
+        assert len(result) == 2
+        versions = {str(it.resolved_version) for it in result}
+        assert versions == {"1.0", "3.0"}
+
+    def test_all_cached_keeps_highest_version(self, tmp_context: WorkContext) -> None:
+        """If all versions are cached, keeps the highest for dependency discovery."""
+        bt = bootstrapper.Bootstrapper(tmp_context, multiple_versions=True)
+        item = _make_resolve_item()
+
+        with (
+            patch.object(
+                bt,
+                "resolve_versions",
+                return_value=[
+                    ("url-3.0", Version("3.0")),
+                    ("url-2.0", Version("2.0")),
+                    ("url-1.0", Version("1.0")),
+                ],
+            ),
+            patch.object(
+                bt,
+                "_find_cached_wheel",
+                return_value=(tmp_context.work_dir / "cached.whl", None),
+            ),
+        ):
+            result = bt._phase_resolve(item)
+
+        assert len(result) == 1
+        assert result[0].resolved_version == Version("3.0")
+
+    def test_no_filtering_in_single_version_mode(
+        self, tmp_context: WorkContext
+    ) -> None:
+        """Cache filtering does not apply in single version mode."""
+        bt = bootstrapper.Bootstrapper(tmp_context, multiple_versions=False)
+        item = _make_resolve_item()
+
+        with (
+            patch.object(
+                bt,
+                "resolve_versions",
+                return_value=[("url-1.0", Version("1.0"))],
+            ),
+            patch.object(bt, "_find_cached_wheel") as mock_cache,
+        ):
+            result = bt._phase_resolve(item)
+
+        assert len(result) == 1
+        mock_cache.assert_not_called()
+
 
 class TestPhaseStart:
     def test_new_item_advances_to_prepare_source(


### PR DESCRIPTION


In the RESOLVE phase, check the wheel cache before creating work items for each resolved version. Versions with a cached wheel are filtered out entirely, avoiding all downstream phases and transitive dependency processing. Only applies in --multiple-versions mode.

Fixes: https://github.com/python-wheel-build/fromager/issues/1038