### PR TITLE
docs: add structured bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,33 @@
+name: Bug Report
+description: Report a bug in fromager
+labels: ["bug"]
+title: "[Bug]: "
+body:
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Details about your build environment.
+      value: |
+        - Fromager version:
+        - Python version:
+        - OS / architecture:
+        - Container or local:
+    validations:
+      required: true
+
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug description
+      description: Describe the bug you encountered.
+      value: |
+        **Expected behavior:**
+
+
+        **Actual behavior:**
+
+
+        **Steps to reproduce / logs:**
+    validations:
+      required: true


### PR DESCRIPTION
## What

Adds `.github/ISSUE_TEMPLATE/bug_report.yml` — a structured bug report form with two required sections:

- **Environment** — prefilled with Fromager version, Python version, OS/arch, container/local
- **Bug description** — prefilled prompts for expected behavior, actual behavior, and logs

Auto-applies the `bug` label and sets a `[Bug]:` title prefix.

## Why

Closes #967 — freeform bug reports often miss critical details needed to reproduce failures.

- [x] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines