### PR TITLE
refactor(resolver): move age filter fallback to resolver with cache server lookup

### DIFF
--- a/src/fromager/bootstrap_requirement_resolver.py
+++ b/src/fromager/bootstrap_requirement_resolver.py
@@ -12,7 +12,7 @@ import typing
 from packaging.requirements import Requirement
 from packaging.version import Version
 
-from . import resolver, sources, wheels
+from . import finders, resolver, sources, wheels
 from .dependency_graph import DependencyGraph
 from .requirements_file import RequirementType
 
@@ -40,15 +40,25 @@ class BootstrapRequirementResolver:
         self,
         ctx: context.WorkContext,
         prev_graph: DependencyGraph | None = None,
+        multiple_versions: bool = False,
+        cache_wheel_server_url: str = "",
     ) -> None:
         """Initialize requirement resolver.
 
         Args:
             ctx: Work context with constraints and settings
             prev_graph: Optional previous dependency graph for caching
+            multiple_versions: If ``True`` and no results are found through
+                any other approach, takes the latest candidate from the
+                cache server, ignoring the age filters.  In all other
+                cases, returns an empty list when no candidates are found.
+            cache_wheel_server_url: URL of the remote wheel cache server.
+                Used as a fallback when age filtering produces no candidates.
         """
         self.ctx = ctx
         self.prev_graph = prev_graph
+        self.multiple_versions = multiple_versions
+        self.cache_wheel_server_url = cache_wheel_server_url
         # Session-level resolution cache to avoid re-resolving same requirements
         # Key: (requirement_string, pre_built) to distinguish source vs prebuilt
         # Value: tuple of (url, version) tuples sorted by version (highest first)
@@ -72,6 +82,8 @@ class BootstrapRequirementResolver:
         1. Session cache (if previously resolved)
         2. Previous dependency graph
         3. PyPI resolution (source or prebuilt based on package build info)
+        4. Remote wheel cache server (multi-version mode only, when age
+           filtering produced no candidates)
 
         Args:
             req: Package requirement
@@ -110,36 +122,7 @@ class BootstrapRequirementResolver:
             logger.debug(f"resolved {req} from cache")
             return list(cached_result) if return_all_versions else [cached_result[0]]
 
