### PR TITLE
build(deps): bump github/codeql-action from 4.36.2 to 4.36.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,8 @@ updates:
     schedule:
       # Check for updates to GitHub Actions once a week
       interval: "weekly"
+    groups:
+      # Group all CodeQL action updates into a single PR
+      codeql:
+        patterns:
+          - "github/codeql-action/*"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
         with:
           languages: ${{ matrix.language }}
 

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -53,6 +53,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
# Pull Request Description

## What

Update all `github/codeql-action` sub-actions to v4.36.3:
- `codeql-action/init` in codeql.yaml
- `codeql-action/upload-sarif` in scorecard.yaml

Also configure dependabot to group all `github/codeql-action/*` updates into a single PR to avoid separate PRs for each sub-action.

## Why

Closes: #1231
Closes: #1234

- [X] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
