### PR TITLE
fix(ci): use PR instead of direct push for feature branch sync

### DIFF
--- a/.github/workflows/sync-feature-branch.yaml
+++ b/.github/workflows/sync-feature-branch.yaml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write
     env:
       TARGET_BRANCH: ${{ inputs.target_branch || 'new-resolver-config' }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -61,9 +62,28 @@ jobs:
             echo "DELIM" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Push merged changes
+      - name: Push merged changes via PR
         if: steps.merge.outputs.result == 'merged'
-        run: git push origin "HEAD:${TARGET_BRANCH}"
+        run: |
+          SYNC_BRANCH="sync/${TARGET_BRANCH}-from-main"
+          git push origin "HEAD:${SYNC_BRANCH}" --force
+          EXISTING_PR=$(gh pr list \
+            --head "$SYNC_BRANCH" \
+            --base "$TARGET_BRANCH" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -n "$EXISTING_PR" ]; then
+            echo "Updated existing sync PR #${EXISTING_PR}"
+          else
+            gh pr create \
+              --head "$SYNC_BRANCH" \
+              --base "$TARGET_BRANCH" \
+              --title "Sync ${TARGET_BRANCH} with main" \
+              --body "Automated merge of \`main\` into \`${TARGET_BRANCH}\`.
+
+          **Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          fi
 
       - name: Close resolved sync-conflict issues
         if: steps.merge.outputs.result == 'merged' || steps.merge.outputs.result == 'up-to-date'


### PR DESCRIPTION
## Summary
- The sync workflow failed because `new-resolver-config` is a protected branch requiring changes through PRs ([failed run](https://github.com/python-wheel-build/fromager/actions/runs/33762088321/job/100670650848))
- Changed the workflow to push to an intermediary `sync/<branch>-from-main` branch and create a PR into the target, instead of pushing directly
- If an open sync PR already exists, it updates in place rather than creating duplicates
- Also migrated `new-resolver-config` branch protection from legacy rules to a GitHub ruleset (matching the existing protections)

## Test plan
- [ ] Merge this PR and verify the next sync run creates a PR into `new-resolver-config` instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)