### PR TITLE
fix: skip tests and CodeQL for doc-only changes

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -7,9 +7,19 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '*.rst'
+      - 'LICENSE'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '*.rst'
+      - 'LICENSE'
   schedule:
     # Run weekly on Monday at 02:00 UTC
     - cron: "0 2 * * 1"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,11 @@
 name: CI
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '*.rst'
+      - 'LICENSE'
 
 permissions:
   contents: read


### PR DESCRIPTION
Add paths-ignore for docs/** to test.yaml and codeql.yaml so that doc-only PRs no longer trigger the full CI matrix (unit tests, e2e tests, CodeQL analysis). check.yaml is left unchanged since it runs the Sphinx docs build that validates proposal files.


Closes: #1230

# Pull Request Description

## What

<!-- Brief description of the change. -->

## Why

<!-- Link to issue (Closes #NNN) or explain the motivation. -->

- [x] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
