### PR TITLE
refactor(build_environment): use `self.run()` in `_createenv()`

### DIFF
--- a/src/fromager/build_environment.py
+++ b/src/fromager/build_environment.py
@@ -206,10 +206,7 @@ class BuildEnvironment:
             "--no-project",
             str(self.path),
         ]
-        external_commands.run(
-            cmd,
-            network_isolation=self._ctx.network_isolation,
-        )
+        self.run(cmd)
         logger.info("created build environment in %s", self.path)
 
     def install(self, reqs: typing.Iterable[Requirement]) -> None:


### PR DESCRIPTION
`_createenv()` called `external_commands.run()` directly while every other method uses `self.run()`, duplicating ctx-access logic for `network_isolation`. The `--python` CLI flag passed to `uv venv` takes precedence over `UV_PYTHON` set by `get_venv_environ()`, so the swap is safe.

Having a single entry point for command execution simplifies auditing and future cross-cutting changes like environment filtering or network policy enforcement.

Closes: #1276

# Pull Request Description

## What

<!-- Brief description of the change. -->

## Why

<!-- Link to issue (Closes #NNN) or explain the motivation. -->

- [ ] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
