### PR TITLE
feat(bootstrapper): write partial-failures.json for multi-version mode

### DIFF
--- a/src/fromager/bootstrapper/_bootstrapper.py
+++ b/src/fromager/bootstrapper/_bootstrapper.py
@@ -124,7 +124,8 @@ class Bootstrapper:
         self.failed_packages: list[FailureRecord] = []
 
         # Track failed versions in multiple_versions mode
-        self._failed_versions: dict[tuple[str, str], Exception] = {}
+        # Maps (package_name, version) -> (exception, detail)
+        self._failed_versions: dict[tuple[str, str], tuple[Exception, str]] = {}
 
     @property
     def resolver(self) -> bootstrap_requirement_resolver.BootstrapRequirementResolver:
@@ -1001,6 +1002,13 @@ class Bootstrapper:
             self.record_test_mode_failure(
                 wi.req, str(wi.resolved_version), err, "bootstrap"
             )
+            if self.multiple_versions:
+                self._record_failed_version(
+                    wi.req,
+                    str(wi.resolved_version),
+                    err,
+                    f"failed during {type(item).phase} phase",
+                )
             return []
 
         # Multiple versions mode: record failure, remove from graph, continue
@@ -1035,7 +1043,7 @@ class Bootstrapper:
     ) -> None:
         """Record a version failure in multiple versions mode."""
         pkg_name = canonicalize_name(req.name)