-        # Resolve using strategies
-        results = self._resolve(req, req_type, parent_req, pre_built)
-
-        # Cache the result
-        self.cache_resolution(req, pre_built, results)
-        return results if return_all_versions else [results[0]]
-
-    def _resolve(
-        self,
-        req: Requirement,
-        req_type: RequirementType,
-        parent_req: Requirement | None,
-        pre_built: bool,
-    ) -> list[tuple[str, Version]]:
-        """Internal resolution logic without caching.
-
-        Tries resolution strategies in order:
-        1. Previous dependency graph
-        2. PyPI resolution (source or prebuilt)
-
-        Args:
-            req: Package requirement
-            req_type: Type of requirement
-            parent_req: Parent requirement from dependency chain
-            pre_built: Whether to resolve prebuilt (True) or source (False)
-
-        Returns:
-            List of (url, version) tuples sorted by version (highest first)
-        """
-        # Try graph
+        # Try previous dependency graph
         cached_resolution = self._resolve_from_graph(
             req=req,
             req_type=req_type,
@@ -151,17 +134,13 @@ class BootstrapRequirementResolver:
             logger.debug(
                 f"resolved from previous bootstrap: {len(cached_resolution)} version(s)"
             )
-            return cached_resolution
-
-        # Fallback to PyPI using provider pattern
-        if pre_built:
+            results = cached_resolution
+        elif pre_built:
             # Resolve prebuilt wheel
-            # Get wheel server URLs (use PyPI as cache/fallback server)
             wheel_server_urls = wheels.get_wheel_server_urls(
                 self.ctx, req, cache_wheel_server_url=resolver.PYPI_SERVER_URL
             )
-            # Use shared retry loop logic from wheels module
-            return wheels.resolve_all_prebuilt_wheels(
+            results = wheels.resolve_all_prebuilt_wheels(
                 ctx=self.ctx,
                 req=req,
                 wheel_server_urls=wheel_server_urls,
@@ -176,9 +155,75 @@ class BootstrapRequirementResolver:
                 req_type=req_type,
             )
             max_age_cutoff = resolver._compute_max_age_cutoff(self.ctx)
-            return resolver.find_all_matching_from_provider(
-                provider, req, max_age_cutoff=max_age_cutoff
+            results = resolver.find_all_matching_from_provider(
+                provider,
+                req,
+                max_age_cutoff=max_age_cutoff,
+                fallback_on_empty_age_filter=not self.multiple_versions,
             )
+
+            if not results and self.multiple_versions and self.cache_wheel_server_url:
+                logger.info(
+                    "no results found with normal resolution, "
+                    "falling back to the cache server %s",
+                    self.cache_wheel_server_url,
+                )
+                results = self._resolve_from_cache_server(req)
+
+            if not results:
+                logger.warning(
+                    "resolver returned no results "
+                    "(wheel server URL %s, %s version mode)",
+                    self.cache_wheel_server_url or "(none)",
+                    "multiple" if self.multiple_versions else "single",
+                )
+
+        # Only cache non-empty results.
+        if results:
+            self.cache_resolution(req, pre_built, results)
+
+        if not results:
+            return []
+        if return_all_versions:
+            return results
+        return [results[0]]
+
+    def _resolve_from_cache_server(self, req: Requirement) -> list[tuple[str, Version]]:
+        """Fall back to the remote wheel cache server for a cached version.
+
+        When age filtering removes all candidates in multi-version mode,
+        queries the remote cache server for the newest available wheel.
+        Returns at most one version so that transitive dependencies are
+        re-processed without rebuilding every old version.
+        """
+        logger.info(
+            "checking cache server %s for existing build",
+            self.cache_wheel_server_url,
+        )
+        best: tuple[str, Version] | None = None
+        for include_sdists, include_wheels in [(False, True), (True, False)]:
+            try:
+                provider = finders.PyPICacheProvider(
+                    cache_server_url=self.cache_wheel_server_url,
+                    constraints=self.ctx.constraints,
+                    include_sdists=include_sdists,
+                    include_wheels=include_wheels,
+                )
+                results = resolver.find_all_matching_from_provider(provider, req)
+                if results:
+                    url, version = results[0]
+                    if best is None or version > best[1]:
+                        best = (url, version)
+            except Exception as err:
+                logger.warning(
+                    "error checking cache server %s: %s",
+                    self.cache_wheel_server_url,
+                    err,
+                )
+        if best is not None:
+            logger.info("found version %s on cache server", best[1])
+            return [best]
+        return []
 
     def get_cached_resolution(
         self,

--- a/src/fromager/bootstrapper.py
+++ b/src/fromager/bootstrapper.py
@@ -173,6 +173,8 @@ class Bootstrapper:
         self._resolver = bootstrap_requirement_resolver.BootstrapRequirementResolver(
             ctx=ctx,
             prev_graph=prev_graph,
+            multiple_versions=multiple_versions,
+            cache_wheel_server_url=self.cache_wheel_server_url,
         )
         # Push items onto the stack as we start to resolve their
         # dependencies so at the end we have a list of items that need to

--- a/src/fromager/resolver.py
+++ b/src/fromager/resolver.py
@@ -243,6 +243,7 @@ def find_all_matching_from_provider(
     provider: BaseProvider,
     req: Requirement,
     max_age_cutoff: datetime.datetime | None = None,
+    fallback_on_empty_age_filter: bool = True,
 ) -> list[tuple[str, Version]]:
     """Find all matching candidates from provider without full dependency resolution.
 
@@ -255,6 +256,10 @@ def find_all_matching_from_provider(
         max_age_cutoff: If set, reject candidates published before this time.
             If all candidates are older than the cutoff, all are kept and
             a warning is emitted to avoid empty resolution.
+        fallback_on_empty_age_filter: If ``True`` (default), keep all
+            candidates when age filtering would produce an empty result.
+            If ``False``, return an empty list instead, allowing the
+            caller to implement its own fallback strategy.
 
     Returns list of (url, version) tuples sorted by version (highest first).
 
@@ -315,7 +320,7 @@ def find_all_matching_from_provider(
             )
         if filtered:
             candidates_list = filtered
-        else:
+        elif fallback_on_empty_age_filter:
             logger.warning(
                 "%s: all %d candidate(s) of %s are older than %d days, "
                 "keeping all to avoid empty resolution",
@@ -324,6 +329,15 @@ def find_all_matching_from_provider(
                 req,
                 max_age_days,
             )
+        else:
+            logger.info(
+                "%s: all %d candidate(s) of %s are older than %d days",
+                req.name,
+                len(candidates_list),
+                req,
+                max_age_days,
+            )
+            candidates_list = []
 
     # Convert candidates to list of (url, version) tuples
     # Candidates are sorted by version (highest first) by BaseProvider.find_matches()

--- a/tests/test_bootstrap_requirement_resolver.py
+++ b/tests/test_bootstrap_requirement_resolver.py
@@ -694,3 +694,172 @@ def test_resolve_prebuilt_after_source_uses_separate_cache(
     url2, version2 = results2[0]
     assert url2 == "https://files.pythonhosted.org/testpkg-1.5-py3-none-any.whl"
     assert version2 == Version("1.5")
+
+
+class TestResolveFromCacheServer:
+    """Tests for the cache server fallback in _resolve_from_cache_server."""
+
+    def test_returns_newest_version_from_cache(self, tmp_context: WorkContext) -> None:
+        """Falls back to cache server and returns only the newest version."""
+        brr = BootstrapRequirementResolver(
+            tmp_context,
+            multiple_versions=True,
+            cache_wheel_server_url="http://cache.test/simple",
+        )
+        req = Requirement("testpkg")
+
+        with patch(
+            "fromager.bootstrap_requirement_resolver.resolver"
+            ".find_all_matching_from_provider",
+            return_value=[
+                ("http://cache.test/testpkg-3.0.whl", Version("3.0")),
+                ("http://cache.test/testpkg-2.0.whl", Version("2.0")),
+            ],
+        ):
+            result = brr._resolve_from_cache_server(req)
+
+        assert len(result) == 1
+        assert result[0][1] == Version("3.0")
+
+    def test_returns_empty_when_cache_has_no_match(
+        self, tmp_context: WorkContext
+    ) -> None:
+        """Returns empty list when cache server has nothing."""
+        brr = BootstrapRequirementResolver(
+            tmp_context,
+            multiple_versions=True,
+            cache_wheel_server_url="http://cache.test/simple",
+        )
+        req = Requirement("testpkg")
+
+        with patch(
+            "fromager.bootstrap_requirement_resolver.resolver"
+            ".find_all_matching_from_provider",
+            return_value=[],
+        ):
+            result = brr._resolve_from_cache_server(req)
+
+        assert result == []
+
+    def test_returns_empty_on_exception(self, tmp_context: WorkContext) -> None:
+        """Returns empty list when cache server query fails."""
+        brr = BootstrapRequirementResolver(
+            tmp_context,
+            multiple_versions=True,
+            cache_wheel_server_url="http://cache.test/simple",
+        )
+        req = Requirement("testpkg")
+
+        with patch(
+            "fromager.bootstrap_requirement_resolver.resolver"
+            ".find_all_matching_from_provider",
+            side_effect=RuntimeError("connection refused"),
+        ):
+            result = brr._resolve_from_cache_server(req)
+
+        assert result == []
+
+    def test_resolve_uses_cache_fallback_when_age_filter_empties(
+        self, tmp_context: WorkContext
+    ) -> None:
+        """resolve() falls back to cache server when age filter produces empty result."""
+        brr = BootstrapRequirementResolver(
+            tmp_context,
+            multiple_versions=True,
+            cache_wheel_server_url="http://cache.test/simple",
+        )
+        req = Requirement("testpkg")
+
+        with (
+            patch.object(brr, "_resolve_from_graph", return_value=None),
+            patch(
+                "fromager.bootstrap_requirement_resolver.sources.get_source_provider",
+            ),
+            patch(
+                "fromager.bootstrap_requirement_resolver.resolver"
+                ".find_all_matching_from_provider",
+                return_value=[],
+            ) as mock_pypi,
+            patch.object(
+                brr,
+                "_resolve_from_cache_server",
+                return_value=[("http://cache.test/testpkg-1.0.whl", Version("1.0"))],
+            ) as mock_cache,
+        ):
+            result = brr.resolve(
+                req,
+                RequirementType.INSTALL,
+                parent_req=None,
+                pre_built=False,
+                return_all_versions=True,
+            )
+
+        mock_pypi.assert_called_once()
+        mock_cache.assert_called_once_with(req)
+        assert len(result) == 1
+        assert result[0][1] == Version("1.0")
+
+    def test_resolve_skips_cache_fallback_in_single_version_mode(
+        self, tmp_context: WorkContext
+    ) -> None:
+        """resolve() does not fall back to cache server in single-version mode."""
+        brr = BootstrapRequirementResolver(
+            tmp_context,
+            multiple_versions=False,
+            cache_wheel_server_url="http://cache.test/simple",
+        )
+        req = Requirement("testpkg")
+
+        with (
+            patch.object(brr, "_resolve_from_graph", return_value=None),
+            patch(
+                "fromager.bootstrap_requirement_resolver.sources.get_source_provider",
+            ),
+            patch(
+                "fromager.bootstrap_requirement_resolver.resolver"
+                ".find_all_matching_from_provider",
+                return_value=[("url", Version("1.0"))],
+            ),
+            patch.object(brr, "_resolve_from_cache_server") as mock_cache,
+        ):
+            brr.resolve(
+                req,
+                RequirementType.INSTALL,
+                parent_req=None,
+                pre_built=False,
+            )
+
+        mock_cache.assert_not_called()
+
+    def test_resolve_skips_cache_fallback_when_no_server_url(
+        self, tmp_context: WorkContext
+    ) -> None:
+        """resolve() does not fall back when no cache_wheel_server_url is set."""
+        brr = BootstrapRequirementResolver(
+            tmp_context,
+            multiple_versions=True,
+            cache_wheel_server_url="",
+        )
+        req = Requirement("testpkg")
+
+        with (
+            patch.object(brr, "_resolve_from_graph", return_value=None),
+            patch(
+                "fromager.bootstrap_requirement_resolver.sources.get_source_provider",
+            ),
+            patch(
+                "fromager.bootstrap_requirement_resolver.resolver"
+                ".find_all_matching_from_provider",
+                return_value=[],
+            ),
+            patch.object(brr, "_resolve_from_cache_server") as mock_cache,
+        ):
+            brr.resolve(
+                req,
+                RequirementType.INSTALL,
+                parent_req=None,
+                pre_built=False,
+                return_all_versions=True,
+            )
+
+        mock_cache.assert_not_called()

--- a/tests/test_bootstrap_requirement_resolver_multiple.py
+++ b/tests/test_bootstrap_requirement_resolver_multiple.py
@@ -30,83 +30,93 @@ def tmp_context(tmp_path: Path) -> WorkContext:
     pbi.resolver_ignore_platform = False
     pbi.resolver_sdist_server_url.return_value = "https://pypi.org/simple/"
     ctx.package_build_info.return_value = pbi
+    ctx.max_release_age = None
     return ctx
+
+
+_MOCK_VERSIONS = [
+    ("https://pypi.org/testpkg-2.0.tar.gz", Version("2.0")),
+    ("https://pypi.org/testpkg-1.5.tar.gz", Version("1.5")),
+    ("https://pypi.org/testpkg-1.0.tar.gz", Version("1.0")),
+]
 
 
 def test_resolve_return_all_versions_true(tmp_context: WorkContext) -> None:
     """resolve() with return_all_versions=True returns all matching versions."""
-    resolver = BootstrapRequirementResolver(tmp_context)
+    brr = BootstrapRequirementResolver(tmp_context)
 
-    # Mock the _resolve method to return multiple versions
-    with patch.object(
-        resolver,
-        "_resolve",
-        return_value=[
-            ("https://pypi.org/testpkg-2.0.tar.gz", Version("2.0")),
-            ("https://pypi.org/testpkg-1.5.tar.gz", Version("1.5")),
-            ("https://pypi.org/testpkg-1.0.tar.gz", Version("1.0")),
-        ],
+    with (
+        patch.object(brr, "_resolve_from_graph", return_value=None),
+        patch(
+            "fromager.bootstrap_requirement_resolver.sources.get_source_provider",
+        ),
+        patch(
+            "fromager.bootstrap_requirement_resolver.resolver"
+            ".find_all_matching_from_provider",
+            return_value=list(_MOCK_VERSIONS),
+        ),
     ):
         req = Requirement("testpkg>=1.0")
-        results = resolver.resolve(
+        results = brr.resolve(
             req=req,
             req_type=RequirementType.INSTALL,
             parent_req=None,
             return_all_versions=True,
         )
 
-        # Should return all 3 versions
         assert len(results) == 3
-        assert results[0] == ("https://pypi.org/testpkg-2.0.tar.gz", Version("2.0"))
-        assert results[1] == ("https://pypi.org/testpkg-1.5.tar.gz", Version("1.5"))
-        assert results[2] == ("https://pypi.org/testpkg-1.0.tar.gz", Version("1.0"))
+        assert results[0] == _MOCK_VERSIONS[0]
+        assert results[1] == _MOCK_VERSIONS[1]
+        assert results[2] == _MOCK_VERSIONS[2]
 
 
 def test_resolve_return_all_versions_false_default(tmp_context: WorkContext) -> None:
     """resolve() with return_all_versions=False (default) returns list with only highest version."""
-    resolver = BootstrapRequirementResolver(tmp_context)
+    brr = BootstrapRequirementResolver(tmp_context)
 
-    # Mock the _resolve method to return multiple versions
-    with patch.object(
-        resolver,
-        "_resolve",
-        return_value=[
-            ("https://pypi.org/testpkg-2.0.tar.gz", Version("2.0")),
-            ("https://pypi.org/testpkg-1.5.tar.gz", Version("1.5")),
-            ("https://pypi.org/testpkg-1.0.tar.gz", Version("1.0")),
-        ],
+    with (
+        patch.object(brr, "_resolve_from_graph", return_value=None),
+        patch(
+            "fromager.bootstrap_requirement_resolver.sources.get_source_provider",
+        ),
+        patch(
+            "fromager.bootstrap_requirement_resolver.resolver"
+            ".find_all_matching_from_provider",
+            return_value=list(_MOCK_VERSIONS),
+        ),
     ):
         req = Requirement("testpkg>=1.0")
-
-        # Call without return_all_versions (default False)
-        results = resolver.resolve(
+        results = brr.resolve(
             req=req,
             req_type=RequirementType.INSTALL,
             parent_req=None,
         )
 
-        # Should return list with only the highest version
         assert len(results) == 1
-        assert results[0] == ("https://pypi.org/testpkg-2.0.tar.gz", Version("2.0"))
+        assert results[0] == _MOCK_VERSIONS[0]
 
 
 def test_resolve_return_all_versions_uses_cache(tmp_context: WorkContext) -> None:
     """resolve() with return_all_versions=True uses cache correctly."""
-    resolver = BootstrapRequirementResolver(tmp_context)
+    brr = BootstrapRequirementResolver(tmp_context)
 
-    # First call - will populate cache
-    with patch.object(
-        resolver,
-        "_resolve",
-        return_value=[
-            ("https://pypi.org/testpkg-2.0.tar.gz", Version("2.0")),
-            ("https://pypi.org/testpkg-1.0.tar.gz", Version("1.0")),
-        ],
-    ) as mock_resolve:
+    with (
+        patch.object(brr, "_resolve_from_graph", return_value=None),
+        patch(
+            "fromager.bootstrap_requirement_resolver.sources.get_source_provider",
+        ),
+        patch(
+            "fromager.bootstrap_requirement_resolver.resolver"
+            ".find_all_matching_from_provider",
+            return_value=[
+                ("https://pypi.org/testpkg-2.0.tar.gz", Version("2.0")),
+                ("https://pypi.org/testpkg-1.0.tar.gz", Version("1.0")),
+            ],
+        ) as mock_resolve,
+    ):
         req = Requirement("testpkg>=1.0")
 
-        # First call
-        results1 = resolver.resolve(
+        results1 = brr.resolve(
             req=req,
             req_type=RequirementType.INSTALL,
             parent_req=None,
@@ -115,17 +125,15 @@ def test_resolve_return_all_versions_uses_cache(tmp_context: WorkContext) -> Non
         assert len(results1) == 2
         assert mock_resolve.call_count == 1
 
-        # Second call - should use cache
-        results2 = resolver.resolve(
+        results2 = brr.resolve(
             req=req,
             req_type=RequirementType.INSTALL,
             parent_req=None,
             return_all_versions=True,
         )
 
-        # Should not call _resolve again
+        # Should not call resolution again — cache hit
         assert mock_resolve.call_count == 1
-        # Should return same results
         assert results2 == results1
 
 
@@ -133,7 +141,6 @@ def test_resolve_return_all_versions_with_previous_graph(
     tmp_context: WorkContext,
 ) -> None:
     """resolve() with return_all_versions=True works with previous graph."""
-    # Create graph with multiple versions of the same package
     prev_graph = DependencyGraph()
     prev_graph.add_dependency(
         parent_name=None,
@@ -150,23 +157,19 @@ def test_resolve_return_all_versions_with_previous_graph(
         req_version=Version("1.0"),
     )
 
-    # Mock dependency_graph in context
     tmp_context.dependency_graph = prev_graph
 
-    resolver = BootstrapRequirementResolver(tmp_context, prev_graph)
+    brr = BootstrapRequirementResolver(tmp_context, prev_graph)
 
-    # Request with version spec that matches both
     req = Requirement("testpkg>=1.0")
-    results = resolver.resolve(
+    results = brr.resolve(
         req=req,
         req_type=RequirementType.TOP_LEVEL,
         parent_req=None,
         return_all_versions=True,
     )
 
-    # Should return both versions from graph
     assert len(results) == 2
-    # Verify versions (should be sorted highest first)
     versions = [v for _, v in results]
     assert Version("2.0") in versions
     assert Version("1.0") in versions

--- a/tests/test_bootstrapper_iterative.py
+++ b/tests/test_bootstrapper_iterative.py
@@ -353,6 +353,20 @@ class TestPhaseResolve:
         assert len(result) == 1
         mock_cache.assert_not_called()
 
+    def test_empty_resolution_raises_runtime_error(
+        self, tmp_context: WorkContext
+    ) -> None:
+        """Empty resolution raises RuntimeError regardless of mode."""
+        for multi in (False, True):
+            bt = bootstrapper.Bootstrapper(tmp_context, multiple_versions=multi)
+            item = _make_resolve_item()
+
+            with (
+                patch.object(bt, "resolve_versions", return_value=[]),
+                pytest.raises(RuntimeError, match="Could not resolve"),
+            ):
+                bt._phase_resolve(item)
+
 
 class TestPhaseStart:
     def test_new_item_advances_to_prepare_source(

--- a/tests/test_cooldown.py
+++ b/tests/test_cooldown.py
@@ -796,6 +796,30 @@ def test_max_release_age_all_too_old_keeps_all(
     assert "keeping all to avoid empty resolution" in caplog.text
 
 
+def test_max_release_age_all_too_old_returns_empty_when_fallback_disabled(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When fallback is disabled and all versions are too old, return empty list."""
+    max_age_cutoff = _BOOTSTRAP_TIME + datetime.timedelta(days=1)
+    with requests_mock.Mocker() as r:
+        r.get(
+            "https://pypi.org/simple/test-pkg/",
+            json=_cooldown_json_response,
+            headers={"Content-Type": _PYPI_SIMPLE_JSON_CONTENT_TYPE},
+        )
+        provider = resolver.PyPIProvider(include_sdists=True)
+        with caplog.at_level(logging.INFO, logger="fromager.resolver"):
+            results = resolver.find_all_matching_from_provider(
+                provider,
+                Requirement("test-pkg"),
+                max_age_cutoff=max_age_cutoff,
+                fallback_on_empty_age_filter=False,
+            )
+    assert results == []
+    assert "all 3 candidate(s)" in caplog.text
+    assert "keeping all to avoid empty resolution" not in caplog.text
+
+
 def test_max_release_age_candidates_without_upload_time_pass_through() -> None:
     """Candidates without upload_time are not filtered out by max-release-age."""
     no_timestamp_response = {


### PR DESCRIPTION

Move the two-step fallback logic from `_phase_resolve()` into
`BootstrapRequirementResolver._resolve()`. When age filtering removes
all candidates in multi-version mode, the resolver now queries the
remote wheel cache server for the newest available version and returns
only that single version. The resolver warns on zero results but does
not error — `_phase_resolve()` raises the exception.

Co-Authored-By: Claude <claude@anthropic.com>

Signed-off-by: Rohan Devasthale <rdevasth@redhat.com>

Fixes: https://github.com/python-wheel-build/fromager/issues/1162

