### PR TITLE
fix(bootstrap): handle RESOLVE-phase errors in multiple versions mode

### DIFF
--- a/e2e/ci_bootstrap_suite.sh
+++ b/e2e/ci_bootstrap_suite.sh
@@ -27,6 +27,7 @@ run_test "bootstrap_prerelease"
 run_test "bootstrap_cache"
 run_test "bootstrap_sdist_only"
 run_test "bootstrap_multiple_versions"
+run_test "bootstrap_multiple_versions_resolve_error"
 run_test "bootstrap_max_release_age"
 
 test_section "bootstrap test-mode tests"

--- a/e2e/test_bootstrap_multiple_versions_resolve_error.sh
+++ b/e2e/test_bootstrap_multiple_versions_resolve_error.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# -*- indent-tabs-mode: nil; tab-width: 2; sh-indentation: 2; -*-
+
+# Test that --multiple-versions continues when one package fails to resolve.
+# A nonexistent package triggers a resolution failure; a real package (tomli)
+# should still be bootstrapped successfully.
+# See: https://github.com/python-wheel-build/fromager/issues/1195
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$SCRIPTDIR/common.sh"
+pass=true
+
+# Compute --max-release-age dynamically so tomli 2.0.1 is always included.
+MAX_AGE=$(python3 -c "
+from datetime import date
+age = (date.today() - date(2021, 12, 13)).days
+print(age + 30)
+")
+
+# Bootstrap two packages:
+# - nonexistent-pkg-xyz-99999: guaranteed resolution failure
+# - tomli==2.0.1: should resolve and build successfully
+#
+# The bootstrap must not crash on the nonexistent package.
+set +e
+fromager \
+  --log-file="$OUTDIR/bootstrap.log" \
+  --error-log-file="$OUTDIR/fromager-errors.log" \
+  --sdists-repo="$OUTDIR/sdists-repo" \
+  --wheels-repo="$OUTDIR/wheels-repo" \
+  --work-dir="$OUTDIR/work-dir" \
+  bootstrap \
+  --multiple-versions \
+  --max-release-age="$MAX_AGE" \
+  'nonexistent-pkg-xyz-99999==1.0.0' 'tomli==2.0.1'
+exit_code=$?
+set -e
+
+# The bootstrap should succeed (exit 0) despite the resolution failure
+if [ "$exit_code" -ne 0 ]; then
+  echo "FAIL: expected exit code 0, got $exit_code" 1>&2
+  echo "multiple-versions mode should continue past resolution failures" 1>&2
+  pass=false
+fi
+
+# Verify that tomli was built successfully
+if find "$OUTDIR/wheels-repo/downloads/" -name 'tomli-2.0.1*.whl' | grep -q .; then
+  echo "✓ tomli wheel was built despite nonexistent-pkg resolution failure"
+else
+  echo "FAIL: tomli wheel not found — bootstrap may have crashed early" 1>&2
+  pass=false
+fi
+
+# Verify that the resolution failure for the nonexistent package was logged
+if grep -q "nonexistent-pkg-xyz-99999.*failed to resolve" "$OUTDIR/bootstrap.log"; then
+  echo "✓ Resolution failure was logged for nonexistent package"
+else
+  echo "FAIL: resolution failure message not found in log" 1>&2
+  pass=false
+fi
+
+# Verify the failed versions summary was logged
+if grep -q "version(s) failed to bootstrap" "$OUTDIR/bootstrap.log"; then
+  echo "✓ Failed versions summary was logged"
+else
+  echo "FAIL: failed versions summary not found in log" 1>&2
+  pass=false
+fi
+
+$pass

--- a/src/fromager/bootstrapper.py
+++ b/src/fromager/bootstrapper.py
@@ -247,9 +247,25 @@ class Bootstrapper:
                     constraint=self.ctx.constraints.get_constraint(req.name),
                 )
 
