### PR TITLE
build(test): add pytest-xdist for parallel test execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ mypy = [
 test = [
     "coverage[toml]!=4.4,>=4.0",
     "pytest",
+    "pytest-xdist",
     "requests-mock",
     "spdx-tools",
     "twine>=6.1.0",
@@ -293,6 +294,8 @@ features = ["docs"]
 build = "sphinx-build -M html docs docs/_build -j auto --keep-going {args:--fail-on-warning --fresh-env -n}"
 
 [tool.pytest.ini_options]
+# run tests in parallel with 3 pytest-xdist workers
+addopts = "-n 3"
 markers = [
     "network: test that need network access",
 ]


### PR DESCRIPTION
# Pull Request Description

## What

Add `pytest-xdist` to test dependencies and configure 3 parallel workers via `addopts`. Testing showed that 4 or more workers does not provide measurable benefits.

See https://pytest-xdist.readthedocs.io/en/stable/

## Why

Speed up local testing. On my machine, unit tests now takes less than 4 seconds instead of 12 seconds.

- [ ] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
