### PR TITLE
feat(build_environment): Include abiflags in path

### DIFF
--- a/src/fromager/build_environment.py
+++ b/src/fromager/build_environment.py
@@ -93,8 +93,9 @@ class BuildEnvironment:
         self._ctx = ctx
         self._req = req
         self._sdist_root_dir = sdist_root_dir
+        # abiflags adds 't' for free-threaded (nogil) builds
         self.path = sdist_root_dir.parent.absolute().joinpath(
-            f"build-{platform.python_version()}"
+            f"build-{platform.python_version()}{sys.abiflags}"
         )
         self._createenv()
 


### PR DESCRIPTION
# Pull Request Description

## What
Include abiflags in build env path for free-threading (nogil) Python interpreter.

## Why

Python 3.14 and 3.14t have different ABIs and need separate build environments

- [x] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
