### PR TITLE
fix: Reformat code with Ruff 0.16.0

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -15,8 +15,10 @@ places use the normalized, *canonical name*.
 ```python
 import re
 
+
 def canonicalize_name(name: str) -> NormalizedName:
     return re.sub(r"[-_.]+", "-", name).lower()
+
 
 def override_name(name: str | NormalizedName) -> str:
     return canonicalize_name(name).replace("-", "_")
@@ -456,9 +458,7 @@ def prebuilt_wheel(
     dist_version: str,
     wheel_filename: pathlib.Path,
 ):
-    logger.info(
-        f"{req.name}: running prebuilt wheel hook for {wheel_filename}"
-    )
+    logger.info(f"{req.name}: running prebuilt wheel hook for {wheel_filename}")
 ```
 
 ### post_bootstrap
@@ -515,14 +515,14 @@ mycommand = "mypackage.module:mycommand"
 import click
 from fromager import context
 
+
 @click.command()
 @click.argument("example")
 @click.pass_obj
 def mycommand(
     wkctx: context.WorkContext,
     example: str,
-) -> None:
-    ...
+) -> None: ...
 ```
 
 ## See Also

--- a/docs/http-retry.md
+++ b/docs/http-retry.md
@@ -90,8 +90,10 @@ To register authentication for additional hosts:
 ```python
 from fromager.request_session import session_auth
 
+
 def _resolve_my_auth(scheme: str, hostname: str) -> dict[str, str]:
     return {"Authorization": "Bearer my-token"}
+
 
 session_auth.add("https://my-registry.test", _resolve_my_auth)
 ```
@@ -102,6 +104,7 @@ For functions that might fail due to transient errors:
 
 ```python
 from fromager.http_retry import retry_on_exception, RETRYABLE_EXCEPTIONS
+
 
 @retry_on_exception(
     exceptions=RETRYABLE_EXCEPTIONS,

--- a/docs/proposals/new-resolver-config.md
+++ b/docs/proposals/new-resolver-config.md
@@ -196,19 +196,24 @@ from fromager import context, resolver
 from packaging.version import Version
 
 
-def matcher_factory_pat(ctx: context.WorkContext) -> re.Pattern | resolver.MatchFunction:
+def matcher_factory_pat(
+    ctx: context.WorkContext,
+) -> re.Pattern | resolver.MatchFunction:
     # tag must match 'v1.2+midstream.1.cpu' and results in Version("1.2+midstream.1")
     variant = re.escape(ctx.variant)
     pat = rf"^v(.*\+midstream\.\d+)\.{variant}$"
     return re.compile(pat)
 
 
-def matcher_factory_func(ctx: context.WorkContext) -> re.Pattern | resolver.MatchFunction:
+def matcher_factory_func(
+    ctx: context.WorkContext,
+) -> re.Pattern | resolver.MatchFunction:
     def pep440_matcher(identifier: str, item: str) -> Version | None:
         try:
             return Version(item)
         except ValueError:
             return None
+
     return pep440_matcher
 ```
 

--- a/docs/proposals/wheel-build-tag-hook.md
+++ b/docs/proposals/wheel-build-tag-hook.md
@@ -86,8 +86,7 @@ def build_tag_hook(
     req: Requirement,
     version: Version,
     wheel_tags: frozenset[Tag],
-) -> typing.Sequence[str]:
-    ...
+) -> typing.Sequence[str]: ...
 ```
 
 The hook returns `typing.Sequence[str]`, a sequence of suffix segments

--- a/src/fromager/packagesettings/_pbi.py
+++ b/src/fromager/packagesettings/_pbi.py
@@ -48,7 +48,7 @@ class PackageBuildInfo:
         self._variant_changelog = settings.variant_changelog()
         self._max_jobs: int | None = settings.max_jobs
         self._ps = ps
-        self._plugin_module: types.ModuleType | None | typing.Literal[False] = False
+        self._plugin_module: types.ModuleType | typing.Literal[False] | None = False
         self._patches: PatchMap | None = None
         self._annotations: Annotations | None = None
 


### PR DESCRIPTION
# Pull Request Description

## What

Reformat code with latest Ruff. Ruff 0.16.0 enables more checkers by default and can now format code in Markdown files, too.

## Why

See https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md

- [X] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