+            if not results:
+                if self.multiple_versions:
+                    err = RuntimeError(f"no versions found for {req}")
+                    self._record_failed_version(
+                        req, "unresolved", err, "no versions resolved, skipping"
+                    )
+                    if self.test_mode:
+                        self._record_test_mode_failure(req, None, err, "resolution")
+                    return None
+                raise RuntimeError(f"Could not resolve any versions for {req}")
+
             # Return first result for backward compatibility
             return results[0]
         except Exception as err:
+            if self.multiple_versions:
+                self._record_failed_version(req, "unresolved", err, "failed to resolve")
+                if self.test_mode:
+                    self._record_test_mode_failure(req, None, err, "resolution")
+                return None
             if not self.test_mode:
                 raise
             self._record_test_mode_failure(req, None, err, "resolution")
@@ -1739,10 +1755,22 @@ class Bootstrapper:
         Returns work items to continue processing (e.g. prebuilt fallback),
         or empty list to skip this item. Raises in normal mode (fail-fast).
         """
-        # Resolution failures: only recoverable in test mode
+        # Resolution failures: recoverable in test mode and multiple versions mode
         if item.phase == BootstrapPhase.RESOLVE:
             if self.test_mode:
                 self._record_test_mode_failure(item.req, None, err, "resolution")
+                if self.multiple_versions:
+                    self._record_failed_version(
+                        item.req,
+                        "unresolved",
+                        err,
+                        f"failed during {item.phase} phase",
+                    )
+                return []
+            if self.multiple_versions:
+                self._record_failed_version(
+                    item.req, "unresolved", err, f"failed during {item.phase} phase"
+                )
                 return []
             raise
 
@@ -1777,11 +1805,11 @@ class Bootstrapper:
         if self.multiple_versions:
             assert item.resolved_version is not None
             pkg_name = canonicalize_name(item.req.name)
-            self._failed_versions.append((pkg_name, str(item.resolved_version), err))
-            logger.warning(
-                f"{item.req.name}=={item.resolved_version}: "
-                f"failed to bootstrap during {item.phase} phase: "
-                f"{type(err).__name__}: {err}"
+            self._record_failed_version(
+                item.req,
+                str(item.resolved_version),
+                err,
+                f"failed during {item.phase} phase",
             )
             self.ctx.dependency_graph.remove_dependency(pkg_name, item.resolved_version)
             self._seen_requirements.discard(
@@ -1796,15 +1824,44 @@ class Bootstrapper:
         # Normal mode: fail-fast
         raise
 
+    def _record_failed_version(
+        self,
+        req: Requirement,
+        version: str,
+        err: Exception,
+        detail: str,
+    ) -> None:
+        """Record a version failure in multiple versions mode."""
+        pkg_name = canonicalize_name(req.name)
+        self._failed_versions.append((pkg_name, version, err))
+        logger.warning(
+            "%s==%s: %s: %s: %s",
+            req.name,
+            version,
+            detail,
+            type(err).__name__,
+            err,
+        )
+
+    def _log_failed_versions_table(self) -> None:
+        """Log a summary table of all failed versions."""
+        logger.warning("%d version(s) failed to bootstrap:", len(self._failed_versions))
+        for name, ver, exc in self._failed_versions:
+            logger.warning("  %s==%s: %s: %s", name, ver, type(exc).__name__, exc)
+
     def finalize(self) -> int:
         """Finalize bootstrap and return exit code.
 
+        Reports failed versions in multiple versions mode.
         In test mode, writes failure report and returns non-zero if there were failures.
 
         Returns:
