### PR TITLE
cleanup(bootstrapper): remove unused logger from `_types.py`

### DIFF
--- a/src/fromager/bootstrapper/_types.py
+++ b/src/fromager/bootstrapper/_types.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import dataclasses
-import logging
 import pathlib
 import typing
 from enum import StrEnum
@@ -10,8 +9,6 @@ from packaging.utils import NormalizedName
 
 from .. import build_environment
 from ..requirements_file import SourceType
-
-logger = logging.getLogger(__name__)
 
 # package name, extras, version, sdist/wheel
 SeenKey = tuple[NormalizedName, tuple[str, ...], str, typing.Literal["sdist", "wheel"]]


### PR DESCRIPTION
The `logging` import and `logger` definition were carried over when types were extracted from the monolithic `bootstrapper.py` into `_types.py` in #1226 but are never used.

Closes: #1245

