### PR TITLE
feat(external_commands): wire `ExternalCommands` env filtering into `run()`

### DIFF
--- a/src/fromager/build_environment.py
+++ b/src/fromager/build_environment.py
@@ -186,6 +186,7 @@ class BuildEnvironment:
             cwd=cwd,
             extra_environ=extra_environ,
             network_isolation=network_isolation,
+            env_filter=self._ctx.settings.external_commands,
             log_filename=log_filename,
             stdin=stdin,
         )
@@ -209,6 +210,7 @@ class BuildEnvironment:
         external_commands.run(
             cmd,
             network_isolation=self._ctx.network_isolation,
+            env_filter=self._ctx.settings.external_commands,
         )
         logger.info("created build environment in %s", self.path)
 

--- a/src/fromager/context.py
+++ b/src/fromager/context.py
@@ -154,7 +154,11 @@ class WorkContext:
         req_list: list[str] = sorted(set(req.name for req in reqs))
         logger.debug("invalidate uv cache for %s", req_list)
         cmd.extend(req_list)
-        external_commands.run(cmd, extra_environ=extra_environ)
+        external_commands.run(
+            cmd,
+            extra_environ=extra_environ,
+            env_filter=self.settings.external_commands,
+        )
 
     def package_build_info(
         self, package: str | packagesettings.Package | Requirement

--- a/src/fromager/dependencies.py
+++ b/src/fromager/dependencies.py
@@ -554,6 +554,7 @@ def get_build_backend_hook_caller(
             cwd=cwd,
             extra_environ=extra_environ,
             network_isolation=ctx.network_isolation,
+            env_filter=ctx.settings.external_commands,
             log_filename=log_filename,
         )
 

--- a/src/fromager/external_commands.py
+++ b/src/fromager/external_commands.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import pathlib
@@ -8,6 +10,9 @@ import typing
 from io import TextIOWrapper
 
 from . import log
+
+if typing.TYPE_CHECKING:
+    from . import packagesettings
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +60,7 @@ def run(
     cwd: str | None = None,
     extra_environ: dict[str, typing.Any] | None = None,
     network_isolation: bool = False,
+    env_filter: packagesettings.ExternalCommands | None = None,
     log_filename: str | None = None,
     stdin: TextIOWrapper | None = None,
 ) -> str:
@@ -64,10 +70,16 @@ def run(
     line with the current package name for easier searching. Raises
     ``NetworkIsolationError`` instead of ``CalledProcessError`` when the
     failure output indicates a network access problem.
+
+    When *env_filter* is not ``None``, ``os.environ`` is filtered through
+    ``ExternalCommands.filter_env()`` before *extra_environ* is applied.
+    Variables injected via *extra_environ* are never filtered.
     """
     if extra_environ is None:
         extra_environ = {}
     env = os.environ.copy()
+    if env_filter is not None:
+        env = dict(env_filter.filter_env(env))
     env.update(extra_environ)
 
     if network_isolation:

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -281,6 +281,7 @@ def add_extra_metadata_to_wheels(
             cmd,
             cwd=dir_name,
             network_isolation=ctx.network_isolation,
+            env_filter=ctx.settings.external_commands,
         )
 
     wheel_file.unlink(missing_ok=True)

--- a/tests/test_external_commands.py
+++ b/tests/test_external_commands.py
@@ -9,7 +9,7 @@ import pytest
 from packaging.requirements import Requirement
 from packaging.version import Version
 
-from fromager import external_commands, log
+from fromager import external_commands, log, packagesettings
 
 
 def test_external_commands_environ() -> None:
@@ -176,3 +176,65 @@ def test_format_exception_formats_chained_exceptions() -> None:
         assert "Higher level error" in formatted
         assert "because" in formatted
         assert "Root cause" in formatted
+
+
+# --- env_filter wiring tests ---
+
+
+@mock.patch("subprocess.run", return_value=mock.Mock(returncode=0, stdout=b""))
+@mock.patch.dict(os.environ, {"HOME": "/h", "SECRET": "s"}, clear=True)
+def test_run_env_filter_none_passes_full_environ(m_run: mock.Mock) -> None:
+    """Without env_filter, the full os.environ is passed to the subprocess."""
+    external_commands.run(["true"])
+    call_env = m_run.call_args.kwargs["env"]
+    assert call_env["HOME"] == "/h"
+    assert call_env["SECRET"] == "s"
+
+
+@mock.patch("subprocess.run", return_value=mock.Mock(returncode=0, stdout=b""))
+@mock.patch.dict(os.environ, {"HOME": "/h", "SECRET": "s"}, clear=True)
+def test_run_env_filter_strips_deleted_vars(m_run: mock.Mock) -> None:
+    """With env_filter configured, deleted vars are stripped from the env."""
+    env_filter = packagesettings.ExternalCommands(delete_env=["*"])
+    external_commands.run(["true"], env_filter=env_filter)
+    call_env = m_run.call_args.kwargs["env"]
+    assert call_env["HOME"] == "/h"
+    assert "SECRET" not in call_env
+
+
+@mock.patch("subprocess.run", return_value=mock.Mock(returncode=0, stdout=b""))
+@mock.patch.dict(os.environ, {"HOME": "/h", "SECRET": "s"}, clear=True)
+def test_run_env_filter_extra_environ_survives(m_run: mock.Mock) -> None:
+    """extra_environ values are applied after filtering and never stripped."""
+    env_filter = packagesettings.ExternalCommands(delete_env=["*"])
+    external_commands.run(
+        ["true"],
+        extra_environ={"MY_BUILD_VAR": "42"},
+        env_filter=env_filter,
+    )
+    call_env = m_run.call_args.kwargs["env"]
+    assert call_env["MY_BUILD_VAR"] == "42"
+    assert "SECRET" not in call_env
+
+
+@mock.patch("subprocess.run", return_value=mock.Mock(returncode=0, stdout=b""))
+@mock.patch.dict(os.environ, {"HOME": "/h", "CI_TOKEN": "t", "USER": "u"}, clear=True)
+def test_run_env_filter_selective_delete(m_run: mock.Mock) -> None:
+    """Selective delete_env removes only matching vars."""
+    env_filter = packagesettings.ExternalCommands(delete_env=["CI_TOKEN"])
+    external_commands.run(["true"], env_filter=env_filter)
+    call_env = m_run.call_args.kwargs["env"]
+    assert call_env["HOME"] == "/h"
+    assert call_env["USER"] == "u"
+    assert "CI_TOKEN" not in call_env
+
+
+@mock.patch("subprocess.run", return_value=mock.Mock(returncode=0, stdout=b""))
+@mock.patch.dict(os.environ, {"HOME": "/h", "SECRET": "s"}, clear=True)
+def test_run_env_filter_default_is_noop(m_run: mock.Mock) -> None:
+    """Default ExternalCommands (empty lists) passes all POSIX-valid vars."""
+    env_filter = packagesettings.ExternalCommands()
+    external_commands.run(["true"], env_filter=env_filter)
+    call_env = m_run.call_args.kwargs["env"]
+    assert call_env["HOME"] == "/h"
+    assert call_env["SECRET"] == "s"


### PR DESCRIPTION
Add `env_filter` parameter to `external_commands.run()` and thread it through all call sites that execute untrusted third-party code (PEP 517 build hooks, wheel metadata) and  uv cache invalidation.

`os.environ` is filtered through `ExternalCommands.filter_env()` before `extra_environ` is applied, ensuring injected build variables are never stripped.

Closes: #1083 

# Pull Request Description

## What

<!-- Brief description of the change. -->

## Why

<!-- Link to issue (Closes #NNN) or explain the motivation. -->

- [x] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
