### PR TITLE
fix(tooling): protect Codex skill frontmatter from mdformat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,8 @@ repos:
     rev: 1.0.0
     hooks:
       - id: mdformat
+        # mdformat treats Agent Skill YAML frontmatter as Markdown content.
+        exclude: ^\.agents/skills/.*/SKILL\.md$
         additional_dependencies:
           - mdformat-gfm  # GitHub Flavored Markdown support (tables, autolinks, etc.)
           - mdformat-simple-breaks  # Use --- for thematic breaks instead of 70 underscores


### PR DESCRIPTION
Exclude Codex SKILL.md files because mdformat rewrites their YAML frontmatter and breaks skill discovery.

Closes: #1312

- [x] PR follows [CONTRIBUTING.md](https://github.com/python-wheel-build/fromager/blob/main/CONTRIBUTING.md) guidelines