-            0 if all packages built successfully (or not in test mode)
+            0 if all packages built successfully (or not in test/multiple versions mode)
             1 if any packages failed in test mode
         """
+        if self.multiple_versions and self._failed_versions:
+            self._log_failed_versions_table()
+
         if not self.test_mode:
             return 0
 

--- a/src/fromager/commands/bootstrap.py
+++ b/src/fromager/commands/bootstrap.py
@@ -212,7 +212,7 @@ def bootstrap(
             result = bt.resolve_and_add_top_level(req)
             if result is not None:
                 resolved_reqs.append(req)
-            # If result is None, test_mode recorded the failure and we continue
+            # If result is None, test_mode or multiple_versions recorded the failure
             requirement_ctxvar.reset(token)
 
         # Bootstrap only packages that were successfully resolved

--- a/tests/test_bootstrapper_iterative.py
+++ b/tests/test_bootstrapper_iterative.py
@@ -569,18 +569,24 @@ class TestHandlePhaseError:
             except RuntimeError:
                 bt._handle_phase_error(item, err)
 
-    def test_resolve_error_in_multiple_versions_mode_raises(
+    def test_resolve_error_in_multiple_versions_mode_continues(
         self, tmp_context: WorkContext
     ) -> None:
+        """RESOLVE failures in multiple versions mode are recorded, not raised."""
         bt = bootstrapper.Bootstrapper(tmp_context, multiple_versions=True)
         item = _make_resolve_item()
         err = RuntimeError("resolution failed")
 
-        with pytest.raises(RuntimeError, match="resolution failed"):
-            try:
-                raise err
-            except RuntimeError:
-                bt._handle_phase_error(item, err)
+        try:
+            raise err
+        except RuntimeError:
+            result = bt._handle_phase_error(item, err)
+
+        assert result == []
+        assert len(bt._failed_versions) == 1
+        assert bt._failed_versions[0][0] == canonicalize_name("testpkg")
+        assert bt._failed_versions[0][1] == "unresolved"
+        assert bt._failed_versions[0][2] is err
 
     # -- Build phase errors in test mode --
 
@@ -877,6 +883,43 @@ class TestIterativeBootstrapLoop:
         # Other versions processed successfully (in graph)
         assert f"{canonicalize_name('pkg')}==2.0" in tmp_context.dependency_graph.nodes
         assert f"{canonicalize_name('pkg')}==1.0" in tmp_context.dependency_graph.nodes
+
+    def test_multiple_versions_resolve_failure_continues(
+        self, tmp_context: WorkContext
+    ) -> None:
+        """RESOLVE failure for one dependency does not crash the loop."""
+        bt = bootstrapper.Bootstrapper(tmp_context, multiple_versions=True)
+
+        original_dispatch = bt._dispatch_phase
+        completed: list[str] = []
+
+        def mock_dispatch(item: WorkItem) -> list[WorkItem]:
+            if item.phase == BootstrapPhase.START:
+                return original_dispatch(item)
+            if item.phase == BootstrapPhase.RESOLVE:
+                if str(item.req.name) == "bad-dep":
+                    raise RuntimeError("Could not resolve any versions for bad-dep")
+                return original_dispatch(item)
+            completed.append(str(item.req.name))
+            return []
+
+        with (
+            patch.object(bt, "_dispatch_phase", side_effect=mock_dispatch),
+            patch.object(
+                bt._resolver,
+                "resolve",
+                return_value=[("url-1.0", Version("1.0"))],
+            ),
+            patch.object(bt, "_has_been_seen", return_value=False),
+        ):
+            bt.bootstrap(Requirement("good-pkg"), RequirementType.INSTALL)
+            bt.bootstrap(Requirement("bad-dep"), RequirementType.INSTALL)
+            bt.bootstrap(Requirement("another-good"), RequirementType.INSTALL)
+
+        assert "good-pkg" in completed
+        assert "another-good" in completed
+        failed_names = [name for name, _, _ in bt._failed_versions]
+        assert canonicalize_name("bad-dep") in failed_names
 
     def test_test_mode_continues_after_failure(self, tmp_context: WorkContext) -> None:
         """In test mode, failed items are recorded and processing continues."""


### PR DESCRIPTION
In multiple version bootstrap mode, resolution failures (e.g. all candidates filtered by `--max-release-age` with no cache fallback) crashed the entire bootstrap instead of continuing with remaining packages.

The bug was in `_handle_phase_error()` where RESOLVE-phase errors always re-raised unless in test mode, preventing the `multiple_versions` handler from being reached. A second crash path existed in `resolve_and_add_top_level()` where empty results caused an `IndexError`.

Both paths now record failures in `_failed_versions`, log warnings, and continue processing. A rich table summary of all failed versions is displayed at the end via `finalize()`.

Closes: #1195
