### PR TITLE
fix(bootstrapper): skip already-failed versions in `_phase_resolve()`

### DIFF
--- a/src/fromager/bootstrapper.py
+++ b/src/fromager/bootstrapper.py
@@ -197,8 +197,7 @@ class Bootstrapper:
         self.failed_packages: list[FailureRecord] = []
 
         # Track failed versions in multiple_versions mode
-        # Maps (package_name, version) -> exception info
-        self._failed_versions: list[tuple[str, str, Exception]] = []
+        self._failed_versions: dict[tuple[str, str], Exception] = {}
 
     def resolve_and_add_top_level(
         self,
@@ -417,16 +416,17 @@ class Bootstrapper:
 
         # In multiple versions mode, report any failures for this requirement
         if self.multiple_versions and self._failed_versions:
-            failed_for_req = [
-                (name, ver, exc)
-                for name, ver, exc in self._failed_versions
-                if name == canonicalize_name(req.name)
-            ]
+            req_name = canonicalize_name(req.name)
+            failed_for_req = {
+                (name, ver): exc
+                for (name, ver), exc in self._failed_versions.items()
+                if name == req_name
+            }
             if failed_for_req:
                 logger.warning(
                     f"{req.name}: {len(failed_for_req)} version(s) failed to bootstrap"
                 )
-                for name, ver, exc in failed_for_req:
+                for (name, ver), exc in failed_for_req.items():
                     logger.warning(f"  - {name}=={ver}: {type(exc).__name__}: {exc}")
 
     @contextlib.contextmanager
@@ -1353,9 +1353,10 @@ class Bootstrapper:
         """RESOLVE phase: resolve versions and expand into START-phase items.
 
         Centralizes version resolution so all dependencies are expanded
-        uniformly. In multiple_versions mode, filters out versions whose
-        wheels are already cached to avoid redundant builds and
-        transitive dependency processing.
+        uniformly. In multiple_versions mode, filters out versions that
+        already failed in this run and versions whose wheels are already
+        cached to avoid redundant builds and transitive dependency
+        processing.
 
         Returns:
             One START-phase item per resolved version that needs building.
@@ -1370,6 +1371,18 @@ class Bootstrapper:
             raise RuntimeError(f"Could not resolve any versions for {item.req}")
 
         if self.multiple_versions:
+            pkg_name = canonicalize_name(item.req.name)
+            resolved_versions = [
+                (url, ver)
+                for url, ver in resolved_versions
+                if (pkg_name, str(ver)) not in self._failed_versions
+            ]
+            if not resolved_versions:
+                raise RuntimeError(
+                    f"Could not resolve any versions for {item.req}"
+                    f" (all candidates failed previously)"
+                )
+
             logger.info(f"resolved {len(resolved_versions)} version(s) for {item.req}")
             filtered: list[tuple[str, Version]] = []
             for source_url, version in resolved_versions:
@@ -1831,7 +1844,7 @@ class Bootstrapper:
     ) -> None:
         """Record a version failure in multiple versions mode."""
         pkg_name = canonicalize_name(req.name)
-        self._failed_versions.append((pkg_name, version, err))
+        self._failed_versions[(pkg_name, version)] = err
         logger.warning(
             "%s==%s: %s: %s: %s",
             req.name,
@@ -1844,7 +1857,7 @@ class Bootstrapper:
     def _log_failed_versions_table(self) -> None:
         """Log a summary table of all failed versions."""
         logger.warning("%d version(s) failed to bootstrap:", len(self._failed_versions))
-        for name, ver, exc in self._failed_versions:
+        for (name, ver), exc in self._failed_versions.items():
             logger.warning("  %s==%s: %s: %s", name, ver, type(exc).__name__, exc)
 
     def finalize(self) -> int:

--- a/tests/test_bootstrapper.py
+++ b/tests/test_bootstrapper.py
@@ -352,9 +352,9 @@ def test_multiple_versions_continues_on_error(tmp_context: WorkContext) -> None:
 
                     # Verify that version 1.5 is in failed_versions
                     assert len(bt._failed_versions) == 1
-                    pkg_name, version_str, exc = bt._failed_versions[0]
-                    assert pkg_name == canonicalize_name("testpkg")
-                    assert version_str == "1.5"
+                    key = (canonicalize_name("testpkg"), "1.5")
+                    assert key in bt._failed_versions
+                    exc = bt._failed_versions[key]
                     assert isinstance(exc, ValueError)
                     assert str(exc) == "Simulated failure for version 1.5"
 

--- a/tests/test_bootstrapper_iterative.py
+++ b/tests/test_bootstrapper_iterative.py
@@ -397,6 +397,76 @@ class TestPhaseResolve:
             ):
                 bt._phase_resolve(item)
 
+    def test_filters_failed_versions_in_multiple_versions_mode(
+        self, tmp_context: WorkContext
+    ) -> None:
+        """Previously failed versions are excluded before creating START items."""
+        bt = bootstrapper.Bootstrapper(tmp_context, multiple_versions=True)
+        item = _make_resolve_item()
+
+        bt._failed_versions[(canonicalize_name("testpkg"), "2.0")] = RuntimeError(
+            "boom"
+        )
+
+        with (
+            patch.object(
+                bt,
+                "resolve_versions",
+                return_value=[
+                    ("url-3.0", Version("3.0")),
+                    ("url-2.0", Version("2.0")),
+                    ("url-1.0", Version("1.0")),
+                ],
+            ),
+            patch.object(bt, "_find_cached_wheel", return_value=(None, None)),
+        ):
+            result = bt._phase_resolve(item)
+
+        versions = {str(it.resolved_version) for it in result}
+        assert versions == {"1.0", "3.0"}
+
+    def test_failed_version_filter_does_not_apply_in_single_version_mode(
+        self, tmp_context: WorkContext
+    ) -> None:
+        """Failed-version filtering only applies in multiple_versions mode."""
+        bt = bootstrapper.Bootstrapper(tmp_context, multiple_versions=False)
+        item = _make_resolve_item()
+
+        bt._failed_versions[(canonicalize_name("testpkg"), "1.0")] = RuntimeError(
+            "boom"
+        )
+
+        with patch.object(
+            bt,
+            "resolve_versions",
+            return_value=[("url-1.0", Version("1.0"))],
+        ):
+            result = bt._phase_resolve(item)
+
+        assert len(result) == 1
+        assert result[0].resolved_version == Version("1.0")
+
+    def test_all_versions_failed_raises_runtime_error(
+        self, tmp_context: WorkContext
+    ) -> None:
+        """Raises RuntimeError when all resolved versions already failed."""
+        bt = bootstrapper.Bootstrapper(tmp_context, multiple_versions=True)
+        item = _make_resolve_item()
+
+        bt._failed_versions[(canonicalize_name("testpkg"), "1.0")] = RuntimeError(
+            "boom"
+        )
+
+        with (
+            patch.object(
+                bt,
+                "resolve_versions",
+                return_value=[("url-1.0", Version("1.0"))],
+            ),
+            pytest.raises(RuntimeError, match="failed previously"),
+        ):
+            bt._phase_resolve(item)
+
 
 class TestPhaseStart:
     def test_new_item_advances_to_prepare_source(
@@ -584,9 +654,9 @@ class TestHandlePhaseError:
 
         assert result == []
         assert len(bt._failed_versions) == 1
-        assert bt._failed_versions[0][0] == canonicalize_name("testpkg")
-        assert bt._failed_versions[0][1] == "unresolved"
-        assert bt._failed_versions[0][2] is err
+        key = (canonicalize_name("testpkg"), "unresolved")
+        assert key in bt._failed_versions
+        assert bt._failed_versions[key] is err
 
     # -- Build phase errors in test mode --
 
@@ -679,8 +749,7 @@ class TestHandlePhaseError:
         assert result == []
         # Failure recorded
         assert len(bt._failed_versions) == 1
-        assert bt._failed_versions[0][0] == canonicalize_name("testpkg")
-        assert bt._failed_versions[0][1] == "1.0"
+        assert (canonicalize_name("testpkg"), "1.0") in bt._failed_versions
         # Removed from graph
         key = f"{canonicalize_name('testpkg')}==1.0"
         assert key not in tmp_context.dependency_graph.nodes
@@ -879,7 +948,7 @@ class TestIterativeBootstrapLoop:
             bt.bootstrap(Requirement("pkg"), RequirementType.INSTALL)
 
         assert len(bt._failed_versions) == 1
-        assert bt._failed_versions[0][1] == "1.5"
+        assert (canonicalize_name("pkg"), "1.5") in bt._failed_versions
         # Other versions processed successfully (in graph)
         assert f"{canonicalize_name('pkg')}==2.0" in tmp_context.dependency_graph.nodes
         assert f"{canonicalize_name('pkg')}==1.0" in tmp_context.dependency_graph.nodes
@@ -918,7 +987,7 @@ class TestIterativeBootstrapLoop:
 
         assert "good-pkg" in completed
         assert "another-good" in completed
-        failed_names = [name for name, _, _ in bt._failed_versions]
+        failed_names = [name for name, _ in bt._failed_versions]
         assert canonicalize_name("bad-dep") in failed_names
 
     def test_test_mode_continues_after_failure(self, tmp_context: WorkContext) -> None:


### PR DESCRIPTION
In `--multiple-versions` mode, when a version fails to build, `_handle_phase_error()` discards it from `_seen_requirements` and records it in `_failed_versions`, but `_failed_versions` was never consulted before attempting builds. The resolution cache still returned the full candidate list, so every failed version was re-downloaded, re-prepared, and re-built on each subsequent resolution of the same requirement.

Filter out already-failed versions in `_phase_resolve()` before expanding them into work items, avoiding redundant build attempts.

Closes: #1198 