### PR TITLE
fix(resolver): bypass cooldown for transitive deps when top-level pin exists

### DIFF
--- a/src/fromager/resolver.py
+++ b/src/fromager/resolver.py
@@ -167,6 +167,17 @@ def resolve_package_cooldown(
             logger.info("cooldown bypassed as the top-level requirement uses == pin")
         return None
 
+    if req_type != RequirementType.TOP_LEVEL:
+        root = ctx.dependency_graph.get_root_node()
+        top_level_edges = root.get_outgoing_edges(req.name, RequirementType.TOP_LEVEL)
+        if any(_has_equality_pin(edge.req) for edge in top_level_edges):
+            if ctx.cooldown is not None:
+                logger.info(
+                    "cooldown bypassed — package has a top-level == pin "
+                    "in the dependency graph"
+                )
+            return None
+
     per_package_days = ctx.package_build_info(req).resolver_min_release_age
     global_cooldown = ctx.cooldown
     if per_package_days is None:

--- a/tests/test_cooldown.py
+++ b/tests/test_cooldown.py
@@ -941,3 +941,75 @@ def test_resolve_package_cooldown_toplevel_compound_specifier_not_exempt(
         ctx, Requirement("test-pkg==1.0,>0.9"), req_type=RequirementType.TOP_LEVEL
     )
     assert result is _COOLDOWN
+
+
+def test_transitive_dep_bypasses_cooldown_when_toplevel_pin_exists(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Transitive dep should bypass cooldown when the same package has a top-level exact pin.
+
+    If a requirements file pins test-pkg==2.0.0 (top-level) and another
+    top-level package depends on test-pkg>=1.0 (transitive), cooldown should
+    not block version 2.0.0 for the transitive resolution — the user already
+    explicitly approved that version via the pin.
+    """
+    ctx = _make_ctx(tmp_path, cooldown=_COOLDOWN)
+
+    # Simulate: test-pkg==2.0.0 was already resolved as a top-level pin
+    ctx.dependency_graph.add_dependency(
+        parent_name=None,
+        parent_version=None,
+        req_type=RequirementType.TOP_LEVEL,
+        req=Requirement("test-pkg==2.0.0"),
+        req_version=Version("2.0.0"),
+        download_url="https://files.pythonhosted.org/packages/test_pkg-2.0.0-py3-none-any.whl",
+        pre_built=False,
+    )
+
+    # Transitive resolution of the same package should bypass cooldown
+    result = resolver.resolve_package_cooldown(
+        ctx, Requirement("test-pkg>=1.0"), req_type=RequirementType.INSTALL
+    )
+    assert result is None
+
+
+def test_transitive_dep_resolves_to_toplevel_pinned_version(
+    tmp_path: pathlib.Path,
+) -> None:
+    """End-to-end: transitive dep selects the top-level pinned version, not an older one.
+
+    With cooldown active, test-pkg 2.0.0 (2 days old) is within the cooldown
+    window. A top-level pin test-pkg==2.0.0 bypasses cooldown. When the same
+    package appears as a transitive dependency (test-pkg>=1.0), it should
+    resolve to 2.0.0 — not fall back to 1.3.2.
+    """
+    ctx = _make_ctx(tmp_path, cooldown=_COOLDOWN)
+
+    # Simulate: test-pkg==2.0.0 was already resolved as a top-level pin
+    ctx.dependency_graph.add_dependency(
+        parent_name=None,
+        parent_version=None,
+        req_type=RequirementType.TOP_LEVEL,
+        req=Requirement("test-pkg==2.0.0"),
+        req_version=Version("2.0.0"),
+        download_url="https://files.pythonhosted.org/packages/test_pkg-2.0.0-py3-none-any.whl",
+        pre_built=False,
+    )
+
+    with requests_mock.Mocker() as r:
+        r.get(
+            "https://pypi.org/simple/test-pkg/",
+            json=_cooldown_json_response,
+            headers={"Content-Type": _PYPI_SIMPLE_JSON_CONTENT_TYPE},
+        )
+
+        # Transitive resolution should select 2.0.0, not 1.3.2
+        _, version = resolver.resolve(
+            ctx=ctx,
+            req=Requirement("test-pkg>=1.0"),
+            sdist_server_url="https://pypi.org/simple/",
+            include_sdists=True,
+            include_wheels=True,
+            req_type=RequirementType.INSTALL,
+        )
+        assert str(version) == "2.0.0"


### PR DESCRIPTION
When a package is both a top-level exact-pinned requirement (e.g., `foo==1.0`) and a transitive dependency of another package (e.g., `bar` depends on `foo>=0.9`), the cooldown check was blocking the transitive resolution even though the user explicitly approved that version via the pin. This could cause version downgrades or resolution failures.

`resolve_package_cooldown()` now checks the dependency graph for an existing top-level exact pin before enforcing cooldown on transitive dependencies.

Closes: #1153

- [x] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
