### PR TITLE
fix(output): standardize --output to work for all formats

### DIFF
--- a/src/fromager/clickext.py
+++ b/src/fromager/clickext.py
@@ -1,10 +1,32 @@
+import contextlib
 import os
 import pathlib
+import sys
+import typing
 
 import click
 from packaging.version import Version
 
 from . import requirements_file
+
+
+@contextlib.contextmanager
+def output_file_or_stdout(
+    path: pathlib.Path | None,
+) -> typing.Generator[typing.TextIO, None, None]:
+    """Context manager that opens *path* for writing or yields stdout.
+
+    When *path* is ``None``, yields :data:`sys.stdout` (never closed).
+    Otherwise opens the file, yields it, and closes on exit.
+    """
+    if path:
+        fh = open(path, "w")
+        try:
+            yield fh
+        finally:
+            fh.close()
+    else:
+        yield sys.stdout
 
 
 class ClickPath(click.Path):

--- a/src/fromager/commands/list_overrides.py
+++ b/src/fromager/commands/list_overrides.py
@@ -5,6 +5,7 @@ import sys
 
 import click
 import rich
+import rich.console
 from packaging.version import Version
 from rich.table import Table
 
@@ -26,13 +27,13 @@ from fromager.packagesettings import PatchMap
     "output_format",
     type=click.Choice(["table", "csv", "json"], case_sensitive=False),
     default="table",