-        self._failed_versions[(pkg_name, version)] = err
+        self._failed_versions[(pkg_name, version)] = (err, detail)
         logger.warning(
             "%s==%s: %s: %s: %s",
             req.name,
@@ -1048,8 +1056,38 @@ class Bootstrapper:
     def _log_failed_versions_table(self) -> None:
         """Log a summary table of all failed versions."""
         logger.warning("%d version(s) failed to bootstrap:", len(self._failed_versions))
-        for (name, ver), exc in self._failed_versions.items():
+        for (name, ver), (exc, _detail) in self._failed_versions.items():
             logger.warning("  %s==%s: %s: %s", name, ver, type(exc).__name__, exc)
+
+    def _write_partial_failures_report(self) -> None:
+        """Write a JSON report of multi-version bootstrap failures.
+
+        Produces a ``partial-failures.json`` file in the work directory
+        so that downstream analysis tools can detect soft failures in
+        jobs that exited successfully.
+        """
+        failures_file = self.ctx.work_dir / "partial-failures.json"
+        failures = sorted(
+            [
+                {
+                    "name": name if ver == "unresolved" else f"{name}=={ver}",
+                    "version": None if ver == "unresolved" else ver,
+                    "phase": detail,
+                    "error_type": type(exc).__name__,
+                    "message": str(exc),
+                }
+                for (name, ver), (exc, detail) in self._failed_versions.items()
+            ],
+            key=lambda f: f["name"] or "",
+        )
+        with open(failures_file, "w") as f:
+            json.dump({"failures": failures}, f, indent=2)
+            f.write("\n")
+        logger.info(
+            "multi-version: wrote %d failure(s) to %s",
+            len(failures),
+            failures_file,
+        )
 
     def finalize(self) -> int:
         """Finalize bootstrap and return exit code.
@@ -1089,6 +1127,9 @@ class Bootstrapper:
 
         if self.multiple_versions and self._failed_versions:
             self._log_failed_versions_table()
+            self._write_partial_failures_report()
+        else:
+            (self.ctx.work_dir / "partial-failures.json").unlink(missing_ok=True)
 
         if not self.test_mode:
             return 0

--- a/src/fromager/resolver.py
+++ b/src/fromager/resolver.py
@@ -1181,7 +1181,7 @@ class GitHubTagProvider(GenericProvider):
         identifier: str,
     ) -> Iterable[Candidate]:
         headers = {"accept": "application/vnd.github+json"}
-        nexturl = self.api_url.format(self=self)
+        nexturl: str | None = self.api_url.format(self=self)
         while nexturl:
             resp = session.get(nexturl, headers=headers)
             resp.raise_for_status()
@@ -1288,7 +1288,7 @@ class GitLabTagProvider(GenericProvider):
         self,
         identifier: str,
     ) -> Iterable[Candidate]:
-        nexturl: str = self.api_url
+        nexturl: str | None = self.api_url
         created_at: datetime.datetime | None
         project_name = self.project_path.split("/")[-1]
         if self.override_download_url is None:

--- a/tests/test_bootstrapper.py
+++ b/tests/test_bootstrapper.py
@@ -426,9 +426,10 @@ def test_multiple_versions_continues_on_error(tmp_context: WorkContext) -> None:
                 pkg_name = canonicalize_name("testpkg")
                 version_str = "1.5"
                 assert (pkg_name, version_str) in bt._failed_versions
-                exc = bt._failed_versions[(pkg_name, version_str)]
+                exc, detail = bt._failed_versions[(pkg_name, version_str)]
                 assert isinstance(exc, ValueError)
                 assert str(exc) == "Simulated failure for version 1.5"
+                assert "failed during" in detail
 
         # Verify that failed version 1.5 is NOT in the dependency graph
         failed_key = f"{canonicalize_name('testpkg')}==1.5"
@@ -1231,3 +1232,95 @@ def test_resolve_versions_rejects_url_requirement(
     bs = bootstrapper.Bootstrapper(tmp_context)
     with pytest.raises(ValueError, match="no longer supported"):
         bs.resolve_versions(req=req, req_type=RequirementType.TOP_LEVEL)
+
+
+class TestPartialFailuresReport:
+    """Test partial-failures.json generation for multi-version mode."""
+
+    def test_finalize_writes_partial_failures(self, tmp_context: WorkContext) -> None:
+        bt = bootstrapper.Bootstrapper(tmp_context, multiple_versions=True)
+        bt._failed_versions = {
+            ("pkg-a", "1.0"): (ValueError("build failed"), "failed during build phase"),
+            ("pkg-b", "2.0"): (RuntimeError("timeout"), "failed to resolve"),
+        }
+
+        assert bt.finalize() == 0
+
+        report = tmp_context.work_dir / "partial-failures.json"
+        assert report.exists()
+        data = json.loads(report.read_text())
+        assert len(data["failures"]) == 2
+        assert data["failures"][0] == {
+            "name": "pkg-a==1.0",
+            "version": "1.0",
+            "phase": "failed during build phase",
+            "error_type": "ValueError",
+            "message": "build failed",
+        }
+        assert data["failures"][1] == {
+            "name": "pkg-b==2.0",
+            "version": "2.0",
+            "phase": "failed to resolve",
+            "error_type": "RuntimeError",
+            "message": "timeout",
+        }
+
+    def test_finalize_includes_unresolved_failures(
+        self, tmp_context: WorkContext
+    ) -> None:
+        bt = bootstrapper.Bootstrapper(tmp_context, multiple_versions=True)
+        bt._failed_versions = {
+            ("somepkg", "unresolved"): (
+                RuntimeError("no versions found for somepkg"),
+                "failed to resolve",
+            ),
+        }
+
+        assert bt.finalize() == 0
+
+        report = tmp_context.work_dir / "partial-failures.json"
+        assert report.exists()
+        data = json.loads(report.read_text())
+        assert len(data["failures"]) == 1
+        assert data["failures"][0] == {
+            "name": "somepkg",
+            "version": None,
+            "phase": "failed to resolve",
+            "error_type": "RuntimeError",
+            "message": "no versions found for somepkg",
+        }
+
+    def test_finalize_no_report_when_no_failures(
+        self, tmp_context: WorkContext
+    ) -> None:
+        bt = bootstrapper.Bootstrapper(tmp_context, multiple_versions=True)
+
+        bt.finalize()
+
+        report = tmp_context.work_dir / "partial-failures.json"
+        assert not report.exists()
+
+    def test_finalize_removes_stale_report(self, tmp_context: WorkContext) -> None:
+        """A clean run removes a partial-failures.json left by a previous run."""
+        report = tmp_context.work_dir / "partial-failures.json"
+        report.write_text('{"failures": [{"name": "old==1.0"}]}')
+
+        bt = bootstrapper.Bootstrapper(tmp_context, multiple_versions=True)
+        bt.finalize()
+
+        assert not report.exists()
+
+    def test_finalize_no_report_without_multiple_versions(
+        self, tmp_context: WorkContext
+    ) -> None:
+        report = tmp_context.work_dir / "partial-failures.json"
+        report.write_text('{"failures": [{"name": "stale==1.0"}]}')
+
+        bt = bootstrapper.Bootstrapper(tmp_context, multiple_versions=False)
+        bt._failed_versions = {
+            ("pkg-a", "1.0"): (ValueError("build failed"), "failed during build phase"),
+        }
+
+        bt.finalize()
+
+        assert not report.exists()

--- a/tests/test_bootstrapper_iterative.py
+++ b/tests/test_bootstrapper_iterative.py
@@ -489,8 +489,9 @@ class TestPhaseResolve:
         bt = bootstrapper.Bootstrapper(tmp_context, multiple_versions=True)
         item = _make_resolve_item()
 
-        bt._failed_versions[(canonicalize_name("testpkg"), "2.0")] = RuntimeError(
-            "boom"
+        bt._failed_versions[(canonicalize_name("testpkg"), "2.0")] = (
+            RuntimeError("boom"),
+            "failed during build phase",
         )
         item.bg_future = _make_resolved_future(
             [
@@ -515,8 +516,9 @@ class TestPhaseResolve:
         bt = bootstrapper.Bootstrapper(tmp_context, multiple_versions=False)
         item = _make_resolve_item()
 
-        bt._failed_versions[(canonicalize_name("testpkg"), "1.0")] = RuntimeError(
-            "boom"
+        bt._failed_versions[(canonicalize_name("testpkg"), "1.0")] = (
+            RuntimeError("boom"),
+            "failed during build phase",
         )
         item.bg_future = _make_resolved_future([("url-1.0", Version("1.0"))])
 
@@ -532,8 +534,9 @@ class TestPhaseResolve:
         bt = bootstrapper.Bootstrapper(tmp_context, multiple_versions=True)
         item = _make_resolve_item()
 
-        bt._failed_versions[(canonicalize_name("testpkg"), "1.0")] = RuntimeError(
-            "boom"
+        bt._failed_versions[(canonicalize_name("testpkg"), "1.0")] = (
+            RuntimeError("boom"),
+            "failed during build phase",
         )
         item.bg_future = _make_resolved_future([("url-1.0", Version("1.0"))])
 
@@ -880,7 +883,7 @@ class TestHandlePhaseError:
         assert len(bt._failed_versions) == 1
         key = (canonicalize_name("testpkg"), "unresolved")
         assert key in bt._failed_versions
-        assert bt._failed_versions[key] is err
+        assert bt._failed_versions[key][0] is err
 
     def test_resolve_error_enriched_before_test_mode_record(
         self, tmp_context: WorkContext
@@ -926,7 +929,7 @@ class TestHandlePhaseError:
         bt._handle_phase_error(item, err)
 
         key = (canonicalize_name("flashinfer-python"), "unresolved")
-        assert "dependency chain: its-hub==1.0" in str(bt._failed_versions[key])
+        assert "dependency chain: its-hub==1.0" in str(bt._failed_versions[key][0])
 
     def test_resolve_error_enriched_before_normal_mode_raise(
         self, tmp_context: WorkContext


### PR DESCRIPTION
## Summary

- Write `partial-failures.json` to `work-dir/` when multi-version bootstrap has package failures
- Exit code stays 0 (the expected behavior with multi-version bootstrap is enabled)

This change gives analysis tools the metadata necessary to detect soft failures without manually parsing logs/stdout

## Test plan

- [x] Report written when multi-version has failures
- [x] No report when zero failures
- [x] No report when `multiple_versions=False`
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)