### PR TITLE
feat(sdist): add helpers to normalize git clones and tarballs into va…

### DIFF
--- a/src/fromager/sdist.py
+++ b/src/fromager/sdist.py
@@ -1,0 +1,157 @@
+"""Helpers to normalize arbitrary source directories into valid sdist layout.
+
+Git clones and non-standard tarballs (e.g. GitHub release assets) lack the
+``PKG-INFO`` file and standardized directory naming that PEP 517 build
+backends expect.  These helpers bridge that gap *before* the build backend
+is available -- only the package name and version are required.
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+import shutil
+import tarfile
+
+from packaging.version import Version
+
+from . import dependencies, overrides, tarballs
+
+logger = logging.getLogger(__name__)
+
+PKG_INFO_TEMPLATE = """\
+Metadata-Version: 2.2
+Name: {name}
+Version: {version}
+Summary: {summary}
+"""
+
+
+def _write_pkg_info(
+    directory: pathlib.Path,
+    name: str,
+    version: Version,
+) -> pathlib.Path:
+    """Write a stub ``PKG-INFO`` into *directory* if one does not exist.
+
+    Returns the path to the ``PKG-INFO`` file.
+    """
+    pkg_info_file = directory / "PKG-INFO"
+    if not pkg_info_file.is_file():
+        logger.info("writing stub PKG-INFO in %s", directory)
+        pkg_info_file.write_text(
+            PKG_INFO_TEMPLATE.format(
+                name=name,
+                version=str(version),
+                summary=dependencies.STUB_PKG_INFO_SUMMARY,
+            )
+        )
+    return pkg_info_file
+
+
+def make_sdist_directory(
+    source_dir: pathlib.Path,
+    name: str,
+    version: Version,
+    *,
+    build_dir: pathlib.Path | None = None,
+) -> pathlib.Path:
+    """Normalize *source_dir* into a valid sdist directory layout.
+
+    The directory is renamed to ``{normalized_name}-{version}`` (using
+    :func:`~fromager.overrides.pkgname_to_override_module`) and a stub
+    ``PKG-INFO`` is written if missing.  When *build_dir* differs from
+    the source root a second ``PKG-INFO`` is placed there for
+    ``setuptools-scm`` compatibility.
+
+    Args:
+        source_dir: Path to the source directory (git clone or unpacked
+            tarball).
+        name: Distribution name (e.g. ``req.name``).
+        version: Package version.
+        build_dir: Optional non-standard build directory inside
+            *source_dir*.  Receives its own ``PKG-INFO`` copy.
+
+    Returns:
+        Path to the (possibly renamed) source directory.
+    """
+    normalized_name = overrides.pkgname_to_override_module(name)
+    expected_name = f"{normalized_name}-{version}"
+
+    if source_dir.name != expected_name:
+        old_source_dir = source_dir
+        desired = source_dir.parent / expected_name
+        logger.info(
+            "renaming source directory %s -> %s",
+            source_dir.name,
+            expected_name,
+        )
+        try:
+            shutil.move(str(source_dir), str(desired))
+        except Exception as err:
+            raise RuntimeError(
+                f"Could not rename {source_dir} to {desired}: {err}"
+            ) from err
+        source_dir = desired
+
+        # Rebase build_dir so it tracks the renamed parent directory.
+        if build_dir is not None and build_dir.is_relative_to(old_source_dir):
+            build_dir = source_dir / build_dir.relative_to(old_source_dir)
+
+    _write_pkg_info(source_dir, name, version)
+
+    if build_dir is not None and build_dir != source_dir:
+        _write_pkg_info(build_dir, name, version)
+
+    return source_dir
+
+
+def repack_as_sdist(
+    source_dir: pathlib.Path,
+    name: str,
+    version: Version,
+    output_dir: pathlib.Path,
+    *,
+    build_dir: pathlib.Path | None = None,
+) -> pathlib.Path:
+    """Repack *source_dir* into a standards-compliant sdist tarball.
+
+    Calls :func:`make_sdist_directory` to normalize the layout first,
+    then creates a reproducible ``{name}-{version}.tar.gz`` in
+    *output_dir*.
+
+    Args:
+        source_dir: Path to the source directory.
+        name: Distribution name.
+        version: Package version.
+        output_dir: Directory where the tarball is written.
+        build_dir: Optional non-standard build subdirectory.  When set
+            the tarball is rooted at *build_dir* (matching
+            :func:`~fromager.sources.default_build_sdist` behavior).
+
+    Returns:
+        Path to the created ``.tar.gz`` file.
+    """
+    old_source_dir = source_dir
+    source_dir = make_sdist_directory(source_dir, name, version, build_dir=build_dir)
+
+    # Rebase build_dir after a potential rename inside make_sdist_directory.
+    if build_dir is not None and source_dir != old_source_dir:
+        build_dir = source_dir / build_dir.relative_to(old_source_dir)
+
+    tar_root = build_dir if build_dir is not None else source_dir
+    normalized_name = overrides.pkgname_to_override_module(name)
+    sdist_filename = output_dir / f"{normalized_name}-{version}.tar.gz"
+
+    if sdist_filename.exists():
+        sdist_filename.unlink()
+
+    with tarfile.open(sdist_filename, "x:gz", format=tarfile.PAX_FORMAT) as tar:
+        tarballs.tar_reproducible(
+            tar=tar,
+            basedir=tar_root,
+            prefix=tar_root.parent,
+        )
+
+    logger.info("created sdist archive %s", sdist_filename)
+    return sdist_filename

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -715,12 +715,15 @@ def default_build_sdist(
     is built from a repository checkout and error out when the PEP 517
     interface is used, so this function simply tars the tree back up.
     """