-    help="Output format for detailed view (requires --details, default: table)",
+    help="Output format for detailed view (used with --details, default: table)",
 )
 @click.option(
     "-o",
     "--output",
     type=clickext.ClickPath(),
-    help="Output file to create (requires --details, default: stdout)",
+    help="Write output to file instead of stdout",
 )
 @click.pass_obj
 def list_overrides(
@@ -42,23 +43,11 @@ def list_overrides(
     output: pathlib.Path | None,
 ) -> None:
     """List all of the packages with overrides in the current configuration."""
-    # Warn if format/output options are used without --details
-    if not details:
-        if output_format != "table":
-            click.echo(
-                "Warning: --format option is ignored when --details is not used",
-                err=True,
-            )
-        if output is not None:
-            click.echo(
-                "Warning: --output option is ignored when --details is not used",
-                err=True,
-            )
-
     overridden_packages = sorted(wkctx.settings.list_overrides())
     if not details:
-        for name in overridden_packages:
-            print(name)
+        with clickext.output_file_or_stdout(output) as fh:
+            for name in overridden_packages:
+                print(name, file=fh)
         return
 
     # Collect data for export
@@ -140,7 +129,7 @@ def list_overrides(
         case "csv":
             _export_csv(export_data, variant_names, output)
         case "table":
-            _export_table(export_data, variant_names)
+            _export_table(export_data, variant_names, output)
         case _:
             raise ValueError(f"Invalid output format: {output_format}")
 
@@ -180,8 +169,10 @@ def _export_csv(
         writer.writerows(data)
 
 
-def _export_table(data: list[dict], variants: list[str]) -> None:
-    """Export data as Rich table (original behavior)."""
+def _export_table(
+    data: list[dict], variants: list[str], output: pathlib.Path | None = None
+) -> None:
+    """Export data as Rich table."""
     table = Table(title="Package Overrides")
     table.add_column("Package", justify="left", no_wrap=True)
     table.add_column("Version", justify="left", no_wrap=True)
@@ -194,7 +185,6 @@ def _export_table(data: list[dict], variants: list[str]) -> None:
 
     table.add_column("Plugin", justify="left")
 
-    # Define column keys in the same order as CSV exporter
     column_keys = (
         ["package", "version", "patches", "min_release_age"]
         + variants
@@ -205,4 +195,8 @@ def _export_table(data: list[dict], variants: list[str]) -> None:
         row = [row_data.get(key, "") for key in column_keys]
         table.add_row(*row)
 
-    rich.get_console().print(table)
+    if output:
+        with open(output, "w") as fh:
+            rich.console.Console(file=fh, width=120).print(table)
+    else:
+        rich.get_console().print(table)

--- a/src/fromager/commands/package.py
+++ b/src/fromager/commands/package.py
@@ -121,7 +121,7 @@ def package() -> None:
     "-o",
     "--output",
     type=clickext.ClickPath(),
-    help="Output file (default: stdout)",
+    help="Write output to file instead of stdout",
 )
 @click.option(
     "--ignore-per-package-overrides",
@@ -228,18 +228,12 @@ def list_versions(
         provider.supports_upload_time,
     )
 
-    if output is not None and output_format in ("versions", "requirements"):
-        click.echo(
-            "Warning: --output option is ignored for 'versions' and 'requirements' formats",
-            err=True,
-        )
-
     match output_format:
         case "versions":
-            _export_versions_plain(version_rows, req.name, cooldown)
+            _export_versions_plain(version_rows, req.name, cooldown, output=output)
         case "requirements":
             _export_versions_plain(
-                version_rows, req.name, cooldown, as_requirements=True
+                version_rows, req.name, cooldown, as_requirements=True, output=output
             )
         case "table":
             _export_versions_table(version_rows, req.name, cooldown, output)
@@ -350,15 +344,17 @@ def _export_versions_plain(
     cooldown: Cooldown | None,
     *,
     as_requirements: bool = False,
+    output: pathlib.Path | None = None,
 ) -> None:
     """Export versions as a plain list, filtering out cooldown-blocked entries."""
-    for row in data:
-        if cooldown is not None and row["cooldown"] == "blocked":
-            continue
-        if as_requirements:
-            print(f"{package_name}=={row['version']}")
-        else:
-            print(row["version"])
+    with clickext.output_file_or_stdout(output) as fh:
+        for row in data:
+            if cooldown is not None and row["cooldown"] == "blocked":
+                continue
+            if as_requirements:
+                print(f"{package_name}=={row['version']}", file=fh)
+            else:
+                print(row["version"], file=fh)
 
 
 def _export_versions_json(

--- a/tests/test_list_overrides.py
+++ b/tests/test_list_overrides.py
@@ -203,38 +203,16 @@ def test_list_overrides_format_option_help(cli_runner: CliRunner) -> None:
     )
     assert result.exit_code == 0
     assert "--format [table|csv|json]" in result.stdout
-    assert "requires --details" in result.stdout
 
 
-def test_list_overrides_warnings_without_details(
-    testdata_path: pathlib.Path, cli_runner: CliRunner
+def test_list_overrides_output_file_plain(
+    testdata_path: pathlib.Path, cli_runner: CliRunner, tmp_path: pathlib.Path
 ) -> None:
-    """Test that warnings are shown when using format/output without details."""
+    """--output writes plain name list to a file when --details is not used."""
     settings_file = testdata_path / "context" / "overrides" / "settings.yaml"
     patches_dir = testdata_path / "context" / "overrides" / "patches"
+    output_file = tmp_path / "overrides.txt"
 
-    # Test format warning
-    result = cli_runner.invoke(
-        fromager,
-        [
-            "--settings-file",
-            str(settings_file),
-            "--patches-dir",
-            str(patches_dir),
-            "list-overrides",
-            "--format",
-            "json",
-        ],
-        catch_exceptions=False,
-    )
-    assert result.exit_code == 0
-    assert (
-        "Warning: --format option is ignored when --details is not used"
-        in result.output
-    )
-    assert "test-other-pkg" in result.output
-
-    # Test output warning
     result = cli_runner.invoke(
         fromager,
         [
@@ -244,16 +222,19 @@ def test_list_overrides_warnings_without_details(
             str(patches_dir),
             "list-overrides",
             "--output",
-            "test.txt",
+            str(output_file),
         ],
-        catch_exceptions=False,
     )
     assert result.exit_code == 0
-    assert (
-        "Warning: --output option is ignored when --details is not used"
-        in result.output
-    )
-    assert "test-other-pkg" in result.output
+    assert output_file.exists()
+    content = output_file.read_text()
+    assert "test-other-pkg" in content
+    assert "test-pkg" in content
+    assert "test-pkg-library" in content
+    # stdout should be empty (no data printed to console)
+    assert "test-pkg" not in result.stdout
+    assert "test-other-pkg" not in result.stdout
+    assert "test-pkg-library" not in result.stdout
 
 
 def test_list_overrides_min_release_age(

--- a/tests/test_list_versions.py
+++ b/tests/test_list_versions.py
@@ -329,21 +329,48 @@ def test_list_versions_output_file(
     assert len(data) == 3
 
 
-def test_list_versions_output_ignored_for_plain_formats(
+def test_list_versions_output_file_versions_format(
     cli_runner: CliRunner, tmp_path: pathlib.Path
 ) -> None:
-    """--output is ignored with a warning for 'versions' and 'requirements' formats."""
+    """--output writes plain version list to a file for 'versions' format."""
     output_file = tmp_path / "versions.txt"
-    for fmt in ("versions", "requirements"):
-        result = _invoke_list_versions(
-            cli_runner,
-            extra_args=["--format", fmt, "--output", str(output_file)],
-        )
-        assert result.exit_code == 0
-        assert not output_file.exists(), (
-            f"--output should be ignored for --format {fmt}"
-        )
-        assert "Warning: --output option is ignored" in result.output
+    result = _invoke_list_versions(
+        cli_runner,
+        extra_args=["--format", "versions", "--output", str(output_file)],
+    )
+    assert result.exit_code == 0
+    assert output_file.exists()
+    content = output_file.read_text()
+    lines = [line for line in content.strip().split("\n") if line.strip()]
+    assert "1.2.2" in lines
+    assert "1.3.2" in lines
+    assert "2.0.0" in lines
+    # stdout should be empty (no data printed to console)
+    assert "1.2.2" not in result.stdout
+    assert "1.3.2" not in result.stdout
+    assert "2.0.0" not in result.stdout
+
+
+def test_list_versions_output_file_requirements_format(
+    cli_runner: CliRunner, tmp_path: pathlib.Path
+) -> None:
+    """--output writes requirements pins to a file for 'requirements' format."""
+    output_file = tmp_path / "requirements.txt"
+    result = _invoke_list_versions(
+        cli_runner,
+        extra_args=["--format", "requirements", "--output", str(output_file)],
+    )
+    assert result.exit_code == 0
+    assert output_file.exists()
+    content = output_file.read_text()
+    lines = [line for line in content.strip().split("\n") if line.strip()]
+    assert "test-pkg==1.2.2" in lines
+    assert "test-pkg==1.3.2" in lines
+    assert "test-pkg==2.0.0" in lines
+    # stdout should be empty (no data printed to console)
+    assert "test-pkg==1.2.2" not in result.stdout
+    assert "test-pkg==1.3.2" not in result.stdout
+    assert "test-pkg==2.0.0" not in result.stdout
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Wire -o into plain formats for `list-versions` (versions, requirements) and `list-overrides` (no --details), removing inconsistent warn-and-ignore behavior. Matches the find-updates reference implementation.

Closes: #1177

- [x] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
