### PR TITLE
fix(resolver): resolve sdist URL via source provider in cache fallback

### DIFF
--- a/src/fromager/bootstrap_requirement_resolver.py
+++ b/src/fromager/bootstrap_requirement_resolver.py
@@ -168,7 +168,7 @@ class BootstrapRequirementResolver:
                     "falling back to the cache server %s",
                     self.cache_wheel_server_url,
                 )
-                results = self._resolve_from_cache_server(req)
+                results = self._resolve_from_cache_server(req, req_type)
 
             if not results:
                 logger.warning(
@@ -188,11 +188,16 @@ class BootstrapRequirementResolver:
             return results
         return [results[0]]
 
-    def _resolve_from_cache_server(self, req: Requirement) -> list[tuple[str, Version]]:
+    def _resolve_from_cache_server(
+        self, req: Requirement, req_type: RequirementType
+    ) -> list[tuple[str, Version]]:
         """Fall back to the remote wheel cache server for a cached version.
 
         When age filtering removes all candidates in multi-version mode,
-        queries the remote cache server for the newest available wheel.
+        queries the remote cache server (both wheels and sdists) to find
+        the newest available version, then re-resolves the sdist URL
+        through the normal source provider (including overrides).
+
         Returns at most one version so that transitive dependencies are
         re-processed without rebuilding every old version.
         """
@@ -220,9 +225,49 @@ class BootstrapRequirementResolver:
                     self.cache_wheel_server_url,
                     err,
                 )