-    sdist.make_sdist_directory(
+    old_root = sdist_root_dir
+    sdist_root_dir = sdist.make_sdist_directory(
         sdist_root_dir,
         req.name,
         version,
         build_dir=build_dir,
     )
+    if sdist_root_dir != old_root and build_dir.is_relative_to(old_root):
+        build_dir = sdist_root_dir / build_dir.relative_to(old_root)
     sdist_filename = ctx.sdists_builds / f"{req.name}-{version}.tar.gz"
     if sdist_filename.exists():
         sdist_filename.unlink()

--- a/src/fromager/sources.py
+++ b/src/fromager/sources.py
@@ -29,6 +29,7 @@ from . import (
     packagesettings,
     pyproject,
     resolver,
+    sdist,
     tarballs,
     vendor_rust,
 )
@@ -540,6 +541,15 @@ def prepare_source(
             source_root_dir=source_root_dir,
             version=version,
         )
+        source_root_dir = sdist.make_sdist_directory(
+            source_root_dir,
+            req.name,
+            version,
+        )
+        pbi = ctx.package_build_info(req)
+        build_dir = pbi.build_dir(source_root_dir)
+        if build_dir != source_root_dir:
+            sdist._write_pkg_info(build_dir, req.name, version)
     else:
         logger.info(f"preparing source for {req} from {source_filename}")
         prepare_source_details = overrides.find_and_invoke(
@@ -698,31 +708,27 @@ def default_build_sdist(
     build_env: build_environment.BuildEnvironment,
     build_dir: pathlib.Path,
 ) -> pathlib.Path:
-    # It seems like the "correct" way to do this would be to run the
-    # PEP 517 API in the source tree we have modified. However, quite
-    # a few packages assume their source distribution is being built
-    # from a source code repository checkout and those throw an error
-    # when we use the interface to try to rebuild the sdist. Since we
-    # know what we have is an exploded tarball, we just tar it back
-    # up.
-    #
-    # For cases where the PEP 517 approach works, use
-    # pep517_build_sdist().
+    """Rebuild an sdist by re-tarring a previously unpacked source tree.
+
+    For cases where the PEP 517 approach works, use
+    :func:`pep517_build_sdist` instead.  Many packages assume the sdist
+    is built from a repository checkout and error out when the PEP 517
+    interface is used, so this function simply tars the tree back up.
+    """
+    sdist.make_sdist_directory(
+        sdist_root_dir,
+        req.name,
+        version,
+        build_dir=build_dir,
+    )
     sdist_filename = ctx.sdists_builds / f"{req.name}-{version}.tar.gz"
     if sdist_filename.exists():
         sdist_filename.unlink()
-    ensure_pkg_info(
-        ctx=ctx,
-        req=req,
-        version=version,
-        sdist_root_dir=sdist_root_dir,
-        build_dir=build_dir,
-    )
     # The format argument is specified based on
     # https://peps.python.org/pep-0517/#build-sdist.
-    with tarfile.open(sdist_filename, "x:gz", format=tarfile.PAX_FORMAT) as sdist:
+    with tarfile.open(sdist_filename, "x:gz", format=tarfile.PAX_FORMAT) as sdist_tar:
         tarballs.tar_reproducible(
-            tar=sdist,
+            tar=sdist_tar,
             basedir=build_dir,
             prefix=build_dir.parent,
         )
@@ -754,14 +760,6 @@ def pep517_build_sdist(
     return ctx.sdists_builds / sdist_filename
 
 
-PKG_INFO_CONTENT = """\
-Metadata-Version: 1.0
-Name: {name}
-Version: {version}
-Summary: {summary}
-"""
-
-
 def ensure_pkg_info(
     *,
     ctx: context.WorkContext,
@@ -772,11 +770,11 @@ def ensure_pkg_info(
 ) -> bool:
     """Ensure that sdist has a PKG-INFO file.
 
-    Returns True if PKG-INFO is present, False if file is missing. The
-    function also updates build_dir if package has a non-standard build
-    directory. Every sdist must have a PKG-INFO file in the first directory.
-    The additional PKG-INFO file in build_dir is required for projects
-    with a non-standard layout and projects using setuptools-scm.
+    Delegates to :func:`fromager.sdist._write_pkg_info` to create stub
+    files when missing.
+
+    Returns True if PKG-INFO was already present in all directories,
+    False if any file had to be created.
     """
     had_pkg_info = True
     directories = [sdist_root_dir]
@@ -788,13 +786,7 @@ def ensure_pkg_info(
             logger.warning(
                 f"PKG-INFO file is missing from {directory}, creating stub file"
             )
-            pkg_info_file.write_text(
-                PKG_INFO_CONTENT.format(
-                    name=req.name,
-                    version=str(version),
-                    summary=dependencies.STUB_PKG_INFO_SUMMARY,
-                )
-            )
+            sdist._write_pkg_info(directory, req.name, version)
             had_pkg_info = False
     return had_pkg_info
 

--- a/tests/test_sdist.py
+++ b/tests/test_sdist.py
@@ -1,0 +1,195 @@
+import pathlib
+import tarfile
+
+from packaging.version import Version
+
+from fromager import dependencies, sdist
+
+
+def test_make_sdist_directory_renames_and_adds_pkg_info(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Directory is renamed and PKG-INFO is created."""
+    # Arrange
+    src = tmp_path / "SomeProject"
+    src.mkdir()
+    (src / "setup.py").write_text("# placeholder")
+
+    # Act
+    result = sdist.make_sdist_directory(src, "Some-Project", Version("1.2.3"))
+
+    # Assert
+    assert result.name == "some_project-1.2.3"
+    assert result.exists()
+    pkg_info = result / "PKG-INFO"
+    assert pkg_info.is_file()
+    content = pkg_info.read_text()
+    assert "Metadata-Version: 2.2" in content
+    assert "Name: Some-Project" in content
+    assert "Version: 1.2.3" in content
+    assert dependencies.STUB_PKG_INFO_SUMMARY in content
+
+
+def test_make_sdist_directory_already_correct_name(
+    tmp_path: pathlib.Path,
+) -> None:
+    """No rename when directory already has the expected name."""
+    # Arrange
+    src = tmp_path / "my_pkg-0.1"
+    src.mkdir()
+
+    # Act
+    result = sdist.make_sdist_directory(src, "my-pkg", Version("0.1"))
+
+    # Assert
+    assert result == src
+    assert (result / "PKG-INFO").is_file()
+
+
+def test_make_sdist_directory_preserves_existing_pkg_info(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Existing PKG-INFO is not overwritten."""
+    # Arrange
+    src = tmp_path / "mypkg-2.0"
+    src.mkdir()
+    existing_content = "Metadata-Version: 2.1\nName: mypkg\nVersion: 2.0\n"
+    (src / "PKG-INFO").write_text(existing_content)
+
+    # Act
+    result = sdist.make_sdist_directory(src, "mypkg", Version("2.0"))
+
+    # Assert
+    assert (result / "PKG-INFO").read_text() == existing_content
+
+
+def test_make_sdist_directory_writes_build_dir_pkg_info(
+    tmp_path: pathlib.Path,
+) -> None:
+    """PKG-INFO is also written to build_dir when it differs from source root."""
+    # Arrange
+    src = tmp_path / "pkg-1.0"
+    src.mkdir()
+    build_dir = src / "src"
+    build_dir.mkdir()
+
+    # Act
+    result = sdist.make_sdist_directory(src, "pkg", Version("1.0"), build_dir=build_dir)
+
+    # Assert
+    assert (result / "PKG-INFO").is_file()
+    assert (build_dir / "PKG-INFO").is_file()
+
+
+def test_make_sdist_directory_skips_build_dir_when_same(
+    tmp_path: pathlib.Path,
+) -> None:
+    """When build_dir equals source_dir, only one PKG-INFO is written."""
+    # Arrange
+    src = tmp_path / "pkg-1.0"
+    src.mkdir()
+
+    # Act
+    result = sdist.make_sdist_directory(src, "pkg", Version("1.0"), build_dir=src)
+
+    # Assert
+    assert (result / "PKG-INFO").is_file()
+
+
+def test_make_sdist_directory_rebases_build_dir_after_rename(
+    tmp_path: pathlib.Path,
+) -> None:
+    """build_dir subdirectory is correctly rebased when source_dir is renamed."""
+    # Arrange
+    src = tmp_path / "MyPkg"
+    src.mkdir()
+    sub = src / "python"
+    sub.mkdir()
+    (sub / "lib.py").write_text("# code")
+
+    # Act
+    result = sdist.make_sdist_directory(src, "MyPkg", Version("1.0"), build_dir=sub)
+
+    # Assert
+    assert result.name == "mypkg-1.0"
+    expected_build = result / "python"
+    assert expected_build.is_dir()
+    assert (expected_build / "PKG-INFO").is_file()
+
+
+def test_repack_as_sdist_creates_tarball(tmp_path: pathlib.Path) -> None:
+    """Verify the archive is created with correct name and contents."""
+    # Arrange
+    src = tmp_path / "project"
+    src.mkdir()
+    (src / "setup.py").write_text("# placeholder")
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    # Act
+    result = sdist.repack_as_sdist(src, "project", Version("3.0"), output_dir)
+
+    # Assert
+    assert result.name == "project-3.0.tar.gz"
+    assert result.is_file()
+    with tarfile.open(result, "r:gz") as tf:
+        names = tf.getnames()
+    assert any("PKG-INFO" in n for n in names)
+    assert any("setup.py" in n for n in names)
+
+
+def test_repack_as_sdist_uses_build_dir(tmp_path: pathlib.Path) -> None:
+    """When build_dir is set, the tarball is rooted at build_dir."""
+    # Arrange
+    src = tmp_path / "mylib-1.0"
+    src.mkdir()
+    build_sub = src / "python"
+    build_sub.mkdir()
+    (build_sub / "lib.py").write_text("# code")
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    # Act
+    result = sdist.repack_as_sdist(
+        src, "mylib", Version("1.0"), output_dir, build_dir=build_sub
+    )
+
+    # Assert
+    assert result.is_file()
+    with tarfile.open(result, "r:gz") as tf:
+        names = tf.getnames()
+    assert any("lib.py" in n for n in names)
+
+
+def test_repack_as_sdist_normalizes_name(tmp_path: pathlib.Path) -> None:
+    """Package name is normalized in the archive filename."""
+    # Arrange
+    src = tmp_path / "My-Package"
+    src.mkdir()
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    # Act
+    result = sdist.repack_as_sdist(src, "My-Package", Version("0.1"), output_dir)
+
+    # Assert
+    assert result.name == "my_package-0.1.tar.gz"
+
+
+def test_repack_as_sdist_overwrites_existing(tmp_path: pathlib.Path) -> None:
+    """Pre-existing tarball with the same name is replaced."""
+    # Arrange
+    src = tmp_path / "pkg-1.0"
+    src.mkdir()
+    (src / "file.txt").write_text("content")
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    stale = output_dir / "pkg-1.0.tar.gz"
+    stale.write_text("stale")
+
+    # Act
+    result = sdist.repack_as_sdist(src, "pkg", Version("1.0"), output_dir)
+
+    # Assert
+    assert result.is_file()
+    assert result.read_bytes() != b"stale"

--- a/tests/test_sdist.py
+++ b/tests/test_sdist.py
@@ -1,9 +1,10 @@
 import pathlib
 import tarfile
+from unittest import mock
 
 from packaging.version import Version
 
-from fromager import dependencies, sdist
+from fromager import dependencies, sdist, sources
 
 
 def test_make_sdist_directory_renames_and_adds_pkg_info(
@@ -117,6 +118,66 @@ def test_make_sdist_directory_rebases_build_dir_after_rename(
     assert (expected_build / "PKG-INFO").is_file()
 
 
+def test_make_sdist_directory_deeply_nested_build_dir(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Deeply nested build_dir (e.g. src/bindings/python/nixl-meta) is rebased correctly."""
+    src = tmp_path / "NixlRepo"
+    nested = src / "src" / "bindings" / "python" / "nixl-meta"
+    nested.mkdir(parents=True)
+    (nested / "pyproject.toml").write_text("[build-system]")
+
+    result = sdist.make_sdist_directory(
+        src, "nixl", Version("0.5.0"), build_dir=nested
+    )
+
+    assert result.name == "nixl-0.5.0"
+    rebased = result / "src" / "bindings" / "python" / "nixl-meta"
+    assert rebased.is_dir()
+    assert (rebased / "PKG-INFO").is_file()
+    assert (rebased / "pyproject.toml").is_file()
+    assert (result / "PKG-INFO").is_file()
+
+
+def test_make_sdist_directory_build_dir_not_child_of_source(
+    tmp_path: pathlib.Path,
+) -> None:
+    """build_dir outside source_dir is left unchanged (no rebase, no PKG-INFO)."""
+    src = tmp_path / "project"
+    src.mkdir()
+    external_build = tmp_path / "other" / "build"
+    external_build.mkdir(parents=True)
+
+    result = sdist.make_sdist_directory(
+        src, "project", Version("1.0"), build_dir=external_build
+    )
+
+    assert result.name == "project-1.0"
+    assert (result / "PKG-INFO").is_file()
+    assert (external_build / "PKG-INFO").is_file()
+
+
+def test_make_sdist_directory_build_dir_outside_not_rebased_on_rename(
+    tmp_path: pathlib.Path,
+) -> None:
+    """build_dir outside source_dir is NOT rebased when source is renamed."""
+    src = tmp_path / "WrongName"
+    src.mkdir()
+    external_build = tmp_path / "separate-build"
+    external_build.mkdir()
+    (external_build / "code.py").write_text("# code")
+
+    result = sdist.make_sdist_directory(
+        src, "mypkg", Version("2.0"), build_dir=external_build
+    )
+
+    assert result.name == "mypkg-2.0"
+    # external_build should still be at its original location
+    assert external_build.is_dir()
+    assert (external_build / "PKG-INFO").is_file()
+    assert (external_build / "code.py").is_file()
+
+
 def test_repack_as_sdist_creates_tarball(tmp_path: pathlib.Path) -> None:
     """Verify the archive is created with correct name and contents."""
     # Arrange
@@ -176,6 +237,48 @@ def test_repack_as_sdist_normalizes_name(tmp_path: pathlib.Path) -> None:
     assert result.name == "my_package-0.1.tar.gz"
 
 
+def test_repack_as_sdist_build_dir_with_rename(tmp_path: pathlib.Path) -> None:
+    """repack_as_sdist correctly rebases build_dir when source is renamed."""
+    src = tmp_path / "MonoRepo"
+    sub = src / "python"
+    sub.mkdir(parents=True)
+    (sub / "setup.py").write_text("# setup")
+    (sub / "mylib.py").write_text("# lib")
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    result = sdist.repack_as_sdist(
+        src, "mylib", Version("1.0"), output_dir, build_dir=sub
+    )
+
+    assert result.name == "mylib-1.0.tar.gz"
+    assert result.is_file()
+    with tarfile.open(result, "r:gz") as tf:
+        names = tf.getnames()
+    assert any("mylib.py" in n for n in names)
+    assert any("PKG-INFO" in n for n in names)
+
+
+def test_repack_as_sdist_deeply_nested_build_dir(tmp_path: pathlib.Path) -> None:
+    """repack_as_sdist handles deeply nested build_dir with rename."""
+    src = tmp_path / "BigRepo"
+    nested = src / "clients" / "python"
+    nested.mkdir(parents=True)
+    (nested / "setup.cfg").write_text("[metadata]\nname = tacozip")
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    result = sdist.repack_as_sdist(
+        src, "tacozip", Version("0.12.0"), output_dir, build_dir=nested
+    )
+
+    assert result.name == "tacozip-0.12.0.tar.gz"
+    assert result.is_file()
+    with tarfile.open(result, "r:gz") as tf:
+        names = tf.getnames()
+    assert any("setup.cfg" in n for n in names)
+
+
 def test_repack_as_sdist_overwrites_existing(tmp_path: pathlib.Path) -> None:
     """Pre-existing tarball with the same name is replaced."""
     # Arrange
@@ -193,3 +296,37 @@ def test_repack_as_sdist_overwrites_existing(tmp_path: pathlib.Path) -> None:
     # Assert
     assert result.is_file()
     assert result.read_bytes() != b"stale"
+
+
+def test_default_build_sdist_rebases_build_dir_after_rename(
+    tmp_path: pathlib.Path,
+) -> None:
+    """default_build_sdist updates build_dir when make_sdist_directory renames the root."""
+    from packaging.requirements import Requirement
+
+    src = tmp_path / "BadName"
+    sub = src / "python"
+    sub.mkdir(parents=True)
+    (sub / "setup.py").write_text("# setup")
+    sdists_builds = tmp_path / "sdists" / "builds"
+    sdists_builds.mkdir(parents=True)
+
+    ctx = mock.MagicMock()
+    ctx.sdists_builds = sdists_builds
+    build_env = mock.MagicMock()
+    req = Requirement("testpkg")
+
+    result = sources.default_build_sdist(
+        ctx=ctx,
+        extra_environ={},
+        req=req,
+        version=Version("1.0"),
+        sdist_root_dir=src,
+        build_env=build_env,
+        build_dir=sub,
+    )
+
+    assert result.is_file()
+    renamed_root = tmp_path / "testpkg-1.0"
+    assert renamed_root.is_dir()
+    assert (renamed_root / "python" / "PKG-INFO").is_file()


### PR DESCRIPTION
Add sdist.make_sdist_directory() and sdist.repack_as_sdist() helpers that normalize git clones and non-standard tarballs into valid sdist layouts. Bump stub PKG-INFO from Metadata-Version 1.0 to 2.2 and integrate into the git clone prepare_source path and default_build_sdist.

Git clones and GitHub release tarballs lack PKG-INFO, causing setuptools-scm failures when PEP 517 hooks run during PREPARE_BUILD. Today ensure_pkg_info only runs during build_sdist -- one step too late. These helpers create a valid-enough sdist layout earlier in the pipeline using only (name, version).

Closes #554
