### PR TITLE
fix(ci): set COVERAGE_FILE so unit coverage uploads correctly

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,6 +57,7 @@ jobs:
         run: hatch run test:test --with-network
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERAGE_FILE: .coverage.unit.py${{ matrix.python-version }}.${{ matrix.os }}
 
       - name: Upload coverage
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,11 +133,10 @@ lint-requirements = "fromager.commands.lint_requirements:lint_requirements"
 branch = true
 parallel = true
 relative_files = true
-source = ["fromager", "tests/"]
+source = ["fromager"]
 
 [tool.coverage.paths]
 source = ["src/fromager", ".hatch/**/site-packages/fromager"]
-tests = ["tests/"]
 
 [tool.coverage.report]
 show_missing = true


### PR DESCRIPTION
The switch from `coverage run -m pytest` to `pytest --cov` (#1219)
caused pytest-cov to write a single `.coverage` file. The CI upload
step uses the glob `.coverage.*`, which requires a suffix after the
dot — so the unit test coverage data was never uploaded. Only e2e
coverage data (which still produces `.coverage.*` files via subprocess
instrumentation) reached the combine step, dropping overall coverage
from ~93% to 37% and failing the `--fail-under=60` gate.
    
Fix by setting `COVERAGE_FILE` with a per-job suffix so pytest-cov
writes directly to e.g. `.coverage.unit.py3.12.ubuntu-latest`, which
the upload glob matches.
    
Also remove `tests/` from `[tool.coverage.run].source` to measure
only production code coverage.


Closes: #1222

- [x] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
