### PR TITLE
fix(build): set CARGO_TARGET_DIR per package to prevent parallel build collisions

### DIFF
--- a/src/fromager/vendor_rust.py
+++ b/src/fromager/vendor_rust.py
@@ -115,6 +115,18 @@ def _detect_rust_build_backend(
     return None
 
 
+def has_rust_build_backend(req: Requirement, project_dir: pathlib.Path) -> bool:
+    """Return ``True`` if the project uses a Rust build backend.
+
+    Checks whether the project's ``pyproject.toml`` declares ``maturin``
+    or ``setuptools-rust`` as its build backend.
+    """
+    pyproject_toml = dependencies.get_pyproject_contents(project_dir)
+    if not pyproject_toml:
+        return False
+    return _detect_rust_build_backend(req, pyproject_toml) is not None
+
+
 def vendor_generic_rust_package(
     req: Requirement,
     manifests: list[pathlib.Path],

--- a/src/fromager/wheels.py
+++ b/src/fromager/wheels.py
@@ -30,6 +30,7 @@ from . import (
     requirements_file,
     resolver,
     sbom,
+    vendor_rust,
 )
 from .pkgmetadata.pep376 import verbatim_dist_name
 
@@ -333,6 +334,12 @@ def build_wheel(
         version=version,
         build_env=build_env,
     )
+
+    # Isolate Rust build artifacts per package to prevent CARGO_TARGET_DIR
+    # collisions during parallel builds and EXDEV (cross-device rename)
+    # failures.
+    if vendor_rust.has_rust_build_backend(req, sdist_root_dir):
+        extra_environ.setdefault("CARGO_TARGET_DIR", str(sdist_root_dir / "target"))
 
     if pbi.build_ext_parallel:
         logger.warning(

--- a/tests/test_vendor_rust.py
+++ b/tests/test_vendor_rust.py
@@ -1,0 +1,43 @@
+import pathlib
+
+from packaging.requirements import Requirement
+
+from fromager import vendor_rust
+
+
+def test_has_rust_build_backend_maturin(tmp_path: pathlib.Path) -> None:
+    """Detect maturin as a Rust build backend."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[build-system]\nrequires = ["maturin>=1.0"]\nbuild-backend = "maturin"\n'
+    )
+    req = Requirement("some-rust-pkg")
+    assert vendor_rust.has_rust_build_backend(req, tmp_path) is True
+
+
+def test_has_rust_build_backend_setuptools_rust(tmp_path: pathlib.Path) -> None:
+    """Detect setuptools-rust as a Rust build backend."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[build-system]\nrequires = ["setuptools", "setuptools-rust"]\n'
+        'build-backend = "setuptools.build_meta"\n'
+    )
+    req = Requirement("some-rust-pkg")
+    assert vendor_rust.has_rust_build_backend(req, tmp_path) is True
+
+
+def test_has_rust_build_backend_pure_python(tmp_path: pathlib.Path) -> None:
+    """Pure Python packages return False."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[build-system]\nrequires = ["setuptools"]\n'
+        'build-backend = "setuptools.build_meta"\n'
+    )
+    req = Requirement("pure-python-pkg")
+    assert vendor_rust.has_rust_build_backend(req, tmp_path) is False
+
+
+def test_has_rust_build_backend_no_pyproject(tmp_path: pathlib.Path) -> None:
+    """No pyproject.toml returns False."""
+    req = Requirement("legacy-pkg")
+    assert vendor_rust.has_rust_build_backend(req, tmp_path) is False

--- a/tests/test_wheels.py
+++ b/tests/test_wheels.py
@@ -337,3 +337,123 @@ def test_validate_wheel_file(
     else:
         with pytest.raises(ValueError):
             wheels.validate_wheel_filename(req, version, wheel_file)
+
+
+@patch("fromager.wheels.add_extra_metadata_to_wheels")
+@patch("fromager.wheels.overrides.find_and_invoke")
+@patch("fromager.wheels.vendor_rust.has_rust_build_backend", return_value=True)
+@patch("fromager.wheels.packagesettings.get_extra_environ", return_value={})
+def test_build_wheel_sets_cargo_target_dir_for_rust_packages(
+    mock_get_extra_environ: Mock,
+    mock_has_rust: Mock,
+    mock_find_and_invoke: Mock,
+    mock_add_metadata: Mock,
+    tmp_path: pathlib.Path,
+    tmp_context: context.WorkContext,
+) -> None:
+    """CARGO_TARGET_DIR is set per package for Rust builds."""
+    req = Requirement("some-rust-pkg==1.0.0")
+    sdist_root = tmp_path / "some_rust_pkg-1.0.0"
+    sdist_root.mkdir()
+    build_env = build_environment.BuildEnvironment(
+        ctx=tmp_context,
+        req=req,
+        sdist_root_dir=sdist_root,
+    )
+
+    wheel_file = tmp_context.wheels_build / "some_rust_pkg-1.0.0-py3-none-any.whl"
+    wheel_file.parent.mkdir(parents=True, exist_ok=True)
+    wheel_file.touch()
+    mock_add_metadata.return_value = wheel_file
+
+    wheels.build_wheel(
+        ctx=tmp_context,
+        req=req,
+        sdist_root_dir=sdist_root,
+        version=Version("1.0.0"),
+        build_env=build_env,
+    )
+
+    extra_environ = mock_find_and_invoke.call_args.kwargs["extra_environ"]
+    assert extra_environ["CARGO_TARGET_DIR"] == str(sdist_root / "target")
+
+
+@patch("fromager.wheels.add_extra_metadata_to_wheels")
+@patch("fromager.wheels.overrides.find_and_invoke")
+@patch("fromager.wheels.vendor_rust.has_rust_build_backend", return_value=True)
+@patch(
+    "fromager.wheels.packagesettings.get_extra_environ",
+    return_value={"CARGO_TARGET_DIR": "/custom/target"},
+)
+def test_build_wheel_does_not_override_explicit_cargo_target_dir(
+    mock_get_extra_environ: Mock,
+    mock_has_rust: Mock,
+    mock_find_and_invoke: Mock,
+    mock_add_metadata: Mock,
+    tmp_path: pathlib.Path,
+    tmp_context: context.WorkContext,
+) -> None:
+    """Per-package CARGO_TARGET_DIR from settings takes precedence."""
+    req = Requirement("some-rust-pkg==1.0.0")
+    sdist_root = tmp_path / "some_rust_pkg-1.0.0"
+    sdist_root.mkdir()
+    build_env = build_environment.BuildEnvironment(
+        ctx=tmp_context,
+        req=req,
+        sdist_root_dir=sdist_root,
+    )
+
+    wheel_file = tmp_context.wheels_build / "some_rust_pkg-1.0.0-py3-none-any.whl"
+    wheel_file.parent.mkdir(parents=True, exist_ok=True)
+    wheel_file.touch()
+    mock_add_metadata.return_value = wheel_file
+
+    wheels.build_wheel(
+        ctx=tmp_context,
+        req=req,
+        sdist_root_dir=sdist_root,
+        version=Version("1.0.0"),
+        build_env=build_env,
+    )
+
+    extra_environ = mock_find_and_invoke.call_args.kwargs["extra_environ"]
+    assert extra_environ["CARGO_TARGET_DIR"] == "/custom/target"
+
+
+@patch("fromager.wheels.add_extra_metadata_to_wheels")
+@patch("fromager.wheels.overrides.find_and_invoke")
+@patch("fromager.wheels.vendor_rust.has_rust_build_backend", return_value=False)
+@patch("fromager.wheels.packagesettings.get_extra_environ", return_value={})
+def test_build_wheel_skips_cargo_target_dir_for_non_rust_packages(
+    mock_get_extra_environ: Mock,
+    mock_has_rust: Mock,
+    mock_find_and_invoke: Mock,
+    mock_add_metadata: Mock,
+    tmp_path: pathlib.Path,
+    tmp_context: context.WorkContext,
+) -> None:
+    """Non-Rust packages do not get CARGO_TARGET_DIR."""
+    req = Requirement("pure-python-pkg==1.0.0")
+    sdist_root = tmp_path / "pure_python_pkg-1.0.0"
+    sdist_root.mkdir()
+    build_env = build_environment.BuildEnvironment(
+        ctx=tmp_context,
+        req=req,
+        sdist_root_dir=sdist_root,
+    )
+
+    wheel_file = tmp_context.wheels_build / "pure_python_pkg-1.0.0-py3-none-any.whl"
+    wheel_file.parent.mkdir(parents=True, exist_ok=True)
+    wheel_file.touch()
+    mock_add_metadata.return_value = wheel_file
+
+    wheels.build_wheel(
+        ctx=tmp_context,
+        req=req,
+        sdist_root_dir=sdist_root,
+        version=Version("1.0.0"),
+        build_env=build_env,
+    )
+
+    extra_environ = mock_find_and_invoke.call_args.kwargs["extra_environ"]
+    assert "CARGO_TARGET_DIR" not in extra_environ


### PR DESCRIPTION


When multiple Rust/maturin packages build in parallel via `ThreadPoolExecutor`, a shared `CARGO_TARGET_DIR` (inherited from the process environment) causes cargo to write intermediate artifacts to the same directory. This leads to collisions — e.g. two packages declaring `#[pyclass(generic)]` overwrite each other's build outputs.

Set `CARGO_TARGET_DIR` to `sdist_root_dir / "target"` for every package that uses a Rust build backend (maturin or setuptools-rust). Each package already has its own `sdist_root_dir`, so this isolates cargo artifacts per package. Using `setdefault` preserves any explicit override from per-package settings.

This also prevents EXDEV (cross-device rename) failures when cargo's target dir is on a different filesystem than the source tree.

Adds `has_rust_build_backend()` public helper to `vendor_rust` module.

Closes: #1300

