### PR TITLE
feat(gitutils): add `git_clean` to remove untracked files

### DIFF
--- a/src/fromager/gitutils.py
+++ b/src/fromager/gitutils.py
@@ -140,6 +140,19 @@ def git_clone_fast(
         logger.debug("no .gitmodules file")
 
 
+def git_clean(source_dir: pathlib.Path) -> None:
+    """Remove untracked files and directories from a git working tree.
+
+    Runs ``git clean -xdf`` in *source_dir* to remove all untracked and
+    ignored files, restoring the working tree to a pristine state.
+
+    .. versionadded:: 0.90.0
+    """
+    cmd: list[str] = ["git", "clean", "-xdf"]
+    logger.debug("cleaning untracked files in %s", source_dir)
+    external_commands.run(cmd, cwd=str(source_dir))
+
+
 def parse_vcs_url(vcs_url: str, *, require_ref: bool = True) -> tuple[str, str]:
     """Parse a `pip VCS URL`_ into a repo clone URL and git ref.
 

--- a/tests/test_gitutils.py
+++ b/tests/test_gitutils.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 import pytest
 from packaging.version import Version
 
-from fromager.gitutils import GIT_HEAD, git_clone_fast, parse_vcs_url
+from fromager.gitutils import GIT_HEAD, git_clean, git_clone_fast, parse_vcs_url
 
 needs_git_command = pytest.mark.skipif(
     shutil.which("git") is None, reason="requires 'git' command"
@@ -73,6 +73,16 @@ def test_git_clone_fast_submodules(m_run: Mock, tmp_path: pathlib.Path) -> None:
         ],
         cwd=str(tmp_path),
         network_isolation=False,
+    )
+
+
+@patch("fromager.external_commands.run")
+def test_git_clean(m_run: Mock, tmp_path: pathlib.Path) -> None:
+    git_clean(tmp_path)
+
+    m_run.assert_called_once_with(
+        ["git", "clean", "-xdf"],
+        cwd=str(tmp_path),
     )
 
 


### PR DESCRIPTION
# Pull Request Description

## What

add `git_clean` to remove untracked files from a working tree

## Why

Some projects write files when the PEP 517 hook `prepare_metadata_for_build_wheel` is called, e.g. projects that unconditionally compile code in setup.py. Add a `git_clean` wrapper that runs `git clean -xdf` to restore a working tree to a pristine state after such hooks.

- [x] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
