### PR TITLE
cleanup(bootstrapper): expose `DEFAULT_BG_THREADS` as public class constant

### DIFF
--- a/src/fromager/bootstrapper/__init__.py
+++ b/src/fromager/bootstrapper/__init__.py
@@ -1,4 +1,3 @@
 from ._bootstrapper import Bootstrapper
-from ._types import _DEFAULT_BG_THREADS
 
-__all__ = ["_DEFAULT_BG_THREADS", "Bootstrapper"]
+__all__ = ["Bootstrapper"]

--- a/src/fromager/bootstrapper/_bootstrapper.py
+++ b/src/fromager/bootstrapper/_bootstrapper.py
@@ -19,6 +19,7 @@ from .. import (
     bootstrap_requirement_resolver,
     progress,
     sources,
+    threading_utils,
 )
 from ..dependency_graph import DependencyGraph
 from ..log import req_ctxvar_context, requirement_ctxvar
@@ -31,7 +32,6 @@ from ._prepare_source import PrepareSource
 from ._process_install_deps import ProcessInstallDeps
 from ._resolve import Resolve
 from ._types import (
-    _DEFAULT_BG_THREADS,
     FailureRecord,
     FailureType,
     SeenKey,
@@ -52,6 +52,8 @@ class Bootstrapper:
     the dependency tree, then ``finalize()`` for cleanup and exit code.
     """
 
+    DEFAULT_BG_THREADS: int = max(1, threading_utils.get_cpu_count() // 2)
+
     def __init__(
         self,
         ctx: context.WorkContext,
@@ -61,7 +63,7 @@ class Bootstrapper:
         sdist_only: bool = False,
         test_mode: bool = False,
         multiple_versions: bool = False,
-        num_bg_threads: int = _DEFAULT_BG_THREADS,
+        num_bg_threads: int = DEFAULT_BG_THREADS,
     ) -> None:
         if test_mode and sdist_only:
             raise ValueError(

--- a/src/fromager/bootstrapper/_types.py
+++ b/src/fromager/bootstrapper/_types.py
@@ -8,15 +8,13 @@ from enum import StrEnum
 
 from packaging.utils import NormalizedName
 
-from .. import build_environment, threading_utils
+from .. import build_environment
 from ..requirements_file import SourceType
 
 logger = logging.getLogger(__name__)
 
 # package name, extras, version, sdist/wheel
 SeenKey = tuple[NormalizedName, tuple[str, ...], str, typing.Literal["sdist", "wheel"]]
-
-_DEFAULT_BG_THREADS: int = max(1, threading_utils.get_cpu_count() // 2)
 
 
 @dataclasses.dataclass

--- a/src/fromager/commands/bootstrap.py
+++ b/src/fromager/commands/bootstrap.py
@@ -20,6 +20,7 @@ from .. import (
     resolver,
     server,
 )
+from ..bootstrapper import Bootstrapper
 from .build import build_parallel
 from .graph import find_why, show_explain_duplicates
 
@@ -120,7 +121,7 @@ def _get_requirements_from_args(
     "--bg-threads",
     "num_bg_threads",
     type=click.IntRange(min=1),
-    default=bootstrapper._DEFAULT_BG_THREADS,
+    default=Bootstrapper.DEFAULT_BG_THREADS,
     show_default=True,
     help="Number of background threads for parallel I/O pre-fetching (min 1).",
 )
@@ -511,7 +512,7 @@ bootstrap._fromager_show_build_settings = True  # type: ignore
     "--bg-threads",
     "num_bg_threads",
     type=click.IntRange(min=1),
-    default=bootstrapper._DEFAULT_BG_THREADS,
+    default=Bootstrapper.DEFAULT_BG_THREADS,
     show_default=True,
     help="Number of background threads for parallel I/O pre-fetching (min 1).",
 )


### PR DESCRIPTION
Make `DEFAULT_BG_THREADS` a public class constant on `Bootstrapper`
instead of a private module-level `_DEFAULT_BG_THREADS` in `_types.py`.
The CLI layer now references `Bootstrapper.DEFAULT_BG_THREADS` for the
`--bg-threads` default, keeping the thread-count knowledge with the
bootstrapper while giving it a clean public API surface.

Closes: https://github.com/python-wheel-build/fromager/issues/1246