-        if best is not None:
-            logger.info("found version %s on cache server", best[1])
-            return [best]
+
+        if best is None:
+            logger.debug(
+                "no versions found on cache server %s for %s",
+                self.cache_wheel_server_url,
+                req.name,
+            )
+            return []
+
+        _, version = best
+        logger.info("found version %s on cache server, resolving sdist URL", version)
+
+        pinned_req = Requirement(f"{req.name}=={version}")
+        try:
+            source_provider = sources.get_source_provider(
+                ctx=self.ctx,
+                req=pinned_req,
+                sdist_server_url=resolver.PYPI_SERVER_URL,
+                req_type=req_type,
+            )
+            sdist_results = resolver.find_all_matching_from_provider(
+                source_provider, pinned_req
+            )
+            if sdist_results:
+                logger.info(
+                    "resolved sdist URL for %s==%s from source provider",
+                    req.name,
+                    version,
+                )
+                return [sdist_results[0]]
+        except Exception as err:
+            logger.warning(
+                "failed to resolve sdist URL for %s==%s: %s",
+                req.name,
+                version,
+                err,
+            )
+
+        logger.warning(
+            "cache server has %s==%s but source provider returned no sdist",
+            req.name,
+            version,
+        )
         return []
 
     def get_cached_resolution(

--- a/tests/test_bootstrap_requirement_resolver.py
+++ b/tests/test_bootstrap_requirement_resolver.py
@@ -699,8 +699,10 @@ def test_resolve_prebuilt_after_source_uses_separate_cache(
 class TestResolveFromCacheServer:
     """Tests for the cache server fallback in _resolve_from_cache_server."""
 
-    def test_returns_newest_version_from_cache(self, tmp_context: WorkContext) -> None:
-        """Falls back to cache server and returns only the newest version."""
+    def test_resolves_sdist_url_via_source_provider(
+        self, tmp_context: WorkContext
+    ) -> None:
+        """Finds version on cache, then resolves sdist URL via source provider."""
         brr = BootstrapRequirementResolver(
             tmp_context,
             multiple_versions=True,
@@ -708,18 +710,28 @@ class TestResolveFromCacheServer:
         )
         req = Requirement("testpkg")
 
-        with patch(
-            "fromager.bootstrap_requirement_resolver.resolver"
-            ".find_all_matching_from_provider",
-            return_value=[
-                ("http://cache.test/testpkg-3.0.whl", Version("3.0")),
-                ("http://cache.test/testpkg-2.0.whl", Version("2.0")),
-            ],
+        cache_results = [
+            ("http://cache.test/testpkg-3.0-py3-none-any.whl", Version("3.0")),
+        ]
+        sdist_results = [
+            ("https://pypi.test/testpkg-3.0.tar.gz", Version("3.0")),
+        ]
+
+        with (
+            patch(
+                "fromager.bootstrap_requirement_resolver.resolver"
+                ".find_all_matching_from_provider",
+                side_effect=[cache_results, [], sdist_results],
+            ),
+            patch(
+                "fromager.bootstrap_requirement_resolver.sources.get_source_provider",
+            ),
         ):
-            result = brr._resolve_from_cache_server(req)
+            result = brr._resolve_from_cache_server(req, RequirementType.INSTALL)
 
         assert len(result) == 1
         assert result[0][1] == Version("3.0")
+        assert result[0][0] == "https://pypi.test/testpkg-3.0.tar.gz"
 
     def test_returns_empty_when_cache_has_no_match(
         self, tmp_context: WorkContext
@@ -737,11 +749,11 @@ class TestResolveFromCacheServer:
             ".find_all_matching_from_provider",
             return_value=[],
         ):
-            result = brr._resolve_from_cache_server(req)
+            result = brr._resolve_from_cache_server(req, RequirementType.INSTALL)
 
         assert result == []
 
-    def test_returns_empty_on_exception(self, tmp_context: WorkContext) -> None:
+    def test_returns_empty_on_cache_exception(self, tmp_context: WorkContext) -> None:
         """Returns empty list when cache server query fails."""
         brr = BootstrapRequirementResolver(
             tmp_context,
@@ -755,7 +767,36 @@ class TestResolveFromCacheServer:
             ".find_all_matching_from_provider",
             side_effect=RuntimeError("connection refused"),
         ):
-            result = brr._resolve_from_cache_server(req)
+            result = brr._resolve_from_cache_server(req, RequirementType.INSTALL)
+
+        assert result == []
+
+    def test_returns_empty_when_source_provider_has_no_sdist(
+        self, tmp_context: WorkContext
+    ) -> None:
+        """Returns empty when cache has version but source provider has no sdist."""
+        brr = BootstrapRequirementResolver(
+            tmp_context,
+            multiple_versions=True,
+            cache_wheel_server_url="http://cache.test/simple",
+        )
+        req = Requirement("testpkg")
+
+        cache_results = [
+            ("http://cache.test/testpkg-3.0-py3-none-any.whl", Version("3.0")),
+        ]
+
+        with (
+            patch(
+                "fromager.bootstrap_requirement_resolver.resolver"
+                ".find_all_matching_from_provider",
+                side_effect=[cache_results, [], []],
+            ),
+            patch(
+                "fromager.bootstrap_requirement_resolver.sources.get_source_provider",
+            ),
+        ):
+            result = brr._resolve_from_cache_server(req, RequirementType.INSTALL)
 
         assert result == []
 
@@ -783,7 +824,7 @@ class TestResolveFromCacheServer:
             patch.object(
                 brr,
                 "_resolve_from_cache_server",
-                return_value=[("http://cache.test/testpkg-1.0.whl", Version("1.0"))],
+                return_value=[("https://pypi.test/testpkg-1.0.tar.gz", Version("1.0"))],
             ) as mock_cache,
         ):
             result = brr.resolve(
@@ -795,7 +836,7 @@ class TestResolveFromCacheServer:
             )
 
         mock_pypi.assert_called_once()
-        mock_cache.assert_called_once_with(req)
+        mock_cache.assert_called_once_with(req, RequirementType.INSTALL)
         assert len(result) == 1
         assert result[0][1] == Version("1.0")
 


### PR DESCRIPTION
## Summary

- `_resolve_from_cache_server` now queries the cache server for both wheels and sdists to find the newest version, then re-resolves the sdist URL through `sources.get_source_provider()`
- This uses the normal source resolution path including overrides (`get_resolver_provider` hook), custom download URLs, and `resolver_sdist_server_url` settings
- If the source provider cannot find an sdist for the pinned version, returns empty and logs a warning

Previously the method could return a wheel URL as `source_url`, which was written to `build-order.json` with `source_url_type: "sdist"`, causing downstream consumers to fail on a `.whl` basename.

Closes: #1184

## Test plan

- [x] `test_resolves_sdist_url_via_source_provider` — finds version on cache, resolves sdist via source provider
- [x] `test_returns_empty_when_source_provider_has_no_sdist` — cache has version but no sdist available
- [x] `test_returns_empty_when_cache_has_no_match` — cache server has nothing
- [x] `test_returns_empty_on_cache_exception` — cache server query fails
- [x] Integration tests for `resolve()` fallback path unchanged
- [x] All 28 resolver tests pass, mypy and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)