### PR TITLE
refactor(build_environment): add sdist_root_dir and req to BuildEnvironment

### DIFF
--- a/src/fromager/bootstrapper/_prepare_source.py
+++ b/src/fromager/bootstrapper/_prepare_source.py
@@ -155,7 +155,8 @@ class PrepareSource(Phase):
 
         wi.build_env = build_environment.BuildEnvironment(
             ctx=bt.ctx,
-            parent_dir=sdist_root_dir.parent,
+            req=wi.req,
+            sdist_root_dir=sdist_root_dir,
         )
 
         # Get build system dependencies

--- a/src/fromager/build_environment.py
+++ b/src/fromager/build_environment.py
@@ -78,12 +78,35 @@ class BuildEnvironment:
 
     def __init__(
         self,
+        *,
         ctx: context.WorkContext,
-        parent_dir: pathlib.Path,
+        req: Requirement,
+        sdist_root_dir: pathlib.Path,
     ):
+        """Create a build environment for an sdist.
+
+        Args:
+            ctx: the work context
+            req: the requirement being built
+            sdist_root_dir: root directory of the unpacked sdist
+        """
         self._ctx = ctx
-        self.path = parent_dir.absolute() / f"build-{platform.python_version()}"
+        self._req = req
+        self._sdist_root_dir = sdist_root_dir
+        self.path = sdist_root_dir.parent.absolute().joinpath(
+            f"build-{platform.python_version()}"
+        )
         self._createenv()
+
+    @property
+    def sdist_root_dir(self) -> pathlib.Path:
+        """Root directory of the unpacked sdist."""
+        return self._sdist_root_dir
+
+    @property
+    def req(self) -> Requirement:
+        """The requirement being built."""
+        return self._req
 
     @property
     def python(self) -> pathlib.Path:
@@ -257,7 +280,8 @@ def prepare_build_environment(
 
     build_env = BuildEnvironment(
         ctx=ctx,
-        parent_dir=sdist_root_dir.parent,
+        req=req,
+        sdist_root_dir=sdist_root_dir,
     )
 
     build_system_dependencies = dependencies.get_build_system_dependencies(

--- a/src/fromager/commands/step.py
+++ b/src/fromager/commands/step.py
@@ -123,7 +123,8 @@ def build_sdist(
     source_root_dir = _find_source_root_dir(wkctx, wkctx.work_dir, req, dist_version)
     build_env = build_environment.BuildEnvironment(
         ctx=wkctx,
-        parent_dir=source_root_dir.parent,
+        req=req,
+        sdist_root_dir=source_root_dir,
     )
     sdist_filename = sources.build_sdist(
         ctx=wkctx,
@@ -218,7 +219,8 @@ def build_wheel(
     server.start_wheel_server(wkctx)
     build_env = build_environment.BuildEnvironment(
         ctx=wkctx,
-        parent_dir=source_root_dir.parent,
+        req=req,
+        sdist_root_dir=source_root_dir,
     )
     wheel_filename = wheels.build_wheel(
         ctx=wkctx,

--- a/tests/test_bootstrapper_iterative.py
+++ b/tests/test_bootstrapper_iterative.py
@@ -1431,7 +1431,8 @@ class TestPhasePrepareSource:
         assert result[1] is mock_dep_item
         mock_build_env_cls.assert_called_once_with(
             ctx=bt.ctx,
-            parent_dir=sdist_root.parent,
+            req=wi.req,
+            sdist_root_dir=sdist_root,
         )
         mock_create_items.assert_called_once_with(
             wi.build_system_deps,

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -191,9 +191,12 @@ def test_get_build_backend_dependencies(
     tmp_context.wheel_server_url = "https://pypi.org/simple"
 
     req = Requirement("fromager")
+    sdist_root = tmp_path / "fromager-1.0.0"
+    sdist_root.mkdir()
     build_env = build_environment.BuildEnvironment(
         ctx=tmp_context,
-        parent_dir=tmp_path,
+        req=req,
+        sdist_root_dir=sdist_root,
     )
     build_system_dependencies = dependencies.get_build_system_dependencies(
         ctx=tmp_context,
@@ -223,9 +226,11 @@ def test_get_build_backend_dependencies_cached(
     req_file = tmp_path / "build-backend-requirements.txt"
     req_file.write_text("foo==1.0")
 
+    req = Requirement("fromager")
     build_env = build_environment.BuildEnvironment(
         ctx=tmp_context,
-        parent_dir=tmp_path,
+        req=req,
+        sdist_root_dir=sdist_root_dir,
     )
     results = dependencies.get_build_backend_dependencies(
         ctx=tmp_context,
@@ -249,9 +254,12 @@ def test_get_build_sdist_dependencies(
     tmp_context.wheel_server_url = "https://pypi.org/simple"
 
     req = Requirement("fromager")
+    sdist_root = tmp_path / "fromager-1.0.0"
+    sdist_root.mkdir()
     build_env = build_environment.BuildEnvironment(
         ctx=tmp_context,
-        parent_dir=tmp_path,
+        req=req,
+        sdist_root_dir=sdist_root,
     )
     build_system_dependencies = dependencies.get_build_system_dependencies(
         ctx=tmp_context,
@@ -284,7 +292,8 @@ def test_get_build_sdist_dependencies_cached(
     req = Requirement("fromager")
     build_env = build_environment.BuildEnvironment(
         ctx=tmp_context,
-        parent_dir=tmp_path,
+        req=req,
+        sdist_root_dir=sdist_root_dir,
     )
     results = dependencies.get_build_sdist_dependencies(
         ctx=tmp_context,

--- a/tests/test_packagesettings.py
+++ b/tests/test_packagesettings.py
@@ -322,9 +322,12 @@ def test_pbi_test_pkg_extra_environ(
     )
     assert "__version__" not in result
 
+    sdist_root = tmp_path / "test-pkg-1.0.0"
+    sdist_root.mkdir()
     build_env = build_environment.BuildEnvironment(
-        testdata_context,
-        parent_dir=tmp_path,
+        ctx=testdata_context,
+        req=Requirement("test-pkg"),
+        sdist_root_dir=sdist_root,
     )
     result = pbi.get_extra_environ(
         template_env={"EXTRA": "spam", "PATH": "/sbin:/bin"},

--- a/tests/test_wheels.py
+++ b/tests/test_wheels.py
@@ -18,9 +18,12 @@ def test_default_build_wheel(
     testdata_context: context.WorkContext,
 ) -> None:
     req = Requirement("test_pkg")
+    sdist_root = tmp_path / "test_pkg-1.0"
+    sdist_root.mkdir()
     build_env = build_environment.BuildEnvironment(
         ctx=testdata_context,
-        parent_dir=tmp_path,
+        req=req,
+        sdist_root_dir=sdist_root,
     )
     pbi = testdata_context.package_build_info(req)
     assert pbi.config_settings


### PR DESCRIPTION
# Pull Request Description

## What

Replace the generic `parent_dir` parameter with `sdist_root_dir` and `req` so that `BuildEnvironment` has the context it needs for future sandboxing and environment filtering. All arguments are now keyword-only and follow the common `ctx, req, sdist_root_dir` order.

## Why

Part of the sandboxing proposal.

See: #1019

- [X] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
