### PR TITLE
Apply zizmor hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,5 @@ updates:
       codeql:
         patterns:
           - "github/codeql-action/*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
@@ -38,6 +39,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
@@ -59,6 +61,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0

--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -24,6 +24,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      with:
+        persist-credentials: false
       # with:
       #   fetch-depth: 0
     - name: Set up Python
@@ -39,4 +41,4 @@ jobs:
         python -m build
     - name: Publish distribution to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Get source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
@@ -36,11 +38,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Rust ${{ matrix.rust-version }}
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af  # v1
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
         with:
           toolchain: ${{ matrix.rust-version }}
-          default: true
-          override: true
 
       - name: Disable AppArmor restriction for unprivileged user namespaces
         if: matrix.os == 'ubuntu-latest'
@@ -103,6 +103,8 @@ jobs:
     steps:
       - name: Get source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
@@ -110,11 +112,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Rust ${{ matrix.rust-version }}
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af  # v1
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c  # master
         with:
           toolchain: ${{ matrix.rust-version }}
-          default: true
-          override: true
 
       - name: Disable AppArmor restriction for unprivileged user namespaces
         if: matrix.os == 'ubuntu-latest'
@@ -161,6 +161,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6


### PR DESCRIPTION
# Pull Request Description

## What

Zizmor is a static analyzer for CI/CD configuration. It can detect and fix issues in GHA configuration. Run [zizmor](https://docs.zizmor.sh/) and apply all fixers to harden GitHub Actions:

```raw
help[artipacked]: credential persistence through GitHub Actions artifacts
warning[archived-uses]: action or reusable workflow from archived repository
warning[dependabot-cooldown]: insufficient cooldown in Dependabot updates
```

Replace archived `actions-rs/toolchain` with `dtolnay/rust-toolchain`, which is also used by pyca/cryptography.

## Why

Improve security of GHA

- [X] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
